### PR TITLE
More consistent with/add methods for both Scala and Java APIs

### DIFF
--- a/integration-tests/src/test/java/play/libs/ws/ahc/HeaderAppendingFilter.java
+++ b/integration-tests/src/test/java/play/libs/ws/ahc/HeaderAppendingFilter.java
@@ -17,6 +17,6 @@ public class HeaderAppendingFilter implements WSRequestFilter {
 
     @Override
     public WSRequestExecutor apply(WSRequestExecutor executor) {
-        return request -> executor.apply(request.setHeader(key, value));
+        return request -> executor.apply(request.addHeader(key, value));
     }
 }

--- a/play-ahc-ws-standalone/src/main/java/play/libs/ws/ahc/AhcWSCookie.java
+++ b/play-ahc-ws-standalone/src/main/java/play/libs/ws/ahc/AhcWSCookie.java
@@ -56,7 +56,7 @@ public class AhcWSCookie implements WSCookie {
     }
 
     @Override
-    public boolean httpOnly() {
+    public boolean isHttpOnly() {
         return ahcCookie.isHttpOnly();
     }
 }

--- a/play-ahc-ws-standalone/src/main/java/play/libs/ws/ahc/AhcWSCookie.java
+++ b/play-ahc-ws-standalone/src/main/java/play/libs/ws/ahc/AhcWSCookie.java
@@ -24,27 +24,38 @@ public class AhcWSCookie implements WSCookie {
         return ahcCookie;
     }
 
+    @Override
     public String getDomain() {
         return ahcCookie.getDomain();
     }
 
+    @Override
     public String getName() {
         return ahcCookie.getName();
     }
 
+    @Override
     public String getValue() {
         return ahcCookie.getValue();
     }
 
+    @Override
     public String getPath() {
         return ahcCookie.getPath();
     }
 
+    @Override
     public long getMaxAge() {
         return ahcCookie.getMaxAge();
     }
 
+    @Override
     public boolean isSecure() {
         return ahcCookie.isSecure();
+    }
+
+    @Override
+    public boolean httpOnly() {
+        return ahcCookie.isHttpOnly();
     }
 }

