### PR TITLE
Add a cache type and provide stub for it.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -274,8 +274,9 @@ lazy val `play-ahc-ws-standalone` = project
   .settings(formattingSettings)
   .settings(SbtScalariform.scalariformSettings)
   .settings(
+    fork in Test := true,
     testOptions in Test := Seq(Tests.Argument(TestFrameworks.JUnit, "-a", "-v")),
-    libraryDependencies ++= (slf4jtest ++ specsBuild ++ junitInterface ++ caffeine).map(_ % Test)
+    libraryDependencies ++= (slf4jtest ++ specsBuild ++ junitInterface).map(_ % Test)
   )
   .settings(libraryDependencies ++= standaloneAhcWSDependencies)
   .settings(shadedAhcSettings)
@@ -311,9 +312,10 @@ lazy val `integration-tests` = project.in(file("integration-tests"))
   .settings(disablePublishing)
   .settings(SbtScalariform.scalariformSettings)
   .settings(
+    fork in Test := true,
     concurrentRestrictions += Tags.limitAll(1), // only one integration test at a time
     testOptions in Test := Seq(Tests.Argument(TestFrameworks.JUnit, "-a", "-v")),
-    libraryDependencies ++= (specsBuild ++ akkaHttp ++ caffeine).map(_ % Test)
+    libraryDependencies ++= (specsBuild ++ akkaHttp).map(_ % Test)
   )
   .settings(libraryDependencies ++= standaloneAhcWSDependencies)
   .settings(shadedAhcSettings)

--- a/integration-tests/src/test/scala/play/api/libs/ws/ahc/cache/CachingSpec.scala
+++ b/integration-tests/src/test/scala/play/api/libs/ws/ahc/cache/CachingSpec.scala
@@ -1,9 +1,11 @@
+/*
+ * Copyright (C) 2009-2017 Lightbend Inc. <https://www.lightbend.com>
+ *
+ */
+
 package play.api.libs.ws.ahc.cache
 
-import javax.cache.{ Cache, Caching }
-import javax.cache.configuration.FactoryBuilder.SingletonFactory
-import javax.cache.configuration.MutableConfiguration
-import javax.cache.expiry.EternalExpiryPolicy
+import java.util.concurrent.TimeUnit
 
 import akka.actor.ActorSystem
 import akka.http.scaladsl.Http
@@ -13,15 +15,17 @@ import akka.http.scaladsl.server.Route
 import akka.stream.ActorMaterializer
 import org.specs2.concurrent.ExecutionEnv
 import org.specs2.matcher.FutureMatchers
-import org.specs2.mutable.{ BeforeAfter, Specification }
+import org.specs2.mutable.Specification
 import org.specs2.specification.AfterAll
 import play.api.libs.ws.ahc._
 import play.shaded.ahc.org.asynchttpclient._
 
+import scala.collection.mutable
+
 /**
  *
  */
