### PR TITLE
Throw more explicit exception on invalid URL

### DIFF
--- a/integration-tests/src/test/scala/play/api/libs/ws/ahc/AhcWSClientSpec.scala
+++ b/integration-tests/src/test/scala/play/api/libs/ws/ahc/AhcWSClientSpec.scala
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2009-2017 Lightbend Inc. <https://www.lightbend.com>
+ */
+package play.api.libs.ws.ahc
+
+import akka.actor.ActorSystem
+import akka.stream.ActorMaterializer
+import org.specs2.concurrent.ExecutionEnv
+import org.specs2.matcher.FutureMatchers
+import org.specs2.mutable.Specification
+import org.specs2.specification.AfterAll
+
+class AhcWSClientSpec(implicit ee: ExecutionEnv) extends Specification with AfterAll with FutureMatchers {
+
+  sequential
+
+  val testServerPort = 49231
+
+  // Create Akka system for thread and streaming management
+  implicit val system = ActorSystem()
+  implicit val materializer = ActorMaterializer()
+
+  // Create the standalone WS client
+  val client = StandaloneAhcWSClient()
+
+  override def afterAll = {
+    client.close()
+    system.terminate()
+  }
+
+  "url" should {
+    "throw an exception on invalid url" in {
+      { client.url("localhost") } must throwAn[IllegalArgumentException]
+    }
+
+    "not throw exception on valid url" in {
+      { client.url("http://localhost:9000") } must not(throwAn[IllegalArgumentException])
+    }
+  }
+}

--- a/play-ws-standalone/src/main/scala/play/api/libs/ws/StandaloneWSClient.scala
+++ b/play-ws-standalone/src/main/scala/play/api/libs/ws/StandaloneWSClient.scala
@@ -18,13 +18,16 @@ trait StandaloneWSClient extends Closeable {
   def underlying[T]: T
 
   /**
-   * Generates a request.
+   * Generates a request.  Throws IllegalArgumentException if the URL is invalid.
    *
    * @param url The base URL to make HTTP requests to.
    * @return a request
    */
+  @throws[IllegalArgumentException]
   def url(url: String): StandaloneWSRequest
 
-  /** Closes this client, and releases underlying resources. */
+  /**
+   * Closes this client, and releases underlying resources.
+   */
   @throws[IOException] def close(): Unit
 }


### PR DESCRIPTION
The WS client will throw an exception when building a URL, when the 
underlying URL is invalid.  However, the exception throw is an NPE
which says things like "scheme is null" rather than saying that the
URL is invalid.

This fix looks for NPE coming from an asynchttpclient URI parsing and
then wraps it in an illegal argument exception, and details the API
as throwing IllegalArgumentException on invalid URL.