--- a/play-ahc-ws-standalone/src/main/java/play/libs/ws/ahc/AhcWSCookie.java
+++ b/play-ahc-ws-standalone/src/main/java/play/libs/ws/ahc/AhcWSCookie.java
@@ -20,7 +20,8 @@ public class AhcWSCookie implements WSCookie {
     /**
      * Returns the underlying "native" object for the cookie.
      */
-    public Object getUnderlying() {
+    @Override
+    public play.shaded.ahc.org.asynchttpclient.cookie.Cookie getUnderlying() {
         return ahcCookie;
     }
 

--- a/play-ahc-ws-standalone/src/main/java/play/libs/ws/ahc/StandaloneAhcWSRequest.java
+++ b/play-ahc-ws-standalone/src/main/java/play/libs/ws/ahc/StandaloneAhcWSRequest.java
@@ -21,13 +21,9 @@ import play.shaded.ahc.org.asynchttpclient.request.body.generator.InputStreamBod
 import play.shaded.ahc.org.asynchttpclient.util.HttpUtils;
 import org.reactivestreams.Publisher;
 import play.api.libs.ws.ahc.FormUrlEncodedParser;
-import play.api.libs.ws.ahc.Streamed;
 
 import play.libs.oauth.OAuth;
 import play.libs.ws.*;
-import scala.compat.java8.FutureConverters;
-import scala.concurrent.Future;
-import scala.concurrent.Promise;
 
 import java.io.File;
 import java.io.InputStream;

--- a/play-ahc-ws-standalone/src/main/java/play/libs/ws/ahc/StandaloneAhcWSRequest.java
+++ b/play-ahc-ws-standalone/src/main/java/play/libs/ws/ahc/StandaloneAhcWSRequest.java
@@ -89,24 +89,19 @@ public class StandaloneAhcWSRequest implements StandaloneWSRequest {
         return this;
     }
 
-    /**
-     * Sets a header with the given name, this can be called repeatedly.
-     *
-     * @param name  the header name
-     * @param value the header value
-     * @return the receiving WSRequest, with the new header set.
-     */
     @Override
-    public StandaloneAhcWSRequest setHeader(String name, String value) {
+    public StandaloneAhcWSRequest addHeader(String name, String value) {
         addValueTo(headers, name, value);
         return this;
     }
 
-    /**
-     * Sets a query string
-     *
-     * @param query the query string
-     */
+    @Override
+    public StandaloneAhcWSRequest setHeaders(Map<String, List<String>> headers) {
+        this.headers.clear();
+        this.headers.putAll(headers);
+        return this;
+    }
+
     @Override
     public StandaloneAhcWSRequest setQueryString(String query) {
         String[] params = query.split("&");
@@ -115,9 +110,9 @@ public class StandaloneAhcWSRequest implements StandaloneWSRequest {
             if (keyValue.length > 2) {
                 throw new RuntimeException(new MalformedURLException("QueryString parameter should not have more than 2 = per part"));
             } else if (keyValue.length == 2) {
-                this.setQueryParameter(keyValue[0], keyValue[1]);
+                this.addQueryParameter(keyValue[0], keyValue[1]);
             } else if (keyValue.length == 1 && param.charAt(0) != '=') {
-                this.setQueryParameter(keyValue[0], null);
+                this.addQueryParameter(keyValue[0], null);
             } else {
                 throw new RuntimeException(new MalformedURLException("QueryString part should not start with an = and not be empty"));
             }
@@ -126,8 +121,15 @@ public class StandaloneAhcWSRequest implements StandaloneWSRequest {
     }
 
     @Override
-    public StandaloneAhcWSRequest setQueryParameter(String name, String value) {
+    public StandaloneAhcWSRequest addQueryParameter(String name, String value) {
         addValueTo(queryParameters, name, value);
+        return this;
+    }
+
+    @Override
+    public StandaloneAhcWSRequest setQueryString(Map<String, List<String>> params) {
+        this.queryParameters.clear();
+        this.queryParameters.putAll(params);
         return this;
     }
 
@@ -200,7 +202,7 @@ public class StandaloneAhcWSRequest implements StandaloneWSRequest {
 
     @Override
     public StandaloneAhcWSRequest setContentType(String contentType) {
-        return setHeader(HttpHeaders.Names.CONTENT_TYPE, contentType);
+        return addHeader(HttpHeaders.Names.CONTENT_TYPE, contentType);
     }
 
     @Override
@@ -274,12 +276,12 @@ public class StandaloneAhcWSRequest implements StandaloneWSRequest {
     }
 
     @Override
-    public Map<String, Collection<String>> getHeaders() {
+    public Map<String, List<String>> getHeaders() {
         return new HashMap<>(this.headers);
     }
 
     @Override
-    public Map<String, Collection<String>> getQueryParameters() {
+    public Map<String, List<String>> getQueryParameters() {
         return new HashMap<>(this.queryParameters);
     }
 
@@ -316,128 +318,6 @@ public class StandaloneAhcWSRequest implements StandaloneWSRequest {
     // Intentionally package public.
     String getVirtualHost() {
         return this.virtualHost;
-    }
-
-    @Override
-    public CompletionStage<? extends StandaloneWSResponse> get() {
-        return execute("GET");
-    }
-
-    //-------------------------------------------------------------------------
-    // PATCH
-    //-------------------------------------------------------------------------
-
-    @Override
-    public CompletionStage<? extends StandaloneWSResponse> patch(String body) {
-        setMethod("PATCH");
-        setBody(body);
-        return execute();
-    }
-
-    @Override
-    public CompletionStage<? extends StandaloneWSResponse> patch(JsonNode body) {
-        setMethod("PATCH");
-        setBody(body);
-        return execute();
-    }
-
-    @Override
-    public CompletionStage<? extends StandaloneWSResponse> patch(InputStream body) {
-        setMethod("PATCH");
-        setBody(body);
-        return execute();
-    }
-
-    @Override
-    public CompletionStage<? extends StandaloneWSResponse> patch(File body) {
-        setMethod("PATCH");
-        setBody(body);
-        return execute();
-    }
-
-    //-------------------------------------------------------------------------
-    // POST
-    //-------------------------------------------------------------------------
-
-    @Override
-    public CompletionStage<? extends StandaloneWSResponse> post(String body) {
-        setMethod("POST");
-        setBody(body);
-        return execute();
-    }
-
-    @Override
-    public CompletionStage<? extends StandaloneWSResponse> post(JsonNode body) {
-        setMethod("POST");
-        setBody(body);
-        return execute();
-    }
-
-    @Override
-    public CompletionStage<? extends StandaloneWSResponse> post(InputStream body) {
-        setMethod("POST");
-        setBody(body);
-        return execute();
-    }
-
-    @Override
-    public CompletionStage<? extends StandaloneWSResponse> post(File body) {
-        setMethod("POST");
-        setBody(body);
-        return execute();
-    }
-
-    //-------------------------------------------------------------------------
-    // PUT
-    //-------------------------------------------------------------------------
-
-    @Override
-    public CompletionStage<? extends StandaloneWSResponse> put(String body) {
-        setMethod("PUT");
-        setBody(body);
-        return execute();
-    }
-
-    @Override
-    public CompletionStage<? extends StandaloneWSResponse> put(JsonNode body) {
-        setMethod("PUT");
-        setBody(body);
-        return execute();
-    }
-
-    @Override
-    public CompletionStage<? extends StandaloneWSResponse> put(InputStream body) {
-        setMethod("PUT");
-        setBody(body);
-        return execute();
-    }
-
-    @Override
-    public CompletionStage<? extends StandaloneWSResponse> put(File body) {
-        setMethod("PUT");
-        setBody(body);
-        return execute();
-    }
-
-    @Override
-    public CompletionStage<? extends StandaloneWSResponse> delete() {
-        return execute("DELETE");
-    }
-
-    @Override
-    public CompletionStage<? extends StandaloneWSResponse> head() {
-        return execute("HEAD");
-    }
-
-    @Override
-    public CompletionStage<? extends StandaloneWSResponse> options() {
-        return execute("OPTIONS");
-    }
-
-    @Override
-    public CompletionStage<? extends StandaloneWSResponse> execute(String method) {
-        setMethod(method);
-        return execute();
     }
 
     @SuppressWarnings("unchecked")
@@ -581,7 +461,7 @@ public class StandaloneAhcWSRequest implements StandaloneWSRequest {
 
     private void addValueTo(Map<String, List<String>> map, String name, String value) {
         if (map.containsKey(name)) {
-            Collection<String> values = map.get(name);
+            List<String> values = map.get(name);
             values.add(value);
         } else {
             List<String> values = new ArrayList<>();

--- a/play-ahc-ws-standalone/src/main/java/play/libs/ws/ahc/StandaloneAhcWSRequest.java
+++ b/play-ahc-ws-standalone/src/main/java/play/libs/ws/ahc/StandaloneAhcWSRequest.java
@@ -47,6 +47,8 @@ public class StandaloneAhcWSRequest implements StandaloneWSRequest {
     private final Map<String, List<String>> headers = new HashMap<>();
     private final Map<String, List<String>> queryParameters = new HashMap<>();
 
+    private final List<WSCookie> cookies = new ArrayList<>();
+
     private String username;
     private String password;
     private WSAuthScheme scheme;
@@ -130,6 +132,29 @@ public class StandaloneAhcWSRequest implements StandaloneWSRequest {
     public StandaloneAhcWSRequest setQueryString(Map<String, List<String>> params) {
         this.queryParameters.clear();
         this.queryParameters.putAll(params);
+        return this;
+    }
+
+    @Override
+    public StandaloneAhcWSRequest addCookie(WSCookie cookie) {
+        if (cookie == null) {
+            throw new NullPointerException("Trying to add a null WSCookie");
+        }
+
+        this.cookies.add(cookie);
+        return this;
+    }
+
+    @Override
+    public StandaloneAhcWSRequest addCookies(WSCookie ... cookies) {
+        Arrays.asList(cookies).forEach(this::addCookie);
+        return this;
+    }
+
+    @Override
+    public StandaloneAhcWSRequest setCookies(List<WSCookie> cookies) {
+        this.cookies.clear();
+        cookies.forEach(this::addCookie);
         return this;
     }
 
@@ -455,6 +480,12 @@ public class StandaloneAhcWSRequest implements StandaloneWSRequest {
                 throw new IllegalStateException("Use OAuth.OAuthCalculator");
             }
         }
+
+        // add cookies
+        this.cookies.forEach(cookie -> {
+            AhcWSCookie ahcWSCookie = (AhcWSCookie)cookie;
+            builder.addCookie(ahcWSCookie.getUnderlying());
+        });
 
         return builder.build();
     }

--- a/play-ahc-ws-standalone/src/main/scala/play/api/libs/ws/ahc/AhcWSCookie.scala
+++ b/play-ahc-ws-standalone/src/main/scala/play/api/libs/ws/ahc/AhcWSCookie.scala
@@ -50,6 +50,11 @@ private class AhcWSCookie(ahcCookie: AHCCookie) extends WSCookie {
    */
   def secure: Boolean = ahcCookie.isSecure
 
+  /**
+   * If the cookie is HTTPOnly.
+   */
+  def httpOnly: Boolean = ahcCookie.isHttpOnly
+
   /*
    * Cookie ports should not be used; cookies for a given host are shared across
    * all the ports on that host.

--- a/play-ahc-ws-standalone/src/main/scala/play/api/libs/ws/ahc/StandaloneAhcWSClient.scala
+++ b/play-ahc-ws-standalone/src/main/scala/play/api/libs/ws/ahc/StandaloneAhcWSClient.scala
@@ -38,7 +38,22 @@ class StandaloneAhcWSClient @Inject() (asyncHttpClient: AsyncHttpClient)(implici
 
   def url(url: String): StandaloneWSRequest = {
     validate(url)
-    StandaloneAhcWSRequest(this, url, "GET", EmptyBody, TreeMap()(CaseInsensitiveOrdered), Map(), None, None, None, None, None, None, None)
+    StandaloneAhcWSRequest(
+      client = this,
+      url = url,
+      method = "GET",
+      body = EmptyBody,
+      headers = TreeMap()(CaseInsensitiveOrdered),
+      queryString = Map.empty,
+      cookies = Seq.empty,
+      calc = None,
+      auth = None,
+      followRedirects = None,
+      requestTimeout = None,
+      virtualHost = None,
+      proxyServer = None,
+      disableUrlEncoding = None
+    )
   }
 
   private[ahc] def execute(request: Request): Future[StandaloneAhcWSResponse] = {

--- a/play-ahc-ws-standalone/src/main/scala/play/api/libs/ws/ahc/StandaloneAhcWSRequest.scala
+++ b/play-ahc-ws-standalone/src/main/scala/play/api/libs/ws/ahc/StandaloneAhcWSRequest.scala
@@ -16,6 +16,7 @@ import play.shaded.ahc.org.asynchttpclient.Realm.AuthScheme
 import play.shaded.ahc.org.asynchttpclient.proxy.{ ProxyServer => AHCProxyServer }
 import play.shaded.ahc.org.asynchttpclient.util.HttpUtils
 import play.shaded.ahc.org.asynchttpclient._
+import play.shaded.ahc.org.asynchttpclient.cookie.{ Cookie => AhcCookie }
 
 import scala.collection.JavaConverters._
 import scala.collection.immutable.TreeMap
@@ -360,7 +361,7 @@ case class StandaloneAhcWSRequest(
     }
 
     // cookies
-    cookies.foreach(c => builder.addCookie(c.underlying))
+    cookies.foreach(c => builder.addCookie(c.underlying[AhcCookie]))
 
     builderWithBody.build()
   }

--- a/play-ahc-ws-standalone/src/main/scala/play/api/libs/ws/ahc/StandaloneAhcWSRequest.scala
+++ b/play-ahc-ws-standalone/src/main/scala/play/api/libs/ws/ahc/StandaloneAhcWSRequest.scala
@@ -46,7 +46,7 @@ case class StandaloneAhcWSRequest(
   override type Self = StandaloneWSRequest
   override type Response = StandaloneWSResponse
 
-  require(client != null, "A [[StandaloneAhcWSClient]] is required, but it is null")
+  require(client != null, "A StandaloneAhcWSClient is required, but it is null")
   require(url != null, "A url is required, but it is null")
 
   override def contentType: Option[String] = this.headers.get(HttpHeaders.Names.CONTENT_TYPE).map(_.head)

--- a/play-ahc-ws-standalone/src/main/scala/play/api/libs/ws/ahc/StandaloneAhcWSRequest.scala
+++ b/play-ahc-ws-standalone/src/main/scala/play/api/libs/ws/ahc/StandaloneAhcWSRequest.scala
@@ -67,7 +67,7 @@ case class StandaloneAhcWSRequest(
   override def withAuth(username: String, password: String, scheme: WSAuthScheme): Self =
     copy(auth = Some((username, password, scheme)))
 
-  override def setHeaders(hdrs: (String, String)*): Self = {
+  override def withHttpHeaders(hdrs: (String, String)*): Self = {
     var newHeaders = hdrs.foldLeft(TreeMap[String, Seq[String]]()(CaseInsensitiveOrdered)) {
       (m, hdr) =>
         if (m.contains(hdr._1)) m.updated(hdr._1, m(hdr._1) :+ hdr._2)
@@ -85,12 +85,12 @@ case class StandaloneAhcWSRequest(
     copy(headers = newHeaders)
   }
 
-  override def setQueryString(parameters: (String, String)*): Self =
+  override def withQueryStringParameters(parameters: (String, String)*): Self =
     copy(queryString = parameters.foldLeft(Map.empty[String, Seq[String]]) {
       case (m, (k, v)) => m + (k -> (v +: m.getOrElse(k, Nil)))
     })
 
-  override def setCookies(cookies: WSCookie*): StandaloneWSRequest = copy(cookies = cookies)
+  override def withCookies(cookies: WSCookie*): StandaloneWSRequest = copy(cookies = cookies)
 
   override def withFollowRedirects(follow: Boolean): Self = copy(followRedirects = Some(follow))
 
@@ -177,7 +177,7 @@ case class StandaloneAhcWSRequest(
     if (headers.contains(HttpHeaders.Names.CONTENT_TYPE)) {
       withBody(wsBody)
     } else {
-      withBody(wsBody).setHeaders(HttpHeaders.Names.CONTENT_TYPE -> contentType)
+      withBody(wsBody).withHttpHeaders(HttpHeaders.Names.CONTENT_TYPE -> contentType)
     }
   }
 

--- a/play-ahc-ws-standalone/src/test/scala/play/api/libs/ws/ahc/AhcWSRequestSpec.scala
+++ b/play-ahc-ws-standalone/src/test/scala/play/api/libs/ws/ahc/AhcWSRequestSpec.scala
@@ -12,13 +12,14 @@ import org.specs2.mutable.Specification
 import org.specs2.specification.AfterAll
 import play.api.libs.oauth.{ ConsumerKey, OAuthCalculator, RequestToken }
 import play.api.libs.ws.{ StandaloneWSRequest, StandaloneWSResponse, _ }
+import play.shaded.ahc.io.netty.handler.codec.http.HttpHeaders
 import play.shaded.ahc.org.asynchttpclient.Realm.AuthScheme
 import play.shaded.ahc.org.asynchttpclient.cookie.{ Cookie => AHCCookie }
-import play.shaded.ahc.org.asynchttpclient.{ Param, Request => AHCRequest, Response => AHCResponse }
+import play.shaded.ahc.org.asynchttpclient.{ Param, Request => AHCRequest }
 
-import scala.concurrent.Future
 import scala.concurrent.duration.{ Duration, _ }
 import scala.language.implicitConversions
+import scala.collection.JavaConverters._
 
 class AhcWSRequestSpec extends Specification with Mockito with AfterAll {
   sequential
@@ -36,162 +37,405 @@ class AhcWSRequestSpec extends Specification with Mockito with AfterAll {
     block(wsClient)
   }
 
-  "give the full URL with the query string" in {
+  "Given the full URL" in {
+
     implicit val materializer = mock[akka.stream.Materializer]
     val client = mock[StandaloneAhcWSClient]
-    val request = StandaloneAhcWSRequest(client, "http://example.com")
 
-    request.uri.toString must equalTo("http://example.com")
-    request.withQueryString("bar" -> "baz").uri.toString must equalTo("http://example.com?bar=baz")
-    request.withQueryString("bar" -> "baz", "bar" -> "bah").uri.toString must equalTo("http://example.com?bar=bah&bar=baz")
+    "request withQueryStringParameters" in {
+      val request = StandaloneAhcWSRequest(client, "http://example.com")
 
-  }
+      request.uri.toString must equalTo("http://example.com")
+      request.withQueryString("bar" -> "baz").uri.toString must equalTo("http://example.com?bar=baz")
+      request.withQueryString("bar" -> "baz", "bar" -> "bah").uri.toString must equalTo("http://example.com?bar=bah&bar=baz")
+    }
 
-  "correctly URL-encode the query string part" in {
-    implicit val materializer = mock[akka.stream.Materializer]
-    val client = mock[StandaloneAhcWSClient]
-    val request = StandaloneAhcWSRequest(client, "http://example.com")
+    "correctly URL-encode the query string part" in {
+      val request = StandaloneAhcWSRequest(client, "http://example.com")
 
-    request.withQueryString("&" -> "=").uri.toString must equalTo("http://example.com?%26=%3D")
+      request.withQueryString("&" -> "=").uri.toString must equalTo("http://example.com?%26=%3D")
+    }
 
-  }
+    "set all query string parameters" in {
+      val request = StandaloneAhcWSRequest(client, "http://example.com")
 
-  "AhcWSCookie.underlying" in {
-    val mockCookie = mock[AHCCookie]
-    val cookie = new AhcWSCookie(mockCookie)
-    cookie.underlying[AHCCookie] must beAnInstanceOf[AHCCookie]
-  }
+      request.setQueryString("bar" -> "baz").uri.toString must equalTo("http://example.com?bar=baz")
+      request.setQueryString("bar" -> "baz", "bar" -> "bah").uri.toString must equalTo("http://example.com?bar=bah&bar=baz")
+    }
 
-  "support several query string values for a parameter" in {
-    withClient { client =>
-      val req: AHCRequest = client.url("http://playframework.com/")
-        .withQueryString("foo" -> "foo1", "foo" -> "foo2").asInstanceOf[StandaloneAhcWSRequest].buildRequest()
+    "discard old query parameters when setting new ones" in {
+      val request = StandaloneAhcWSRequest(client, "http://example.com")
 
-      import scala.collection.JavaConverters._
-      val paramsList: Seq[Param] = req.getQueryParams.asScala.toSeq
-      paramsList.exists(p => (p.getName == "foo") && (p.getValue == "foo1")) must beTrue
-      paramsList.exists(p => (p.getName == "foo") && (p.getValue == "foo2")) must beTrue
-      paramsList.count(p => p.getName == "foo") must beEqualTo(2)
+      request
+        .setQueryString("bar" -> "baz")
+        .setQueryString("bar" -> "bah")
+        .uri.toString must equalTo("http://example.com?bar=bah")
+    }
+
+    "add query string param" in {
+      val request = StandaloneAhcWSRequest(client, "http://example.com")
+
+      request
+        .setQueryString("bar" -> "baz")
+        .addQueryString("bar" -> "bah")
+        .uri.toString must equalTo("http://example.com?bar=bah&bar=baz")
+    }
+
+    "support adding several query string values for a parameter" in {
+      val request = StandaloneAhcWSRequest(client, "http://example.com")
+      val newRequest = request
+        .setQueryString("play" -> "foo1")
+        .addQueryString("play" -> "foo2")
+
+      newRequest.queryString.get("play") must beSome.which(_.contains("foo1"))
+      newRequest.queryString.get("play") must beSome.which(_.contains("foo2"))
+      newRequest.queryString.get("play") must beSome.which(_.size == 2)
+    }
+
+    "support several query string values for  a parameter" in {
+      withClient { client =>
+        val req: AHCRequest = client.url("http://playframework.com/")
+          .setQueryString("foo" -> "foo1", "foo" -> "foo2")
+          .asInstanceOf[StandaloneAhcWSRequest]
+          .buildRequest()
+
+        val paramsList: Seq[Param] = req.getQueryParams.asScala
+        paramsList.exists(p => (p.getName == "foo") && (p.getValue == "foo1")) must beTrue
+        paramsList.exists(p => (p.getName == "foo") && (p.getValue == "foo2")) must beTrue
+        paramsList.count(p => p.getName == "foo") must beEqualTo(2)
+      }
+
     }
 
   }
 
-  /*
-  "StandaloneAhcWSRequest.setHeaders using a builder with direct map" in new WithApplication {
-    val request = new StandaloneAhcWSRequest(mock[AhcWSClient], "GET", None, None, Map.empty, EmptyBody, new RequestBuilder("GET"))
-    val headerMap: Map[String, Seq[String]] = Map("key" -> Seq("value"))
-    val ahcRequest = request.setHeaders(headerMap).build
-    ahcRequest.getHeaders.containsKey("key") must beTrue
-  }
+  "For Cookies" in {
 
-  "StandaloneAhcWSRequest.setQueryString" in new WithApplication {
-    val request = new StandaloneAhcWSRequest(mock[AhcWSClient], "GET", None, None, Map.empty, EmptyBody, new RequestBuilder("GET"))
-    val queryString: Map[String, Seq[String]] = Map("key" -> Seq("value"))
-    val ahcRequest = request.setQueryString(queryString).build
-    ahcRequest.getQueryParams().containsKey("key") must beTrue
-  }
-
-  "support several query string values for a parameter" in new WithApplication {
-    val req = WS.url("http://playframework.com/")
-      .setQueryString("foo" -> "foo1", "foo" -> "foo2").asInstanceOf[StandaloneAhcWSRequestHolder]
-      .prepare().build
-    req.getQueryParams.get("foo").contains("foo1") must beTrue
-    req.getQueryParams.get("foo").contains("foo2") must beTrue
-    req.getQueryParams.get("foo").size must equalTo(2)
-  }
-  */
-
-  "support http headers" in {
-    withClient { client =>
-      import scala.collection.JavaConverters._
-      val req: AHCRequest = client.url("http://playframework.com/")
-        .withHeaders("key" -> "value1", "key" -> "value2").asInstanceOf[StandaloneAhcWSRequest]
-        .buildRequest()
-      req.getHeaders.getAll("key").asScala must containTheSameElementsAs(Seq("value1", "value2"))
+    def cookie(name: String, value: String): WSCookie = {
+      new AhcWSCookie(
+        AHCCookie.newValidCookie(name, value, false, "example.com", "/", 1000, true, true)
+      )
     }
-  }
 
-  "not make Content-Type header if there is Content-Type in headers already" in {
-    withClient { client =>
-      import scala.collection.JavaConverters._
-      val req: AHCRequest = client.url("http://playframework.com/")
-        .withHeaders("content-type" -> "fake/contenttype; charset=utf-8")
-        .withBody(<aaa>value1</aaa>)
-        .asInstanceOf[StandaloneAhcWSRequest]
-        .buildRequest()
-      req.getHeaders.getAll("Content-Type").asScala must_== Seq("fake/contenttype; charset=utf-8")
-    }
-  }
+    "add cookies to request" in {
+      withClient { client =>
+        val req: AHCRequest = client
+          .url("http://example.com")
+          .addCookies(cookie("cookie1", "value1"))
+          .asInstanceOf[StandaloneAhcWSRequest]
+          .buildRequest()
 
-  "Have form params on POST of content type application/x-www-form-urlencoded" in {
-    withClient { client =>
-      val req: AHCRequest = client.url("http://playframework.com/")
-        .withBody(Map("param1" -> Seq("value1")))
-        .asInstanceOf[StandaloneAhcWSRequest]
-        .buildRequest()
-      (new String(req.getByteData, "UTF-8")) must_== ("param1=value1")
-    }
-  }
-
-  "Have form body on POST of content type text/plain" in {
-    withClient { client =>
-      val formEncoding = java.net.URLEncoder.encode("param1=value1", "UTF-8")
-      val req: AHCRequest = client.url("http://playframework.com/")
-        .withHeaders("Content-Type" -> "text/plain")
-        .withBody("HELLO WORLD")
-        .asInstanceOf[StandaloneAhcWSRequest]
-        .buildRequest()
-
-      (new String(req.getByteData, "UTF-8")) must be_==("HELLO WORLD")
-      val headers = req.getHeaders
-      headers.get("Content-Length") must beNull
-    }
-  }
-
-  "Have form body on POST of content type application/x-www-form-urlencoded explicitly set" in {
-    withClient { client =>
-      val req: AHCRequest = client.url("http://playframework.com/")
-        .withHeaders("Content-Type" -> "application/x-www-form-urlencoded") // set content type by hand
-        .withBody("HELLO WORLD") // and body is set to string (see #5221)
-        .asInstanceOf[StandaloneAhcWSRequest]
-        .buildRequest()
-      (new String(req.getByteData, "UTF-8")) must be_==("HELLO WORLD") // should result in byte data.
-    }
-  }
-
-  "support a custom signature calculator" in {
-    var called = false
-    val calc = new play.shaded.ahc.org.asynchttpclient.SignatureCalculator with WSSignatureCalculator {
-      override def calculateAndAddSignature(
-        request: play.shaded.ahc.org.asynchttpclient.Request,
-        requestBuilder: play.shaded.ahc.org.asynchttpclient.RequestBuilderBase[_]): Unit = {
-        called = true
+        req.getCookies.asScala must size(1)
+        req.getCookies.asScala.head.getName must beEqualTo("cookie1")
+        req.getCookies.asScala.head.getValue must beEqualTo("value1")
       }
     }
-    withClient { client =>
-      val req = client.url("http://playframework.com/").sign(calc)
-        .asInstanceOf[StandaloneAhcWSRequest]
-        .buildRequest()
-      called must beTrue
+
+    "set all cookies for request" in {
+      withClient { client =>
+        val req: AHCRequest = client
+          .url("http://example.com")
+          .setCookies(cookie("cookie1", "value1"), cookie("cookie2", "value2"))
+          .asInstanceOf[StandaloneAhcWSRequest]
+          .buildRequest()
+
+        req.getCookies.asScala must size(2)
+        req.getCookies.asScala.head.getName must beEqualTo("cookie1")
+        req.getCookies.asScala.head.getValue must beEqualTo("value1")
+
+        req.getCookies.asScala(1).getName must beEqualTo("cookie2")
+        req.getCookies.asScala(1).getValue must beEqualTo("value2")
+      }
+    }
+
+    "keep old cookies when adding a new one" in {
+      withClient { client =>
+        val req: AHCRequest = client
+          .url("http://example.com")
+          .setCookies(cookie("cookie1", "value1"))
+          .addCookies(cookie("cookie2", "value2"))
+          .asInstanceOf[StandaloneAhcWSRequest]
+          .buildRequest()
+
+        req.getCookies.asScala must size(2)
+        req.getCookies.asScala.head.getName must beEqualTo("cookie1")
+        req.getCookies.asScala.head.getValue must beEqualTo("value1")
+
+        req.getCookies.asScala(1).getName must beEqualTo("cookie2")
+        req.getCookies.asScala(1).getValue must beEqualTo("value2")
+      }
+    }
+
+    "discard all cookies when setting new ones" in {
+      withClient { client =>
+        val req: AHCRequest = client
+          .url("http://example.com")
+          .setCookies(cookie("cookie1", "value1"), cookie("cookie2", "value2"))
+          .setCookies(cookie("cookie3", "value3"), cookie("cookie4", "value4"))
+          .asInstanceOf[StandaloneAhcWSRequest]
+          .buildRequest()
+
+        req.getCookies.asScala must size(2)
+        req.getCookies.asScala.head.getName must beEqualTo("cookie3")
+        req.getCookies.asScala.head.getValue must beEqualTo("value3")
+
+        req.getCookies.asScala(1).getName must beEqualTo("cookie4")
+        req.getCookies.asScala(1).getValue must beEqualTo("value4")
+      }
     }
   }
 
-  "Have form params on POST of content type application/x-www-form-urlencoded when signed" in {
-    withClient { client =>
-      import scala.collection.JavaConverters._
-      val consumerKey = ConsumerKey("key", "secret")
-      val requestToken = RequestToken("token", "secret")
-      val calc = OAuthCalculator(consumerKey, requestToken)
-      val req: AHCRequest = client.url("http://playframework.com/").withBody(Map("param1" -> Seq("value1")))
-        .sign(calc)
+  "For HTTP Headers" in {
+
+    "support setting headers" in {
+      withClient { client =>
+        val req: AHCRequest = client
+          .url("http://playframework.com/")
+          .setHeaders("key" -> "value1", "key" -> "value2")
+          .asInstanceOf[StandaloneAhcWSRequest]
+          .buildRequest()
+        req.getHeaders.getAll("key").asScala must containTheSameElementsAs(Seq("value1", "value2"))
+      }
+    }
+
+    "discard old headers when setting" in {
+      withClient { client =>
+        val req: AHCRequest = client
+          .url("http://playframework.com/")
+          .setHeaders("key1" -> "value1")
+          .setHeaders("key2" -> "value2")
+          .asInstanceOf[StandaloneAhcWSRequest]
+          .buildRequest()
+        req.getHeaders.get("key1") must beNull
+        req.getHeaders.get("key2") must beEqualTo("value2")
+      }
+    }
+
+    "support adding headers" in {
+      withClient { client =>
+        val req: AHCRequest = client
+          .url("http://playframework.com/")
+          .setHeaders("key" -> "value1")
+          .addHeaders("key" -> "value2")
+          .asInstanceOf[StandaloneAhcWSRequest]
+          .buildRequest()
+        req.getHeaders.getAll("key").asScala must containTheSameElementsAs(Seq("value1", "value2"))
+      }
+    }
+
+    "keep existent headers when adding a new one" in {
+      withClient { client =>
+        val req: AHCRequest = client
+          .url("http://playframework.com/")
+          .setHeaders("key1" -> "value1")
+          .addHeaders("key2" -> "value2")
+          .asInstanceOf[StandaloneAhcWSRequest]
+          .buildRequest()
+        req.getHeaders.get("key1") must beEqualTo("value1")
+        req.getHeaders.get("key2") must beEqualTo("value2")
+      }
+    }
+
+    "not make Content-Type header if there is Content-Type in headers already" in {
+      withClient { client =>
+        import scala.collection.JavaConverters._
+        val req: AHCRequest = client.url("http://playframework.com/")
+          .setHeaders("content-type" -> "fake/contenttype; charset=utf-8")
+          .withBody(<aaa>value1</aaa>)
+          .asInstanceOf[StandaloneAhcWSRequest]
+          .buildRequest()
+        req.getHeaders.getAll(HttpHeaders.Names.CONTENT_TYPE).asScala must_== Seq("fake/contenttype; charset=utf-8")
+      }
+    }
+
+    "treat headers as case insensitive" in {
+      withClient { client =>
+        val req: AHCRequest = client
+          .url("http://playframework.com/")
+          .setHeaders("key" -> "value1", "KEY" -> "value2")
+
+          .asInstanceOf[StandaloneAhcWSRequest]
+          .buildRequest()
+        req.getHeaders.getAll("key").asScala must containTheSameElementsAs(Seq("value1", "value2"))
+      }
+    }
+  }
+
+  "For POST requests" in {
+
+    "Have form params for content type application/x-www-form-urlencoded" in {
+      withClient { client =>
+        val req: AHCRequest = client.url("http://playframework.com/")
+          .withBody(Map("param1" -> Seq("value1")))
+          .asInstanceOf[StandaloneAhcWSRequest]
+          .buildRequest()
+        (new String(req.getByteData, "UTF-8")) must_== ("param1=value1")
+      }
+    }
+
+    "Have form params for content type application/x-www-form-urlencoded when signed" in {
+      withClient { client =>
+        import scala.collection.JavaConverters._
+        val consumerKey = ConsumerKey("key", "secret")
+        val requestToken = RequestToken("token", "secret")
+        val calc = OAuthCalculator(consumerKey, requestToken)
+        val req: AHCRequest = client.url("http://playframework.com/").withBody(Map("param1" -> Seq("value1")))
+          .sign(calc)
+          .asInstanceOf[StandaloneAhcWSRequest]
+          .buildRequest()
+        // Note we use getFormParams instead of getByteData here.
+        req.getFormParams.asScala must containTheSameElementsAs(List(new play.shaded.ahc.org.asynchttpclient.Param("param1", "value1")))
+        req.getByteData must beNull // should NOT result in byte data.
+
+        val headers = req.getHeaders
+        headers.get("Content-Length") must beNull
+      }
+    }
+
+    "Have form body for content type text/plain" in {
+      withClient { client =>
+        val formEncoding = java.net.URLEncoder.encode("param1=value1", "UTF-8")
+        val req: AHCRequest = client.url("http://playframework.com/")
+          .setHeaders(HttpHeaders.Names.CONTENT_TYPE -> "text/plain")
+          .withBody("HELLO WORLD")
+          .asInstanceOf[StandaloneAhcWSRequest]
+          .buildRequest()
+
+        (new String(req.getByteData, "UTF-8")) must be_==("HELLO WORLD")
+        val headers = req.getHeaders
+        headers.get("Content-Length") must beNull
+      }
+    }
+
+    "Have form body for content type application/x-www-form-urlencoded explicitly set" in {
+      withClient { client =>
+        val req: AHCRequest = client.url("http://playframework.com/")
+          .setHeaders(HttpHeaders.Names.CONTENT_TYPE -> "application/x-www-form-urlencoded") // set content type by hand
+          .withBody("HELLO WORLD") // and body is set to string (see #5221)
+          .asInstanceOf[StandaloneAhcWSRequest]
+          .buildRequest()
+        (new String(req.getByteData, "UTF-8")) must be_==("HELLO WORLD") // should result in byte data.
+      }
+    }
+
+    "Send binary data as is" in withClient { client =>
+      val binData = ByteString((0 to 511).map(_.toByte).toArray)
+      val req: AHCRequest = client.url("http://playframework.com/").withHeaders(HttpHeaders.Names.CONTENT_TYPE -> "application/x-custom-bin-data").withBody(binData).asInstanceOf[StandaloneAhcWSRequest]
+        .buildRequest()
+
+      ByteString(req.getByteData) must_== binData
+    }
+  }
+
+  "When using a Proxy Server" in {
+
+    "support a proxy server with basic" in withClient { client =>
+      val proxy = DefaultWSProxyServer(protocol = Some("https"), host = "localhost", port = 8080, principal = Some("principal"), password = Some("password"))
+      val req: AHCRequest = client.url("http://playframework.com/").withProxyServer(proxy).asInstanceOf[StandaloneAhcWSRequest].buildRequest()
+      val actual = req.getProxyServer
+
+      actual.getHost must be equalTo "localhost"
+      actual.getPort must be equalTo 8080
+      actual.getRealm.getPrincipal must be equalTo "principal"
+      actual.getRealm.getPassword must be equalTo "password"
+      actual.getRealm.getScheme must be equalTo AuthScheme.BASIC
+    }
+
+    "support a proxy server with NTLM" in withClient { client =>
+      val proxy = DefaultWSProxyServer(protocol = Some("ntlm"), host = "localhost", port = 8080, principal = Some("principal"), password = Some("password"), ntlmDomain = Some("somentlmdomain"))
+      val req: AHCRequest = client.url("http://playframework.com/").withProxyServer(proxy).asInstanceOf[StandaloneAhcWSRequest].buildRequest()
+      val actual = req.getProxyServer
+
+      actual.getHost must be equalTo "localhost"
+      actual.getPort must be equalTo 8080
+      actual.getRealm.getPrincipal must be equalTo "principal"
+      actual.getRealm.getPassword must be equalTo "password"
+      actual.getRealm.getNtlmDomain must be equalTo "somentlmdomain"
+      actual.getRealm.getScheme must be equalTo AuthScheme.NTLM
+    }
+
+    "support a proxy server" in withClient { client =>
+      val proxy = DefaultWSProxyServer(host = "localhost", port = 8080)
+      val req: AHCRequest = client.url("http://playframework.com/").withProxyServer(proxy).asInstanceOf[StandaloneAhcWSRequest].buildRequest()
+      val actual = req.getProxyServer
+
+      actual.getHost must be equalTo "localhost"
+      actual.getPort must be equalTo 8080
+      actual.getRealm must beNull
+    }
+  }
+
+  "StandaloneAhcWSRequest supports" in {
+
+    "a custom signature calculator" in {
+      var called = false
+      val calc = new play.shaded.ahc.org.asynchttpclient.SignatureCalculator with WSSignatureCalculator {
+        override def calculateAndAddSignature(
+          request: play.shaded.ahc.org.asynchttpclient.Request,
+          requestBuilder: play.shaded.ahc.org.asynchttpclient.RequestBuilderBase[_]): Unit = {
+          called = true
+        }
+      }
+      withClient { client =>
+        val req = client.url("http://playframework.com/").sign(calc)
+          .asInstanceOf[StandaloneAhcWSRequest]
+          .buildRequest()
+        called must beTrue
+      }
+    }
+
+    "a virtual host" in withClient { client =>
+      val req: AHCRequest = client.url("http://playframework.com/")
+        .withVirtualHost("192.168.1.1").asInstanceOf[StandaloneAhcWSRequest]
+        .buildRequest()
+      req.getVirtualHost must be equalTo "192.168.1.1"
+    }
+
+    "follow redirects" in withClient { client =>
+      val req: AHCRequest = client.url("http://playframework.com/")
+        .withFollowRedirects(follow = true).asInstanceOf[StandaloneAhcWSRequest]
+        .buildRequest()
+      req.getFollowRedirect must beEqualTo(true)
+    }
+
+    "finite timeout" in withClient { client =>
+      val req: AHCRequest = client.url("http://playframework.com/")
+        .withRequestTimeout(1000.millis).asInstanceOf[StandaloneAhcWSRequest]
+        .buildRequest()
+      req.getRequestTimeout must be equalTo 1000
+    }
+
+    "infinite timeout" in withClient { client =>
+      val req: AHCRequest = client.url("http://playframework.com/")
+        .withRequestTimeout(Duration.Inf).asInstanceOf[StandaloneAhcWSRequest]
+        .buildRequest()
+      req.getRequestTimeout must be equalTo -1
+    }
+
+    "no negative timeout" in withClient { client =>
+      client.url("http://playframework.com/").withRequestTimeout(-1.millis) should throwAn[IllegalArgumentException]
+    }
+
+    "no timeout greater than Int.MaxValue" in withClient { client =>
+      client.url("http://playframework.com/").withRequestTimeout((Int.MaxValue.toLong + 1).millis) should throwAn[IllegalArgumentException]
+    }
+  }
+
+  "Set Realm.UsePreemptiveAuth" in {
+    "to false when WSAuthScheme.DIGEST being used" in withClient { client =>
+      val req = client.url("http://playframework.com/")
+        .withAuth("usr", "pwd", WSAuthScheme.DIGEST)
         .asInstanceOf[StandaloneAhcWSRequest]
         .buildRequest()
-      // Note we use getFormParams instead of getByteData here.
-      req.getFormParams.asScala must containTheSameElementsAs(List(new play.shaded.ahc.org.asynchttpclient.Param("param1", "value1")))
-      req.getByteData must beNull // should NOT result in byte data.
+      req.getRealm.isUsePreemptiveAuth must beFalse
+    }
 
-      val headers = req.getHeaders
-      headers.get("Content-Length") must beNull
+    "to true when WSAuthScheme.DIGEST not being used" in withClient { client =>
+      val req = client.url("http://playframework.com/")
+        .withAuth("usr", "pwd", WSAuthScheme.BASIC)
+        .asInstanceOf[StandaloneAhcWSRequest]
+        .buildRequest()
+      req.getRealm.isUsePreemptiveAuth must beTrue
     }
   }
 
@@ -200,7 +444,7 @@ class AhcWSRequestSpec extends Specification with Mockito with AfterAll {
     val requestToken = RequestToken("token", "secret")
     val calc = OAuthCalculator(consumerKey, requestToken)
     val req: AHCRequest = client.url("http://playframework.com/").withBody(Map("param1" -> Seq("value1")))
-      .withHeaders("Content-Length" -> "9001") // add a meaningless content length here...
+      .setHeaders("Content-Length" -> "9001") // add a meaningless content length here...
       .asInstanceOf[StandaloneAhcWSRequest]
       .buildRequest()
 
@@ -216,7 +460,7 @@ class AhcWSRequestSpec extends Specification with Mockito with AfterAll {
     val requestToken = RequestToken("token", "secret")
     val calc = OAuthCalculator(consumerKey, requestToken)
     val req: AHCRequest = client.url("http://playframework.com/").withBody(Map("param1" -> Seq("value1")))
-      .withHeaders("Content-Length" -> "9001") // add a meaningless content length here...
+      .setHeaders("Content-Length" -> "9001") // add a meaningless content length here...
       .sign(calc) // this is signed, so content length is no longer valid per #5221
       .asInstanceOf[StandaloneAhcWSRequest]
       .buildRequest()
@@ -230,106 +474,16 @@ class AhcWSRequestSpec extends Specification with Mockito with AfterAll {
   "Verify Content-Type header is passed through correctly" in withClient { client =>
     import scala.collection.JavaConverters._
     val req: AHCRequest = client.url("http://playframework.com/")
-      .withHeaders("Content-Type" -> "text/plain; charset=US-ASCII")
+      .withHeaders(HttpHeaders.Names.CONTENT_TYPE -> "text/plain; charset=US-ASCII")
       .withBody("HELLO WORLD")
       .asInstanceOf[StandaloneAhcWSRequest]
       .buildRequest()
-    req.getHeaders.getAll("Content-Type").asScala must_== Seq("text/plain; charset=US-ASCII")
+    req.getHeaders.getAll(HttpHeaders.Names.CONTENT_TYPE).asScala must_== Seq("text/plain; charset=US-ASCII")
   }
 
-  "POST binary data as is" in withClient { client =>
-    val binData = ByteString((0 to 511).map(_.toByte).toArray)
-    val req: AHCRequest = client.url("http://playframework.com/").withHeaders("Content-Type" -> "application/x-custom-bin-data").withBody(binData).asInstanceOf[StandaloneAhcWSRequest]
-      .buildRequest()
-
-    ByteString(req.getByteData) must_== binData
+  "AhcWSCookie.underlying" in {
+    val mockCookie = mock[AHCCookie]
+    val cookie = new AhcWSCookie(mockCookie)
+    cookie.underlying[AHCCookie] must beAnInstanceOf[AHCCookie]
   }
-
-  "support a virtual host" in withClient { client =>
-    val req: AHCRequest = client.url("http://playframework.com/")
-      .withVirtualHost("192.168.1.1").asInstanceOf[StandaloneAhcWSRequest]
-      .buildRequest()
-    req.getVirtualHost must be equalTo "192.168.1.1"
-  }
-
-  "support follow redirects" in withClient { client =>
-    val req: AHCRequest = client.url("http://playframework.com/")
-      .withFollowRedirects(follow = true).asInstanceOf[StandaloneAhcWSRequest]
-      .buildRequest()
-    req.getFollowRedirect must beEqualTo(true)
-  }
-
-  "support finite timeout" in withClient { client =>
-    val req: AHCRequest = client.url("http://playframework.com/")
-      .withRequestTimeout(1000.millis).asInstanceOf[StandaloneAhcWSRequest]
-      .buildRequest()
-    req.getRequestTimeout must be equalTo 1000
-  }
-
-  "support infinite timeout" in withClient { client =>
-    val req: AHCRequest = client.url("http://playframework.com/")
-      .withRequestTimeout(Duration.Inf).asInstanceOf[StandaloneAhcWSRequest]
-      .buildRequest()
-    req.getRequestTimeout must be equalTo -1
-  }
-
-  "not support negative timeout" in withClient { client =>
-    client.url("http://playframework.com/").withRequestTimeout(-1.millis) should throwAn[IllegalArgumentException]
-  }
-
-  "not support a timeout greater than Int.MaxValue" in withClient { client =>
-    client.url("http://playframework.com/").withRequestTimeout((Int.MaxValue.toLong + 1).millis) should throwAn[IllegalArgumentException]
-  }
-
-  "support a proxy server with basic" in withClient { client =>
-    val proxy = DefaultWSProxyServer(protocol = Some("https"), host = "localhost", port = 8080, principal = Some("principal"), password = Some("password"))
-    val req: AHCRequest = client.url("http://playframework.com/").withProxyServer(proxy).asInstanceOf[StandaloneAhcWSRequest].buildRequest()
-    val actual = req.getProxyServer
-
-    actual.getHost must be equalTo "localhost"
-    actual.getPort must be equalTo 8080
-    actual.getRealm.getPrincipal must be equalTo "principal"
-    actual.getRealm.getPassword must be equalTo "password"
-    actual.getRealm.getScheme must be equalTo AuthScheme.BASIC
-  }
-
-  "support a proxy server with NTLM" in withClient { client =>
-    val proxy = DefaultWSProxyServer(protocol = Some("ntlm"), host = "localhost", port = 8080, principal = Some("principal"), password = Some("password"), ntlmDomain = Some("somentlmdomain"))
-    val req: AHCRequest = client.url("http://playframework.com/").withProxyServer(proxy).asInstanceOf[StandaloneAhcWSRequest].buildRequest()
-    val actual = req.getProxyServer
-
-    actual.getHost must be equalTo "localhost"
-    actual.getPort must be equalTo 8080
-    actual.getRealm.getPrincipal must be equalTo "principal"
-    actual.getRealm.getPassword must be equalTo "password"
-    actual.getRealm.getNtlmDomain must be equalTo "somentlmdomain"
-    actual.getRealm.getScheme must be equalTo AuthScheme.NTLM
-  }
-
-  "Set Realm.UsePreemptiveAuth to false when WSAuthScheme.DIGEST being used" in withClient { client =>
-    val req = client.url("http://playframework.com/")
-      .withAuth("usr", "pwd", WSAuthScheme.DIGEST)
-      .asInstanceOf[StandaloneAhcWSRequest]
-      .buildRequest()
-    req.getRealm.isUsePreemptiveAuth must beFalse
-  }
-
-  "Set Realm.UsePreemptiveAuth to true when WSAuthScheme.DIGEST not being used" in withClient { client =>
-    val req = client.url("http://playframework.com/")
-      .withAuth("usr", "pwd", WSAuthScheme.BASIC)
-      .asInstanceOf[StandaloneAhcWSRequest]
-      .buildRequest()
-    req.getRealm.isUsePreemptiveAuth must beTrue
-  }
-
-  "support a proxy server" in withClient { client =>
-    val proxy = DefaultWSProxyServer(host = "localhost", port = 8080)
-    val req: AHCRequest = client.url("http://playframework.com/").withProxyServer(proxy).asInstanceOf[StandaloneAhcWSRequest].buildRequest()
-    val actual = req.getProxyServer
-
-    actual.getHost must be equalTo "localhost"
-    actual.getPort must be equalTo 8080
-    actual.getRealm must beNull
-  }
-
 }

--- a/play-ahc-ws-standalone/src/test/scala/play/api/libs/ws/ahc/AhcWSRequestSpec.scala
+++ b/play-ahc-ws-standalone/src/test/scala/play/api/libs/ws/ahc/AhcWSRequestSpec.scala
@@ -223,7 +223,7 @@ class AhcWSRequestSpec extends Specification with Mockito with AfterAll {
       }
     }
 
-    "keep existent headers when adding a new one" in {
+    "keep existing headers when adding a new one" in {
       withClient { client =>
         val req: AHCRequest = client
           .url("http://playframework.com/")

--- a/play-ahc-ws-standalone/src/test/scala/play/api/libs/ws/ahc/AhcWSRequestSpec.scala
+++ b/play-ahc-ws-standalone/src/test/scala/play/api/libs/ws/ahc/AhcWSRequestSpec.scala
@@ -59,16 +59,16 @@ class AhcWSRequestSpec extends Specification with Mockito with AfterAll {
     "set all query string parameters" in {
       val request = StandaloneAhcWSRequest(client, "http://example.com")
 
-      request.setQueryString("bar" -> "baz").uri.toString must equalTo("http://example.com?bar=baz")
-      request.setQueryString("bar" -> "baz", "bar" -> "bah").uri.toString must equalTo("http://example.com?bar=bah&bar=baz")
+      request.withQueryStringParameters("bar" -> "baz").uri.toString must equalTo("http://example.com?bar=baz")
+      request.withQueryStringParameters("bar" -> "baz", "bar" -> "bah").uri.toString must equalTo("http://example.com?bar=bah&bar=baz")
     }
 
     "discard old query parameters when setting new ones" in {
       val request = StandaloneAhcWSRequest(client, "http://example.com")
 
       request
-        .setQueryString("bar" -> "baz")
-        .setQueryString("bar" -> "bah")
+        .withQueryStringParameters("bar" -> "baz")
+        .withQueryStringParameters("bar" -> "bah")
         .uri.toString must equalTo("http://example.com?bar=bah")
     }
 
@@ -76,16 +76,16 @@ class AhcWSRequestSpec extends Specification with Mockito with AfterAll {
       val request = StandaloneAhcWSRequest(client, "http://example.com")
 
       request
-        .setQueryString("bar" -> "baz")
-        .addQueryString("bar" -> "bah")
+        .withQueryStringParameters("bar" -> "baz")
+        .addQueryStringParameter("bar" -> "bah")
         .uri.toString must equalTo("http://example.com?bar=bah&bar=baz")
     }
 
     "support adding several query string values for a parameter" in {
       val request = StandaloneAhcWSRequest(client, "http://example.com")
       val newRequest = request
-        .setQueryString("play" -> "foo1")
-        .addQueryString("play" -> "foo2")
+        .withQueryStringParameters("play" -> "foo1")
+        .addQueryStringParameter("play" -> "foo2")
 
       newRequest.queryString.get("play") must beSome.which(_.contains("foo1"))
       newRequest.queryString.get("play") must beSome.which(_.contains("foo2"))
@@ -95,7 +95,7 @@ class AhcWSRequestSpec extends Specification with Mockito with AfterAll {
     "support several query string values for  a parameter" in {
       withClient { client =>
         val req: AHCRequest = client.url("http://playframework.com/")
-          .setQueryString("foo" -> "foo1", "foo" -> "foo2")
+          .withQueryStringParameters("foo" -> "foo1", "foo" -> "foo2")
           .asInstanceOf[StandaloneAhcWSRequest]
           .buildRequest()
 
@@ -135,7 +135,7 @@ class AhcWSRequestSpec extends Specification with Mockito with AfterAll {
       withClient { client =>
         val req: AHCRequest = client
           .url("http://example.com")
-          .setCookies(cookie("cookie1", "value1"), cookie("cookie2", "value2"))
+          .withCookies(cookie("cookie1", "value1"), cookie("cookie2", "value2"))
           .asInstanceOf[StandaloneAhcWSRequest]
           .buildRequest()
 
@@ -152,7 +152,7 @@ class AhcWSRequestSpec extends Specification with Mockito with AfterAll {
       withClient { client =>
         val req: AHCRequest = client
           .url("http://example.com")
-          .setCookies(cookie("cookie1", "value1"))
+          .withCookies(cookie("cookie1", "value1"))
           .addCookies(cookie("cookie2", "value2"))
           .asInstanceOf[StandaloneAhcWSRequest]
           .buildRequest()
@@ -170,8 +170,8 @@ class AhcWSRequestSpec extends Specification with Mockito with AfterAll {
       withClient { client =>
         val req: AHCRequest = client
           .url("http://example.com")
-          .setCookies(cookie("cookie1", "value1"), cookie("cookie2", "value2"))
-          .setCookies(cookie("cookie3", "value3"), cookie("cookie4", "value4"))
+          .withCookies(cookie("cookie1", "value1"), cookie("cookie2", "value2"))
+          .withCookies(cookie("cookie3", "value3"), cookie("cookie4", "value4"))
           .asInstanceOf[StandaloneAhcWSRequest]
           .buildRequest()
 
@@ -191,7 +191,7 @@ class AhcWSRequestSpec extends Specification with Mockito with AfterAll {
       withClient { client =>
         val req: AHCRequest = client
           .url("http://playframework.com/")
-          .setHeaders("key" -> "value1", "key" -> "value2")
+          .withHttpHeaders("key" -> "value1", "key" -> "value2")
           .asInstanceOf[StandaloneAhcWSRequest]
           .buildRequest()
         req.getHeaders.getAll("key").asScala must containTheSameElementsAs(Seq("value1", "value2"))
@@ -202,8 +202,8 @@ class AhcWSRequestSpec extends Specification with Mockito with AfterAll {
       withClient { client =>
         val req: AHCRequest = client
           .url("http://playframework.com/")
-          .setHeaders("key1" -> "value1")
-          .setHeaders("key2" -> "value2")
+          .withHttpHeaders("key1" -> "value1")
+          .withHttpHeaders("key2" -> "value2")
           .asInstanceOf[StandaloneAhcWSRequest]
           .buildRequest()
         req.getHeaders.get("key1") must beNull
@@ -215,8 +215,8 @@ class AhcWSRequestSpec extends Specification with Mockito with AfterAll {
       withClient { client =>
         val req: AHCRequest = client
           .url("http://playframework.com/")
-          .setHeaders("key" -> "value1")
-          .addHeaders("key" -> "value2")
+          .withHttpHeaders("key" -> "value1")
+          .addHttpHeaders("key" -> "value2")
           .asInstanceOf[StandaloneAhcWSRequest]
           .buildRequest()
         req.getHeaders.getAll("key").asScala must containTheSameElementsAs(Seq("value1", "value2"))
@@ -227,8 +227,8 @@ class AhcWSRequestSpec extends Specification with Mockito with AfterAll {
       withClient { client =>
         val req: AHCRequest = client
           .url("http://playframework.com/")
-          .setHeaders("key1" -> "value1")
-          .addHeaders("key2" -> "value2")
+          .withHttpHeaders("key1" -> "value1")
+          .addHttpHeaders("key2" -> "value2")
           .asInstanceOf[StandaloneAhcWSRequest]
           .buildRequest()
         req.getHeaders.get("key1") must beEqualTo("value1")
@@ -240,7 +240,7 @@ class AhcWSRequestSpec extends Specification with Mockito with AfterAll {
       withClient { client =>
         import scala.collection.JavaConverters._
         val req: AHCRequest = client.url("http://playframework.com/")
-          .setHeaders("content-type" -> "fake/contenttype; charset=utf-8")
+          .withHttpHeaders("content-type" -> "fake/contenttype; charset=utf-8")
           .withBody(<aaa>value1</aaa>)
           .asInstanceOf[StandaloneAhcWSRequest]
           .buildRequest()
@@ -252,7 +252,7 @@ class AhcWSRequestSpec extends Specification with Mockito with AfterAll {
       withClient { client =>
         val req: AHCRequest = client
           .url("http://playframework.com/")
-          .setHeaders("key" -> "value1", "KEY" -> "value2")
+          .withHttpHeaders("key" -> "value1", "KEY" -> "value2")
 
           .asInstanceOf[StandaloneAhcWSRequest]
           .buildRequest()
@@ -296,7 +296,7 @@ class AhcWSRequestSpec extends Specification with Mockito with AfterAll {
       withClient { client =>
         val formEncoding = java.net.URLEncoder.encode("param1=value1", "UTF-8")
         val req: AHCRequest = client.url("http://playframework.com/")
-          .setHeaders(HttpHeaders.Names.CONTENT_TYPE -> "text/plain")
+          .withHttpHeaders(HttpHeaders.Names.CONTENT_TYPE -> "text/plain")
           .withBody("HELLO WORLD")
           .asInstanceOf[StandaloneAhcWSRequest]
           .buildRequest()
@@ -310,7 +310,7 @@ class AhcWSRequestSpec extends Specification with Mockito with AfterAll {
     "Have form body for content type application/x-www-form-urlencoded explicitly set" in {
       withClient { client =>
         val req: AHCRequest = client.url("http://playframework.com/")
-          .setHeaders(HttpHeaders.Names.CONTENT_TYPE -> "application/x-www-form-urlencoded") // set content type by hand
+          .withHttpHeaders(HttpHeaders.Names.CONTENT_TYPE -> "application/x-www-form-urlencoded") // set content type by hand
           .withBody("HELLO WORLD") // and body is set to string (see #5221)
           .asInstanceOf[StandaloneAhcWSRequest]
           .buildRequest()
@@ -444,7 +444,7 @@ class AhcWSRequestSpec extends Specification with Mockito with AfterAll {
     val requestToken = RequestToken("token", "secret")
     val calc = OAuthCalculator(consumerKey, requestToken)
     val req: AHCRequest = client.url("http://playframework.com/").withBody(Map("param1" -> Seq("value1")))
-      .setHeaders("Content-Length" -> "9001") // add a meaningless content length here...
+      .withHttpHeaders("Content-Length" -> "9001") // add a meaningless content length here...
       .asInstanceOf[StandaloneAhcWSRequest]
       .buildRequest()
 
@@ -460,7 +460,7 @@ class AhcWSRequestSpec extends Specification with Mockito with AfterAll {
     val requestToken = RequestToken("token", "secret")
     val calc = OAuthCalculator(consumerKey, requestToken)
     val req: AHCRequest = client.url("http://playframework.com/").withBody(Map("param1" -> Seq("value1")))
-      .setHeaders("Content-Length" -> "9001") // add a meaningless content length here...
+      .withHttpHeaders("Content-Length" -> "9001") // add a meaningless content length here...
       .sign(calc) // this is signed, so content length is no longer valid per #5221
       .asInstanceOf[StandaloneAhcWSRequest]
       .buildRequest()

--- a/play-ahc-ws-standalone/src/test/scala/play/libs/ws/ahc/AhcWSRequestSpec.scala
+++ b/play-ahc-ws-standalone/src/test/scala/play/libs/ws/ahc/AhcWSRequestSpec.scala
@@ -43,7 +43,7 @@ class AhcWSRequestSpec extends Specification with Mockito {
         req.getStringData must be_==("HELLO WORLD")
       }
 
-      "keep existent content type when setting body" in {
+      "keep existing content type when setting body" in {
         val client = mock[StandaloneAhcWSClient]
         val req = new StandaloneAhcWSRequest(client, "http://playframework.com/", null)
           .setContentType("application/x-www-form-urlencoded") // set content type by hand
@@ -169,7 +169,7 @@ class AhcWSRequestSpec extends Specification with Mockito {
           .getHeaders.get("header1") must beEqualTo("value1")
       }
 
-      "add new value for existent header" in {
+      "add new value for existing header" in {
         val client = mock[StandaloneAhcWSClient]
         val request = new StandaloneAhcWSRequest(client, "http://example.com", /*materializer*/ null)
           .addHeader("header1", "value1")
@@ -198,7 +198,7 @@ class AhcWSRequestSpec extends Specification with Mockito {
           .get("header1") must beEqualTo("value1")
       }
 
-      "keep existent headers when adding a new one" in {
+      "keep existing headers when adding a new one" in {
         val client = mock[StandaloneAhcWSClient]
         val request = new StandaloneAhcWSRequest(client, "http://example.com", /*materializer*/ null)
 
@@ -235,7 +235,7 @@ class AhcWSRequestSpec extends Specification with Mockito {
         request.getUrl must contain("p1=v1")
       }
 
-      "add new value for existent parameter" in {
+      "add new value for existing parameter" in {
         val client = mock[StandaloneAhcWSClient]
         val request = new StandaloneAhcWSRequest(client, "http://example.com", /*materializer*/ null)
           .addQueryParameter("p1", "v1")
@@ -246,7 +246,7 @@ class AhcWSRequestSpec extends Specification with Mockito {
         request.getUrl must contain("p1=v2")
       }
 
-      "keep existent parameters when adding a new one" in {
+      "keep existing parameters when adding a new one" in {
         val client = mock[StandaloneAhcWSClient]
         val request = new StandaloneAhcWSRequest(client, "http://example.com", /*materializer*/ null)
           .addQueryParameter("p1", "v1")
@@ -330,7 +330,7 @@ class AhcWSRequestSpec extends Specification with Mockito {
         request.getCookies.asScala(1).getName must beEqualTo("cookie2")
       }
 
-      "keep existent cookies when adding a new one" in {
+      "keep existing cookies when adding a new one" in {
         val client = mock[StandaloneAhcWSClient]
         val request = new StandaloneAhcWSRequest(client, "http://example.com", /*materializer*/ null)
           .addCookie(cookie("cookie1", "value1"))

--- a/play-ws-standalone/src/main/java/play/libs/ws/StandaloneWSRequest.java
+++ b/play-ws-standalone/src/main/java/play/libs/ws/StandaloneWSRequest.java
@@ -10,7 +10,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 
 import java.io.File;
 import java.io.InputStream;
-import java.util.Collection;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletionStage;
 
@@ -32,7 +32,9 @@ public interface StandaloneWSRequest {
      *
      * @return a promise to the response
      */
-    CompletionStage<? extends StandaloneWSResponse> get();
+    default CompletionStage<? extends StandaloneWSResponse> get() {
+        return execute("GET");
+    }
 
     //-------------------------------------------------------------------------
     // "PATCH"
@@ -44,7 +46,9 @@ public interface StandaloneWSRequest {
      * @param body represented as String
      * @return a promise to the response
      */
-    CompletionStage<? extends StandaloneWSResponse> patch(String body);
+    default CompletionStage<? extends StandaloneWSResponse> patch(String body) {
+        return setMethod("PATCH").setBody(body).execute();
+    }
 
     /**
      * Perform a PATCH on the request asynchronously.
@@ -52,15 +56,22 @@ public interface StandaloneWSRequest {
      * @param body represented as JSON
      * @return a promise to the response
      */
-    CompletionStage<? extends StandaloneWSResponse> patch(JsonNode body);
+    default CompletionStage<? extends StandaloneWSResponse> patch(JsonNode body) {
+        return setMethod("PATCH").setBody(body).execute();
+    }
 
     /**
      * Perform a PATCH on the request asynchronously.
      *
      * @param body represented as an InputStream
      * @return a promise to the response
+     *
+     * @deprecated Since 1.0.0. Use {@link #patch(Source)} instead.
      */
-    CompletionStage<? extends StandaloneWSResponse> patch(InputStream body);
+    @Deprecated
+    default CompletionStage<? extends StandaloneWSResponse> patch(InputStream body) {
+        return setMethod("PATCH").setBody(body).execute();
+    }
 
     /**
      * Perform a PATCH on the request asynchronously.
@@ -68,7 +79,19 @@ public interface StandaloneWSRequest {
      * @param body represented as a File
      * @return a promise to the response
      */
-    CompletionStage<? extends StandaloneWSResponse> patch(File body);
+    default CompletionStage<? extends StandaloneWSResponse> patch(File body) {
+        return setMethod("PATCH").setBody(body).execute();
+    }
+
+    /**
+     * Perform a PATCH on the request asynchronously.
+     *
+     * @param body the body of request
+     * @return a promise to the response
+     */
+    default <U> CompletionStage<? extends StandaloneWSResponse> patch(Source<ByteString, U> body) {
+        return setMethod("PATCH").setBody(body).execute();
+    }
 
     //-------------------------------------------------------------------------
     // "POST"
@@ -80,7 +103,9 @@ public interface StandaloneWSRequest {
      * @param body represented as String
      * @return a promise to the response
      */
-    CompletionStage<? extends StandaloneWSResponse> post(String body);
+    default CompletionStage<? extends StandaloneWSResponse> post(String body) {
+        return setMethod("POST").setBody(body).execute();
+    }
 
     /**
      * Perform a POST on the request asynchronously.
@@ -88,15 +113,22 @@ public interface StandaloneWSRequest {
      * @param body represented as JSON
      * @return a promise to the response
      */
-    CompletionStage<? extends StandaloneWSResponse> post(JsonNode body);
+    default CompletionStage<? extends StandaloneWSResponse> post(JsonNode body) {
+        return setMethod("POST").setBody(body).execute();
+    }
 
     /**
      * Perform a POST on the request asynchronously.
      *
      * @param body represented as an InputStream
      * @return a promise to the response
+     *
+     * @deprecated Since 1.0.0. Use {@link #post(Source)} instead.
      */
-    CompletionStage<? extends StandaloneWSResponse> post(InputStream body);
+    @Deprecated
+    default CompletionStage<? extends StandaloneWSResponse> post(InputStream body) {
+        return setMethod("POST").setBody(body).execute();
+    }
 
     /**
      * Perform a POST on the request asynchronously.
@@ -104,7 +136,19 @@ public interface StandaloneWSRequest {
      * @param body represented as a File
      * @return a promise to the response
      */
-    CompletionStage<? extends StandaloneWSResponse> post(File body);
+    default CompletionStage<? extends StandaloneWSResponse> post(File body) {
+        return setMethod("POST").setBody(body).execute();
+    }
+
+    /**
+     * Perform a POST on the request asynchronously.
+     *
+     * @param body the body of request
+     * @return a promise to the response
+     */
+    default <U> CompletionStage<? extends StandaloneWSResponse> post(Source<ByteString, U> body) {
+        return setMethod("POST").setBody(body).execute();
+    }
 
     //-------------------------------------------------------------------------
     // "PUT"
@@ -116,7 +160,9 @@ public interface StandaloneWSRequest {
      * @param body represented as String
      * @return a promise to the response
      */
-    CompletionStage<? extends StandaloneWSResponse> put(String body);
+    default CompletionStage<? extends StandaloneWSResponse> put(String body) {
+        return setMethod("PUT").setBody(body).execute();
+    }
 
     /**
      * Perform a PUT on the request asynchronously.
@@ -124,15 +170,22 @@ public interface StandaloneWSRequest {
      * @param body represented as JSON
      * @return a promise to the response
      */
-    CompletionStage<? extends StandaloneWSResponse> put(JsonNode body);
+    default CompletionStage<? extends StandaloneWSResponse> put(JsonNode body) {
+        return setMethod("PUT").setBody(body).execute();
+    }
 
     /**
      * Perform a PUT on the request asynchronously.
      *
      * @param body represented as an InputStream
      * @return a promise to the response
+     *
+     * @deprecated Since 1.0.0. Use {@link #post(Source)} instead.
      */
-    CompletionStage<? extends StandaloneWSResponse> put(InputStream body);
+    @Deprecated
+    default CompletionStage<? extends StandaloneWSResponse> put(InputStream body) {
+        return setMethod("PUT").setBody(body).execute();
+    }
 
     /**
      * Perform a PUT on the request asynchronously.
@@ -140,7 +193,19 @@ public interface StandaloneWSRequest {
      * @param body represented as a File
      * @return a promise to the response
      */
-    CompletionStage<? extends StandaloneWSResponse> put(File body);
+    default CompletionStage<? extends StandaloneWSResponse> put(File body) {
+        return setMethod("PUT").setBody(body).execute();
+    }
+
+    /**
+     * Perform a PUT on the request asynchronously.
+     *
+     * @param body the body of request
+     * @return a promise to the response
+     */
+    default <U> CompletionStage<? extends StandaloneWSResponse> put(Source<ByteString, U> body) {
+        return setMethod("PUT").setBody(body).execute();
+    }
 
     //-------------------------------------------------------------------------
     // Miscellaneous execution methods
@@ -151,21 +216,27 @@ public interface StandaloneWSRequest {
      *
      * @return a promise to the response
      */
-    CompletionStage<? extends StandaloneWSResponse> delete();
+    default CompletionStage<? extends StandaloneWSResponse> delete() {
+        return execute("DELETE");
+    }
 
     /**
      * Perform a HEAD on the request asynchronously.
      *
      * @return a promise to the response
      */
-    CompletionStage<? extends StandaloneWSResponse> head();
+    default CompletionStage<? extends StandaloneWSResponse> head() {
+        return execute("HEAD");
+    }
 
     /**
      * Perform an OPTIONS on the request asynchronously.
      *
      * @return a promise to the response
      */
-    CompletionStage<? extends StandaloneWSResponse> options();
+    default CompletionStage<? extends StandaloneWSResponse> options() {
+        return execute("OPTIONS");
+    }
 
     /**
      * Execute an arbitrary method on the request asynchronously.
@@ -173,7 +244,9 @@ public interface StandaloneWSRequest {
      * @param method The method to execute
      * @return a promise to the response
      */
-    CompletionStage<? extends StandaloneWSResponse> execute(String method);
+    default CompletionStage<? extends StandaloneWSResponse> execute(String method) {
+        return setMethod(method).execute();
+    }
 
     /**
      * Execute an arbitrary method on the request asynchronously.  Should be used with setMethod().
@@ -222,7 +295,7 @@ public interface StandaloneWSRequest {
      *
      * @param body Deprecated
      * @return Deprecated
-     * @deprecated use {@link #setBody(Source)} instead.
+     * @deprecated Since 1.0.0. Use {@link #setBody(Source)} instead.
      */
     @Deprecated
     StandaloneWSRequest setBody(InputStream body);
@@ -251,8 +324,34 @@ public interface StandaloneWSRequest {
      * @param name  the header name
      * @param value the header value
      * @return the modified WSRequest.
+     *
+     * @deprecated Since 1.0.0. Use {@link #addHeader(String, String)} or {@link #setHeaders(Map)}.
      */
-    StandaloneWSRequest setHeader(String name, String value);
+    @Deprecated
+    default StandaloneWSRequest setHeader(String name, String value) {
+        return addHeader(name, value);
+    }
+
+    /**
+     * Set headers to the request.  Note that duplicate headers are allowed
+     * by the HTTP specification, and removing a header is not available
+     * through this API. Any existent header will be discarded here.
+     *
+     * @param headers the headers
+     * @return the modified WSRequest.
+     */
+    StandaloneWSRequest setHeaders(Map<String, List<String>> headers);
+
+    /**
+     * Adds a header to the request.  Note that duplicate headers are allowed
+     * by the HTTP specification, and removing a header is not available
+     * through this API. Existent headers will be preserved.
+     *
+     * @param name  the header name
+     * @param value the header value
+     * @return the modified WSRequest.
+     */
+    StandaloneWSRequest addHeader(String name, String value);
 
     /**
      * Sets the query string to query.
@@ -268,8 +367,31 @@ public interface StandaloneWSRequest {
      * @param name  the query parameter name
      * @param value the query parameter value
      * @return the modified WSRequest.
+     *
+     * @deprecated Since 1.0.0. Use {@link #addQueryParameter(String, String)}, {@link #setQueryString(String)} or {@link #setQueryString(Map)} instead.
      */
-    StandaloneWSRequest setQueryParameter(String name, String value);
+    @Deprecated
+    default StandaloneWSRequest setQueryParameter(String name, String value) {
+        return addQueryParameter(name, value);
+    }
+
+    /**
+     * Adds a query parameter with the given name, this can be called repeatedly and will preserve existent values.
+     * Duplicate query parameters are allowed.
+     *
+     * @param name  the query parameter name
+     * @param value the query parameter value
+     * @return the modified WSRequest.
+     */
+    StandaloneWSRequest addQueryParameter(String name, String value);
+
+    /**
+     * Sets the query string parameters. This will discard existent values.
+     *
+     * @param params the query string parameters
+     * @return the modified WSRequest.
+     */
+    StandaloneWSRequest setQueryString(Map<String, List<String>> params);
 
     /**
      * Sets the authentication header for the current request using BASIC authentication.
@@ -359,12 +481,12 @@ public interface StandaloneWSRequest {
     /**
      * @return the headers (a copy to prevent side-effects). This has not passed through an internal request builder and so will not be signed.
      */
-    Map<String, Collection<String>> getHeaders();
+    Map<String, List<String>> getHeaders();
 
     /**
      * @return the query parameters (a copy to prevent side-effects). This has not passed through an internal request builder and so will not be signed.
      */
-    Map<String, Collection<String>> getQueryParameters();
+    Map<String, List<String>> getQueryParameters();
 
     /**
      * @return the auth username, null if not an authenticated request.

--- a/play-ws-standalone/src/main/java/play/libs/ws/StandaloneWSRequest.java
+++ b/play-ws-standalone/src/main/java/play/libs/ws/StandaloneWSRequest.java
@@ -335,7 +335,7 @@ public interface StandaloneWSRequest {
     /**
      * Set headers to the request.  Note that duplicate headers are allowed
      * by the HTTP specification, and removing a header is not available
-     * through this API. Any existent header will be discarded here.
+     * through this API. Any existing header will be discarded here.
      *
      * @param headers the headers
      * @return the modified WSRequest.
@@ -376,7 +376,7 @@ public interface StandaloneWSRequest {
     }
 
     /**
-     * Adds a query parameter with the given name, this can be called repeatedly and will preserve existent values.
+     * Adds a query parameter with the given name, this can be called repeatedly and will preserve existing values.
      * Duplicate query parameters are allowed.
      *
      * @param name  the query parameter name
@@ -386,7 +386,7 @@ public interface StandaloneWSRequest {
     StandaloneWSRequest addQueryParameter(String name, String value);
 
     /**
-     * Sets the query string parameters. This will discard existent values.
+     * Sets the query string parameters. This will discard existing values.
      *
      * @param params the query string parameters
      * @return the modified WSRequest.
@@ -394,7 +394,7 @@ public interface StandaloneWSRequest {
     StandaloneWSRequest setQueryString(Map<String, List<String>> params);
 
     /**
-     * Add a new cookie. This can be called repeatedly and will preserve existent cookies.
+     * Add a new cookie. This can be called repeatedly and will preserve existing cookies.
      *
      * @param cookie the cookie to be added
      * @return the modified WSRequest.
@@ -405,7 +405,7 @@ public interface StandaloneWSRequest {
     StandaloneWSRequest addCookie(WSCookie cookie);
 
     /**
-     * Add new cookies. This can be called repeatedly and will preserve existent cookies.
+     * Add new cookies. This can be called repeatedly and will preserve existing cookies.
      *
      * @param cookies the list of cookies to be added
      * @return the modified WSRequest.
@@ -416,7 +416,7 @@ public interface StandaloneWSRequest {
     StandaloneWSRequest addCookies(WSCookie ... cookies);
 
     /**
-     * Set the request cookies. This discard the existent cookies.
+     * Set the request cookies. This discard the existing cookies.
      *
      * @param cookies the cookies to be used.
      * @return the modified WSRequest.

--- a/play-ws-standalone/src/main/java/play/libs/ws/StandaloneWSRequest.java
+++ b/play-ws-standalone/src/main/java/play/libs/ws/StandaloneWSRequest.java
@@ -394,6 +394,36 @@ public interface StandaloneWSRequest {
     StandaloneWSRequest setQueryString(Map<String, List<String>> params);
 
     /**
+     * Add a new cookie. This can be called repeatedly and will preserve existent cookies.
+     *
+     * @param cookie the cookie to be added
+     * @return the modified WSRequest.
+     *
+     * @see #addCookies(WSCookie...)
+     * @see #setCookies(List)
+     */
+    StandaloneWSRequest addCookie(WSCookie cookie);
+
+    /**
+     * Add new cookies. This can be called repeatedly and will preserve existent cookies.
+     *
+     * @param cookies the list of cookies to be added
+     * @return the modified WSRequest.
+     *
+     * @see #addCookie(WSCookie)
+     * @see #setCookies(List)
+     */
+    StandaloneWSRequest addCookies(WSCookie ... cookies);
+
+    /**
+     * Set the request cookies. This discard the existent cookies.
+     *
+     * @param cookies the cookies to be used.
+     * @return the modified WSRequest.
+     */
+    StandaloneWSRequest setCookies(List<WSCookie> cookies);
+
+    /**
      * Sets the authentication header for the current request using BASIC authentication.
      *
      * @param userInfo a string formed as "username:password".

--- a/play-ws-standalone/src/main/java/play/libs/ws/WSCookie.java
+++ b/play-ws-standalone/src/main/java/play/libs/ws/WSCookie.java
@@ -50,7 +50,7 @@ public interface WSCookie {
     /**
      * @return if the cookie is accessed only server side.
      */
-    boolean httpOnly();
+    boolean isHttpOnly();
 
     // Cookie ports should not be used; cookies for a given host are shared across
     // all the ports on that host.

--- a/play-ws-standalone/src/main/java/play/libs/ws/WSCookie.java
+++ b/play-ws-standalone/src/main/java/play/libs/ws/WSCookie.java
@@ -15,19 +15,37 @@ public interface WSCookie {
      *
      * @return the "native" object
      */
-    public Object getUnderlying();
+    Object getUnderlying();
 
-    public String getDomain();
+    /**
+     * @return the cookie domain.
+     */
+    String getDomain();
 
-    public String getName();
+    /**
+     * @return the cookie name.
+     */
+    String getName();
 
-    public String getValue();
+    /**
+     * @return the cookie value.
+     */
+    String getValue();
 
-    public String getPath();
+    /**
+     * @return the cookie path.
+     */
+    String getPath();
 
-    public long getMaxAge();
+    /**
+     * @return the cookie max age, in seconds.
+     */
+    long getMaxAge();
 
-    public boolean isSecure();
+    /**
+     * @return if the cookie is secure or not.
+     */
+    boolean isSecure();
 
     // Cookie ports should not be used; cookies for a given host are shared across
     // all the ports on that host.

--- a/play-ws-standalone/src/main/java/play/libs/ws/WSCookie.java
+++ b/play-ws-standalone/src/main/java/play/libs/ws/WSCookie.java
@@ -47,6 +47,11 @@ public interface WSCookie {
      */
     boolean isSecure();
 
+    /**
+     * @return if the cookie is accessed only server side.
+     */
+    boolean httpOnly();
+
     // Cookie ports should not be used; cookies for a given host are shared across
     // all the ports on that host.
 }

--- a/play-ws-standalone/src/main/scala/play/api/libs/ws/StandaloneWSRequest.scala
+++ b/play-ws-standalone/src/main/scala/play/api/libs/ws/StandaloneWSRequest.scala
@@ -105,14 +105,14 @@ trait StandaloneWSRequest {
   def withAuth(username: String, password: String, scheme: WSAuthScheme): Self
 
   /**
-   * Returns this request with the given headers, discarding the existent ones.
+   * Returns this request with the given headers, discarding the existing ones.
    *
    * @param headers the headers to be used
    */
   def setHeaders(headers: (String, String)*): Self
 
   /**
-   * Returns this request with the given headers, preserving the existent ones.
+   * Returns this request with the given headers, preserving the existing ones.
    *
    * @param headers the headers to be used
    */
@@ -120,7 +120,7 @@ trait StandaloneWSRequest {
   def withHeaders(headers: (String, String)*): Self = addHeaders(headers: _*)
 
   /**
-   * Returns this request with the given headers, preserving the existent ones.
+   * Returns this request with the given headers, preserving the existing ones.
    *
    * @param hdrs the headers to be added
    */
@@ -132,14 +132,14 @@ trait StandaloneWSRequest {
   }
 
   /**
-   * Returns this request with the given query string parameters, discarding the existent ones.
+   * Returns this request with the given query string parameters, discarding the existing ones.
    *
    * @param parameters the query string parameters
    */
   def setQueryString(parameters: (String, String)*): Self
 
   /**
-   * Returns this request with the given query string parameters, preserving the existent ones.
+   * Returns this request with the given query string parameters, preserving the existing ones.
    *
    * @param parameters the query string parameters
    */
@@ -147,7 +147,7 @@ trait StandaloneWSRequest {
   def withQueryString(parameters: (String, String)*): Self = addQueryString(parameters: _*)
 
   /**
-   * Returns this request with the given query string parameters, preserving the existent ones.
+   * Returns this request with the given query string parameters, preserving the existing ones.
    *
    * @param parameters the query string parameters
    */
@@ -159,14 +159,14 @@ trait StandaloneWSRequest {
   }
 
   /**
-   * Returns this request with the given query string parameters, discarding the existent ones.
+   * Returns this request with the given query string parameters, discarding the existing ones.
    *
    * @param cookies the cookies to be used
    */
   def setCookies(cookies: WSCookie*): Self
 
   /**
-   * Returns this request with the given query string parameters, preserving the existent ones.
+   * Returns this request with the given query string parameters, preserving the existing ones.
    *
    * @param cookies the cookies to be used
    */

--- a/play-ws-standalone/src/main/scala/play/api/libs/ws/StandaloneWSRequest.scala
+++ b/play-ws-standalone/src/main/scala/play/api/libs/ws/StandaloneWSRequest.scala
@@ -108,8 +108,6 @@ trait StandaloneWSRequest {
    * Returns this request with the given headers, discarding the existent ones.
    *
    * @param headers the headers to be used
-   *
-   * @see [[addHeaders()]]
    */
   def setHeaders(headers: (String, String)*): Self
 
@@ -117,9 +115,6 @@ trait StandaloneWSRequest {
    * Returns this request with the given headers, preserving the existent ones.
    *
    * @param headers the headers to be used
-   *
-   * @see [[addHeaders()]]
-   * @see [[setHeaders()]]
    */
   @deprecated("Use setHeaders or addHeaders", "1.0.0")
   def withHeaders(headers: (String, String)*): Self = addHeaders(headers: _*)
@@ -128,8 +123,6 @@ trait StandaloneWSRequest {
    * Returns this request with the given headers, preserving the existent ones.
    *
    * @param hdrs the headers to be added
-   *
-   * @see [[setHeaders()]]
    */
   def addHeaders(hdrs: (String, String)*): Self = {
     val newHeaders = headers.toList.flatMap { param =>
@@ -142,7 +135,6 @@ trait StandaloneWSRequest {
    * Returns this request with the given query string parameters, discarding the existent ones.
    *
    * @param parameters the query string parameters
-   * @see [[addQueryString()]]
    */
   def setQueryString(parameters: (String, String)*): Self
 
@@ -150,9 +142,6 @@ trait StandaloneWSRequest {
    * Returns this request with the given query string parameters, preserving the existent ones.
    *
    * @param parameters the query string parameters
-   *
-   * @see [[addQueryString()]]
-   * @see [[setQueryString()]]
    */
   @deprecated("Use setQueryString or addQueryString", "1.0.0")
   def withQueryString(parameters: (String, String)*): Self = addQueryString(parameters: _*)
@@ -161,8 +150,6 @@ trait StandaloneWSRequest {
    * Returns this request with the given query string parameters, preserving the existent ones.
    *
    * @param parameters the query string parameters
-   *
-   * @see [[withQueryString()]]
    */
   def addQueryString(parameters: (String, String)*): Self = {
     val newQueryStringParams = queryString.toList.flatMap { param =>

--- a/play-ws-standalone/src/main/scala/play/api/libs/ws/StandaloneWSRequest.scala
+++ b/play-ws-standalone/src/main/scala/play/api/libs/ws/StandaloneWSRequest.scala
@@ -109,26 +109,26 @@ trait StandaloneWSRequest {
    *
    * @param headers the headers to be used
    */
-  def setHeaders(headers: (String, String)*): Self
+  def withHttpHeaders(headers: (String, String)*): Self
 
   /**
    * Returns this request with the given headers, preserving the existing ones.
    *
    * @param headers the headers to be used
    */
-  @deprecated("Use setHeaders or addHeaders", "1.0.0")
-  def withHeaders(headers: (String, String)*): Self = addHeaders(headers: _*)
+  @deprecated("Use withHttpHeaders or addHttpHeaders", "1.0.0")
+  def withHeaders(headers: (String, String)*): Self = addHttpHeaders(headers: _*)
 
   /**
    * Returns this request with the given headers, preserving the existing ones.
    *
    * @param hdrs the headers to be added
    */
-  def addHeaders(hdrs: (String, String)*): Self = {
+  def addHttpHeaders(hdrs: (String, String)*): Self = {
     val newHeaders = headers.toList.flatMap { param =>
       param._2.map(p => param._1 -> p)
     } ++ hdrs
-    setHeaders(newHeaders: _*)
+    withHttpHeaders(newHeaders: _*)
   }
 
   /**
@@ -136,26 +136,26 @@ trait StandaloneWSRequest {
    *
    * @param parameters the query string parameters
    */
-  def setQueryString(parameters: (String, String)*): Self
+  def withQueryStringParameters(parameters: (String, String)*): Self
 
   /**
    * Returns this request with the given query string parameters, preserving the existing ones.
    *
    * @param parameters the query string parameters
    */
-  @deprecated("Use setQueryString or addQueryString", "1.0.0")
-  def withQueryString(parameters: (String, String)*): Self = addQueryString(parameters: _*)
+  @deprecated("Use withQueryStringParameters or addQueryStringParameter", "1.0.0")
+  def withQueryString(parameters: (String, String)*): Self = addQueryStringParameter(parameters: _*)
 
   /**
    * Returns this request with the given query string parameters, preserving the existing ones.
    *
    * @param parameters the query string parameters
    */
-  def addQueryString(parameters: (String, String)*): Self = {
+  def addQueryStringParameter(parameters: (String, String)*): Self = {
     val newQueryStringParams = queryString.toList.flatMap { param =>
       param._2.map(p => param._1 -> p)
     } ++ parameters
-    setQueryString(newQueryStringParams: _*)
+    withQueryStringParameters(newQueryStringParams: _*)
   }
 
   /**
@@ -163,7 +163,7 @@ trait StandaloneWSRequest {
    *
    * @param cookies the cookies to be used
    */
-  def setCookies(cookies: WSCookie*): Self
+  def withCookies(cookies: WSCookie*): Self
 
   /**
    * Returns this request with the given query string parameters, preserving the existing ones.
@@ -171,7 +171,7 @@ trait StandaloneWSRequest {
    * @param cookies the cookies to be used
    */
   def addCookies(cookies: WSCookie*): Self = {
-    setCookies(this.cookies ++ cookies: _*)
+    withCookies(this.cookies ++ cookies: _*)
   }
 
   /**

--- a/play-ws-standalone/src/main/scala/play/api/libs/ws/WS.scala
+++ b/play-ws-standalone/src/main/scala/play/api/libs/ws/WS.scala
@@ -97,6 +97,11 @@ trait WSCookie {
    * If the cookie is secure.
    */
   def secure: Boolean
+
+  /**
+   * If the cookie is HTTPOnly.
+   */
+  def httpOnly: Boolean
 }
 
 /**


### PR DESCRIPTION
## Fixes

Fixes #83 and #97.

## Purpose

This adds the ability to manipulate cookies and other request attributes using a more uniform and consistent API.

1. `with*` methods were deprecated since they don't have a clear semantic when also compared with other Play APIs. The current behavior was kept.
2. `add*` methods were added and are supposed to append values to attributes, preserving existent values
3. `set*` methods were added and are supposed to completely replace the existent values, discarding them.

More tests were added (or just rearranged) to better ensure the behavior described above.

## Background Context

See discussion here: https://github.com/playframework/playframework/issues/7016