-class CachingSpec(implicit ee: ExecutionEnv) extends Specification with BeforeAfter with AfterAll with FutureMatchers {
+class CachingSpec(implicit ee: ExecutionEnv) extends Specification with AfterAll with FutureMatchers {
 
   sequential
 
@@ -45,33 +49,17 @@ class CachingSpec(implicit ee: ExecutionEnv) extends Specification with BeforeAf
     Http().bindAndHandle(route, "localhost", port = 9000)
   }
 
-  override def before = {
-  }
-
-  override def after = {
-    val cacheManager = Caching.getCachingProvider.getCacheManager
-    cacheManager.destroyCache("play-ws-cache")
-  }
-
   override def afterAll = {
     futureServer.foreach(_.unbind())(materializer.executionContext)
     asyncHttpClient.close()
     system.terminate()
   }
 
-  def createCache(): Cache[EffectiveURIKey, ResponseEntry] = {
-    val cacheManager = Caching.getCachingProvider.getCacheManager
-    val configuration = new MutableConfiguration()
-      .setTypes(classOf[EffectiveURIKey], classOf[ResponseEntry])
-      .setStoreByValue(false)
-      .setExpiryPolicyFactory(new SingletonFactory(new EternalExpiryPolicy()))
-    cacheManager.createCache("play-ws-cache", configuration)
-  }
-
   "GET" should {
 
     "work once" in {
-      val cachingAsyncHttpClient = new CachingAsyncHttpClient(asyncHttpClient, createCache())
+      val cache = new StubHttpCache()
+      val cachingAsyncHttpClient = new CachingAsyncHttpClient(asyncHttpClient, cache, scala.concurrent.ExecutionContext.global)
       val ws = new StandaloneAhcWSClient(cachingAsyncHttpClient)
 
       ws.url("http://localhost:9000/").get().map { response =>
@@ -80,4 +68,20 @@ class CachingSpec(implicit ee: ExecutionEnv) extends Specification with BeforeAf
     }
 
   }
+}
+
+class StubHttpCache extends Cache {
+
+  private val underlying = new mutable.HashMap[EffectiveURIKey, ResponseEntry]()
+
+  override def remove(key: EffectiveURIKey): Unit = underlying.remove(key)
+
+  override def put(key: EffectiveURIKey, entry: ResponseEntry): Unit = underlying.put(key, entry)
+
+  override def get(key: EffectiveURIKey): ResponseEntry = underlying.get(key).orNull
+
+  override def close(): Unit = {
+
+  }
+
 }

--- a/play-ahc-ws-standalone/src/main/java/play/libs/ws/ahc/AhcWSClientConfigFactory.java
+++ b/play-ahc-ws-standalone/src/main/java/play/libs/ws/ahc/AhcWSClientConfigFactory.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (C) 2009-2017 Lightbend Inc. <https://www.lightbend.com>
+ *
+ */
+
 package play.libs.ws.ahc;
 
 import com.typesafe.config.Config;

--- a/play-ahc-ws-standalone/src/main/scala/play/api/libs/ws/ahc/AhcUtilities.scala
+++ b/play-ahc-ws-standalone/src/main/scala/play/api/libs/ws/ahc/AhcUtilities.scala
@@ -1,3 +1,8 @@
+/*
+ * Copyright (C) 2009-2017 Lightbend Inc. <https://www.lightbend.com>
+ *
+ */
+
 package play.api.libs.ws.ahc
 
 import play.shaded.ahc.io.netty.handler.codec.http.HttpHeaders

--- a/play-ahc-ws-standalone/src/main/scala/play/api/libs/ws/ahc/cache/AsyncCachingHandler.scala
+++ b/play-ahc-ws-standalone/src/main/scala/play/api/libs/ws/ahc/cache/AsyncCachingHandler.scala
@@ -1,3 +1,8 @@
+/*
+ * Copyright (C) 2009-2017 Lightbend Inc. <https://www.lightbend.com>
+ *
+ */
+
 package play.api.libs.ws.ahc.cache
 
 import play.shaded.ahc.org.asynchttpclient._

--- a/play-ahc-ws-standalone/src/main/scala/play/api/libs/ws/ahc/cache/BackgroundAsyncHandler.scala
+++ b/play-ahc-ws-standalone/src/main/scala/play/api/libs/ws/ahc/cache/BackgroundAsyncHandler.scala
@@ -1,3 +1,8 @@
+/*
+ * Copyright (C) 2009-2017 Lightbend Inc. <https://www.lightbend.com>
+ *
+ */
+
 package play.api.libs.ws.ahc.cache
 
 import play.shaded.ahc.org.asynchttpclient._

--- a/play-ahc-ws-standalone/src/main/scala/play/api/libs/ws/ahc/cache/Cache.scala
+++ b/play-ahc-ws-standalone/src/main/scala/play/api/libs/ws/ahc/cache/Cache.scala
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2009-2017 Lightbend Inc. <https://www.lightbend.com>
+ *
+ */
+
+package play.api.libs.ws.ahc.cache
+
+/**
+ * A very simple cache trait.
+ *
+ * Implementations can write adapters that map through to this trait, i.e.
+ *
+ * {{{
+ * class CaffeineHttpCache extends Cache {
+ *    val underlying = Caffeine.newBuilder()
+ *      .ticker(Ticker.systemTicker())
+ *      .expireAfterWrite(365, TimeUnit.DAYS)
+ *      .build[EffectiveURIKey, ResponseEntry]()
+ *
+ *     override def remove(key: EffectiveURIKey): Unit = underlying.invalidate(key)
+ *     override def put(key: EffectiveURIKey, entry: ResponseEntry): Unit = underlying.put(key, entry)
+ *     override def get(key: EffectiveURIKey): ResponseEntry = underlying.getIfPresent(key)
+ *     override def close(): Unit = underlying.cleanUp()
+ * }
+ * }}}
+ */
+trait Cache {
+
+  def get(key: EffectiveURIKey): ResponseEntry
+
+  def put(key: EffectiveURIKey, entry: ResponseEntry): Unit
+
+  def remove(key: EffectiveURIKey): Unit
+
+  def close(): Unit
+
+}

--- a/play-ahc-ws-standalone/src/main/scala/play/api/libs/ws/ahc/cache/CacheAsyncConnection.scala
+++ b/play-ahc-ws-standalone/src/main/scala/play/api/libs/ws/ahc/cache/CacheAsyncConnection.scala
@@ -1,3 +1,8 @@
+/*
+ * Copyright (C) 2009-2017 Lightbend Inc. <https://www.lightbend.com>
+ *
+ */
+
 package play.api.libs.ws.ahc.cache
 
 import java.util.concurrent.{ Callable, CompletableFuture, Executor, TimeUnit }

--- a/play-ahc-ws-standalone/src/main/scala/play/api/libs/ws/ahc/cache/CacheableResponse.scala
+++ b/play-ahc-ws-standalone/src/main/scala/play/api/libs/ws/ahc/cache/CacheableResponse.scala
@@ -1,3 +1,8 @@
+/*
+ * Copyright (C) 2009-2017 Lightbend Inc. <https://www.lightbend.com>
+ *
+ */
+
 package play.api.libs.ws.ahc.cache
 
 import java.io.{ ByteArrayInputStream, IOException, InputStream }

--- a/play-ahc-ws-standalone/src/main/scala/play/api/libs/ws/ahc/cache/Debug.scala
+++ b/play-ahc-ws-standalone/src/main/scala/play/api/libs/ws/ahc/cache/Debug.scala
@@ -1,3 +1,8 @@
+/*
+ * Copyright (C) 2009-2017 Lightbend Inc. <https://www.lightbend.com>
+ *
+ */
+
 package play.api.libs.ws.ahc.cache
 
 import play.api.libs.ws.ahc.AhcUtilities

--- a/play-ahc-ws-standalone/src/main/scala/play/api/libs/ws/ahc/cache/EffectiveURIKey.scala
+++ b/play-ahc-ws-standalone/src/main/scala/play/api/libs/ws/ahc/cache/EffectiveURIKey.scala
@@ -1,3 +1,8 @@
+/*
+ * Copyright (C) 2009-2017 Lightbend Inc. <https://www.lightbend.com>
+ *
+ */
+
 package play.api.libs.ws.ahc.cache
 
 import java.net.URI

--- a/play-ahc-ws-standalone/src/test/scala/play/api/libs/ws/ahc/cache/AhcWSCacheSpec.scala
+++ b/play-ahc-ws-standalone/src/test/scala/play/api/libs/ws/ahc/cache/AhcWSCacheSpec.scala
@@ -1,3 +1,8 @@
+/*
+ * Copyright (C) 2009-2017 Lightbend Inc. <https://www.lightbend.com>
+ *
+ */
+
 package play.api.libs.ws.ahc.cache
 
 import com.typesafe.play.cachecontrol.HeaderName
@@ -20,6 +25,7 @@ class AhcWSCacheSpec extends Specification with CacheBuilderMethods {
         d must haveKey(HeaderName("Accept-Encoding"))
         d(HeaderName("Accept-Encoding")) must be_==(Seq("gzip"))
       }
+
     }
 
   }

