### PR TITLE
Use Signpost's internal OAuthProvider and remove commons-http4

### DIFF
--- a/play-ahc-ws-standalone/src/main/java/play/libs/oauth/OAuth.java
+++ b/play-ahc-ws-standalone/src/main/java/play/libs/oauth/OAuth.java
@@ -6,7 +6,7 @@ package play.libs.oauth;
 import play.shaded.oauth.oauth.signpost.OAuthConsumer;
 import play.shaded.oauth.oauth.signpost.OAuthProvider;
 import play.shaded.oauth.oauth.signpost.basic.DefaultOAuthConsumer;
-import play.shaded.oauth.oauth.signpost.commonshttp.CommonsHttpOAuthProvider;
+import play.shaded.oauth.oauth.signpost.basic.DefaultOAuthProvider;
 import play.shaded.oauth.oauth.signpost.exception.OAuthException;
 import play.shaded.ahc.org.asynchttpclient.oauth.OAuthSignatureCalculator;
 import play.libs.ws.WSSignatureCalculator;
@@ -22,7 +22,7 @@ public class OAuth {
 
     public OAuth(ServiceInfo info, boolean use10a) {
         this.info = info;
-        this.provider = new CommonsHttpOAuthProvider(info.requestTokenURL, info.accessTokenURL, info.authorizationURL);
+        this.provider = new DefaultOAuthProvider(info.requestTokenURL, info.accessTokenURL, info.authorizationURL);
         this.provider.setOAuth10a(use10a);
     }
 

--- a/play-ahc-ws-standalone/src/main/scala/play/api/libs/oauth/OAuth.scala
+++ b/play-ahc-ws-standalone/src/main/scala/play/api/libs/oauth/OAuth.scala
@@ -4,7 +4,7 @@
 package play.api.libs.oauth
 
 import play.shaded.oauth.oauth.signpost.basic.DefaultOAuthConsumer
-import play.shaded.oauth.oauth.signpost.commonshttp.CommonsHttpOAuthProvider
+import play.shaded.oauth.oauth.signpost.basic.DefaultOAuthProvider
 import play.shaded.oauth.oauth.signpost.exception.OAuthException
 import play.shaded.ahc.org.asynchttpclient.oauth.OAuthSignatureCalculator
 import play.shaded.ahc.org.asynchttpclient.{Request, RequestBuilderBase, SignatureCalculator}
@@ -21,7 +21,7 @@ import play.shaded.ahc.org.asynchttpclient.oauth.{ConsumerKey => AHCConsumerKey,
 case class OAuth(info: ServiceInfo, use10a: Boolean = true) {
 
   private val provider = {
-    val p = new CommonsHttpOAuthProvider(info.requestTokenURL, info.accessTokenURL, info.authorizationURL)
+    val p = new DefaultOAuthProvider(info.requestTokenURL, info.accessTokenURL, info.authorizationURL)
     p.setOAuth10a(use10a)
     p
   }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -43,7 +43,7 @@ object Dependencies {
   val scalaXml = Seq("org.scala-lang.modules" %% "scala-xml" % scalaXmlVersion)
 
   val oauth = Seq(
-    "signpost-core", "signpost-commonshttp4").map("oauth.signpost" % _ % "1.2.1.2"
+    "oauth.signpost" % "signpost-core" % "1.2.1.2"
   )
 
   // https://mvnrepository.com/artifact/org.reactivestreams/reactive-streams


### PR DESCRIPTION
Signpost has a module that depends on commons-http4 for OAuth.  

This PR removes the dependency and uses the internal OAuthProvider that depends on HttpUrlConnection.