### PR TITLE
Upgrade to Play 2.6.0-M4

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,8 +1,6 @@
 import Dependencies._
 import com.typesafe.sbt.SbtScalariform.ScalariformKeys
 import com.typesafe.tools.mima.plugin.MimaPlugin.mimaDefaultSettings
-import sbt.Keys.artifact
-import sbt.{addArtifact, _}
 import sbtassembly.AssemblyPlugin.autoImport._
 import sbtassembly.MergeStrategy
 
@@ -176,7 +174,8 @@ lazy val `shaded-asynchttpclient` = project.in(file("shaded/asynchttpclient"))
       ShadeRule.rename("io.netty.**" -> "play.shaded.ahc.@0").inAll,
       ShadeRule.rename("javassist.**" -> "play.shaded.ahc.@0").inAll,
       ShadeRule.rename("com.typesafe.netty.**" -> "play.shaded.ahc.@0").inAll,
-      ShadeRule.zap("org.reactivestreams.**").inAll
+      ShadeRule.zap("org.reactivestreams.**").inAll,
+      ShadeRule.zap("org.slf4j.**").inAll
     ),
 
     // https://stackoverflow.com/questions/24807875/how-to-remove-projectdependencies-from-pom
@@ -202,10 +201,11 @@ lazy val `shaded-oauth` = project.in(file("shaded/oauth"))
     name := "shaded-oauth"
   )
   .settings(
-    logLevel in assembly := Level.Error,
+    //logLevel in assembly := Level.Debug,
     assemblyShadeRules in assembly := Seq(
       ShadeRule.rename("oauth.**" -> "play.shaded.oauth.@0").inAll,
-      ShadeRule.rename("org.apache.commons.**" -> "play.shaded.oauth.@0").inAll
+      ShadeRule.rename("org.apache.commons.**" -> "play.shaded.oauth.@0").inAll,
+      ShadeRule.zap("com.google.gdata.**").inAll
     ),
 
     // https://stackoverflow.com/questions/24807875/how-to-remove-projectdependencies-from-pom

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -13,7 +13,7 @@ object Dependencies {
   ).map("org.specs2" %% _ % specsVersion)
 
   // Use the published milestone
-  val playJsonVersion = "2.6.0-M3"
+  val playJsonVersion = "2.6.0-M4"
   val playJson = "com.typesafe.play" %% "play-json" % playJsonVersion
 
   val slf4jApi = Seq("org.slf4j" % "slf4j-api" % "1.7.22")

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,4 +1,4 @@
 #
 # Copyright (C) 2009-2017 Lightbend Inc. <https://www.lightbend.com>
 #
-sbt.version=0.13.13
+sbt.version=0.13.15


### PR DESCRIPTION
* Removes org.slf4j from the shaded-asynchttpclient library
* Removes gdata from shaded-oauth library