--- a/play-ahc-ws-standalone/src/test/scala/play/api/libs/ws/ahc/cache/BackgroundAsyncHandlerSpec.scala
+++ b/play-ahc-ws-standalone/src/test/scala/play/api/libs/ws/ahc/cache/BackgroundAsyncHandlerSpec.scala
@@ -1,3 +1,8 @@
+/*
+ * Copyright (C) 2009-2017 Lightbend Inc. <https://www.lightbend.com>
+ *
+ */
+
 package play.api.libs.ws.ahc.cache
 
 import org.specs2.mutable.Specification

--- a/play-ahc-ws-standalone/src/test/scala/play/api/libs/ws/ahc/cache/CacheAsyncHandlerSpec.scala
+++ b/play-ahc-ws-standalone/src/test/scala/play/api/libs/ws/ahc/cache/CacheAsyncHandlerSpec.scala
@@ -1,3 +1,8 @@
+/*
+ * Copyright (C) 2009-2017 Lightbend Inc. <https://www.lightbend.com>
+ *
+ */
+
 package play.api.libs.ws.ahc.cache
 
 import org.specs2.mutable.Specification

--- a/play-ahc-ws-standalone/src/test/scala/play/api/libs/ws/ahc/cache/CacheAsyncHttpProviderSpec.scala
+++ b/play-ahc-ws-standalone/src/test/scala/play/api/libs/ws/ahc/cache/CacheAsyncHttpProviderSpec.scala
@@ -1,3 +1,8 @@
+/*
+ * Copyright (C) 2009-2017 Lightbend Inc. <https://www.lightbend.com>
+ *
+ */
+
 package play.api.libs.ws.ahc.cache
 
 import org.specs2.mutable.Specification

