### PR TITLE
Manage shaded dependencies

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,8 @@
 import Dependencies._
 import com.typesafe.sbt.SbtScalariform.ScalariformKeys
 import com.typesafe.tools.mima.plugin.MimaPlugin.mimaDefaultSettings
-import sbt._
+import sbt.Keys.artifact
+import sbt.{addArtifact, _}
 import sbtassembly.AssemblyPlugin.autoImport._
 import sbtassembly.MergeStrategy
 
@@ -275,6 +276,7 @@ lazy val `play-ahc-ws-standalone` = project
   .settings(shadedAhcSettings)
   .settings(shadedOAuthSettings)
   .settings(
+    // This will not work if you do a publishLocal, because that uses ivy...
     pomPostProcess := {
       (node: xml.Node) => addShadedDeps(List(
         <dependency>

--- a/project/CleanShadedPlugin.scala
+++ b/project/CleanShadedPlugin.scala
@@ -1,0 +1,59 @@
+// https://github.com/sbt/sbt-dirty-money/blob/master/src/main/scala/sbtdirtymoney/DirtyMoneyPlugin.scala
+
+import sbt._, Keys._
+
+object CleanShadedPlugin extends AutoPlugin {
+  override def requires = plugins.IvyPlugin
+  override def trigger  = allRequirements
+
+  object autoImport {
+    val cleanCacheIvyDirectory: SettingKey[File] = settingKey[File]("")
+    val cleanCache: InputKey[Unit]               = inputKey[Unit]("")
+    val cleanCacheFiles: InputKey[Seq[File]]     = inputKey[Seq[File]]("")
+    val cleanLocal: InputKey[Unit]               = inputKey[Unit]("")
+    val cleanLocalFiles: InputKey[Seq[File]]     = inputKey[Seq[File]]("")
+  }
+  import autoImport._
+
+  object CleanShaded {
+    import sbt.complete.Parser
+    import sbt.complete.DefaultParsers._
+
+    final case class ModuleParam(organization: String, name: Option[String])
+
+    def parseParam: Parser[Option[ModuleParam]] =
+      ((parseOrg ~ parseName.?) map {
+        case o ~ n => ModuleParam(o, n)
+      }).?
+
+    private def parseOrg: Parser[String] =
+      (Space ~> token(StringBasic.examples("\"organization\"")))
+
+    private def parseName: Parser[String] =
+      (Space ~> token(token("%") ~> Space ~> StringBasic.examples("\"name\"")))
+
+    def query(base: File, param: Option[ModuleParam], org: String, name: String): Seq[File] =
+      (param match {
+        case None                                   => base ** ("*" + org + "*") ** ("*" + name + "*")
+        case Some(ModuleParam("*", None))           => base ** "*"
+        case Some(ModuleParam(o, None | Some("*"))) => base ** ("*" + o + "*") ** "*"
+        case Some(ModuleParam(o, Some(n)))          => base ** ("*" + o + "*") ** ("*" + n + "*")
+      }).get
+  }
+
+  override def projectSettings = Seq(
+    cleanCacheIvyDirectory := ivyPaths.value.ivyHome getOrElse (Path.userHome / ".ivy2"),
+    cleanCache := IO.delete(cleanCacheFiles.evaluated),
+    cleanLocal := IO.delete(cleanLocalFiles.evaluated),
+    cleanCacheFiles := {
+      val base = cleanCacheIvyDirectory.value / "cache"
+      val param = CleanShaded.parseParam.parsed
+      CleanShaded.query(base, param, organization.value, moduleName.value)
+    },
+    cleanLocalFiles := {
+      val base = cleanCacheIvyDirectory.value / "local"
+      val param = CleanShaded.parseParam.parsed
+      CleanShaded.query(base, param, organization.value, moduleName.value)
+    }
+  )
+}

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -19,7 +19,7 @@ object Dependencies {
     "play-functional"
   ).map("com.typesafe.play" %% _ % playJsonVersion)
 
-  val slf4j = Seq("org.slf4j" % "slf4j-api" % "1.7.22")
+  val slf4jApi = Seq("org.slf4j" % "slf4j-api" % "1.7.22")
 
   val slf4jtest = Seq("uk.org.lidalia" % "slf4j-test" % "1.1.0")
 
@@ -64,5 +64,5 @@ object Dependencies {
       scalaXml ++
       playJson
 
-  val standaloneAhcWSDependencies = cachecontrol ++ caffeine ++ slf4j ++ reactiveStreams
+  val standaloneAhcWSDependencies = cachecontrol ++ jcache ++ slf4jApi ++ reactiveStreams
 }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -33,7 +33,7 @@ object Dependencies {
 
   val signpostVersion = "1.2.1.2"
   val oauth = Seq(
-    ("oauth.signpost" % "signpost-core" % signpostVersion)
+    "oauth.signpost" % "signpost-core" % signpostVersion
   )
 
   val cachecontrolVersion = "1.1.2"
@@ -41,12 +41,14 @@ object Dependencies {
 
   val asyncHttpClientVersion = "2.0.27"
   val asyncHttpClient = Seq(
-    ("org.asynchttpclient" % "async-http-client" % asyncHttpClientVersion)
+    "org.asynchttpclient" % "async-http-client" % asyncHttpClientVersion
   )
 
   val akkaVersion = "2.4.14"
   val akka = Seq("com.typesafe.akka" %% "akka-stream" % akkaVersion)
   val akkaHttp = Seq("com.typesafe.akka" %% "akka-http" % "10.0.1")
+
+  val reactiveStreams = Seq("org.reactivestreams" % "reactive-streams" % "1.0.0")
 
   val junitInterface = Seq("com.novocode" % "junit-interface" % "0.11")
 
@@ -62,7 +64,5 @@ object Dependencies {
       scalaXml ++
       playJson
 
-  val standaloneAhcWSDependencies = cachecontrol ++
-    caffeine ++
-    slf4j
+  val standaloneAhcWSDependencies = cachecontrol ++ caffeine ++ slf4j ++ reactiveStreams
 }

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -14,3 +14,4 @@ addSbtPlugin("org.scalariform" % "sbt-scalariform" % "1.6.0")
 addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "0.1.13")
 
 addSbtPlugin("com.gilt" % "sbt-dependency-graph-sugar" % "0.8.2")
+


### PR DESCRIPTION
This PR is to resolve shading issues.  It makes sure the shaded-asynchttpclient and shaded-oauth libraries are all that are available to downstream users, and the input dependencies to the shaded libraries are not used.

This is trickier than it looks, because there are several things working against this.  

The "$HOME/.ivy2/cache" packages are sticky, and so doing an "sbt publishLocal" does not change downstream clients, because what's in cache will preceed what's in "$HOME/ivy2/local".  See https://github.com/sbt/sbt/issues/2687 for more details.

There is a note in SBT that says artifacts with SNAPSHOT in the name are not sticky, 

> The version number you select must end with SNAPSHOT, or you must change the version number each time you publish. Ivy maintains a cache, and it stores even local projects in that cache. If Ivy already has a version cached, it will not check the local repository for updates, unless the version number matches a changing pattern, and SNAPSHOT is one such pattern.  

but I have not found that to be the case -- the cache is ALWAYS checked first, even for SNAPSHOT.  See http://www.scala-sbt.org/0.13/docs/Publishing.html#Publishing+Locally 

The best way I've found is to do a "sbt clean cleanLocal cleanCache" to clear out the local repository -- I used sbt-dirty-money as a starting point:

* http://eed3si9n.com/field-test
* https://github.com/sbt/sbt-dirty-money

There should be a way to make this automatic on shaded publishing, but manually doing it works for now.

Both the POM and the IVY file has to be overridden.  When you look something up locally in SBT, it uses the ivy dependency tree, so you can't test it locally -- you have to eyeball the POM files instead or push to a local artifactory server.