--- a/play-ws-standalone/src/main/scala/play/api/libs/ws/WSConfigParser.scala
+++ b/play-ws-standalone/src/main/scala/play/api/libs/ws/WSConfigParser.scala
@@ -1,3 +1,8 @@
+/*
+ * Copyright (C) 2009-2017 Lightbend Inc. <https://www.lightbend.com>
+ *
+ */
+
 package play.api.libs.ws
 
 import javax.inject.{ Inject, Provider, Singleton }

--- a/project/CleanShadedPlugin.scala
+++ b/project/CleanShadedPlugin.scala
@@ -1,3 +1,8 @@
+/*
+ * Copyright (C) 2009-2017 Lightbend Inc. <https://www.lightbend.com>
+ *
+ */
+
 // https://github.com/sbt/sbt-dirty-money/blob/master/src/main/scala/sbtdirtymoney/DirtyMoneyPlugin.scala
 
 import sbt._, Keys._

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -4,16 +4,17 @@
 import sbt._
 
 object Dependencies {
+  val logback = Seq("ch.qos.logback" % "logback-core" % "1.2.3")
 
   val specsVersion = "3.8.6"
   val specsBuild = Seq(
     "specs2-core",
     "specs2-junit",
     "specs2-mock"
-  ).map("org.specs2" %% _ % specsVersion)
+  ).map("org.specs2" %% _ % specsVersion) ++ logback
 
   // Use the published milestone
-  val playJsonVersion = "2.6.0-M3"
+  val playJsonVersion = "2.6.0-M6"
   val playJson = "com.typesafe.play" %% "play-json" % playJsonVersion
 
   val slf4jApi = Seq("org.slf4j" % "slf4j-api" % "1.7.22")
@@ -36,24 +37,19 @@ object Dependencies {
   val cachecontrolVersion = "1.1.2"
   val cachecontrol = Seq("com.typesafe.play" %% "cachecontrol" % cachecontrolVersion)
 
-  val asyncHttpClientVersion = "2.0.27"
+  // https://mvnrepository.com/artifact/org.asynchttpclient/async-http-client
+  val asyncHttpClientVersion = "2.0.31"
   val asyncHttpClient = Seq(
     "org.asynchttpclient" % "async-http-client" % asyncHttpClientVersion
   )
 
-  val akkaVersion = "2.4.14"
+  val akkaVersion = "2.5.0"
   val akka = Seq("com.typesafe.akka" %% "akka-stream" % akkaVersion)
-  val akkaHttp = Seq("com.typesafe.akka" %% "akka-http" % "10.0.1")
+  val akkaHttp = Seq("com.typesafe.akka" %% "akka-http" % "10.0.5")
 
   val reactiveStreams = Seq("org.reactivestreams" % "reactive-streams" % "1.0.0")
 
   val junitInterface = Seq("com.novocode" % "junit-interface" % "0.11")
-
-  val jcache = Seq("javax.cache" % "cache-api" % "1.0.0")
-
-  // https://mvnrepository.com/artifact/com.github.ben-manes.caffeine/jcache
-  val caffeineVersion = "2.3.5"
-  val caffeine = Seq("com.github.ben-manes.caffeine" % "jcache" % caffeineVersion)
 
   val standaloneApiWSDependencies = javaxInject ++
       sslConfigCore ++
@@ -61,5 +57,5 @@ object Dependencies {
       scalaXml :+
       playJson
 
-  val standaloneAhcWSDependencies = cachecontrol ++ jcache ++ slf4jApi ++ reactiveStreams
+  val standaloneAhcWSDependencies = cachecontrol ++ slf4jApi ++ reactiveStreams
 }

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,4 +1,4 @@
 #
 # Copyright (C) 2009-2017 Lightbend Inc. <https://www.lightbend.com>
 #
-sbt.version=0.13.13
+sbt.version=0.13.15


### PR DESCRIPTION
Remove the dependency on `javax.cache.Cache`, and use a small trait.

This is because `javax.cache.Cache` API is disturbingly large and complex, meaning that other cache APis can't be adapted to it.  Given that the underlying functionality is so simple, it makes more sense to break it out completely, and rely on a very small Map based trait that can be easily adapted.