### PR TITLE
Remove source methods as conflict with Multipart

### DIFF
--- a/play-ahc-ws-standalone/src/main/scala/play/api/libs/ws/ahc/StandaloneAhcWSClient.scala
+++ b/play-ahc-ws-standalone/src/main/scala/play/api/libs/ws/ahc/StandaloneAhcWSClient.scala
@@ -25,7 +25,7 @@ import scala.util.{ Failure, Success, Try }
  * @param asyncHttpClient An already configured asynchttpclient.
  *                        Note that the WSClient assumes ownership of the lifecycle here, so closing the WSClient will
  *                        also close asyncHttpClient.
- * @param materializer An execution context, used to execute the stream.
+ * @param materializer A materializer, meant to execute the stream
  */
 class StandaloneAhcWSClient @Inject() (asyncHttpClient: AsyncHttpClient)(implicit materializer: Materializer) extends StandaloneWSClient {
 

--- a/play-ws-standalone/src/main/java/play/libs/ws/StandaloneWSRequest.java
+++ b/play-ws-standalone/src/main/java/play/libs/ws/StandaloneWSRequest.java
@@ -83,16 +83,6 @@ public interface StandaloneWSRequest {
         return setMethod("PATCH").setBody(body).execute();
     }
 
-    /**
-     * Perform a PATCH on the request asynchronously.
-     *
-     * @param body the body of request
-     * @return a promise to the response
-     */
-    default <U> CompletionStage<? extends StandaloneWSResponse> patch(Source<ByteString, U> body) {
-        return setMethod("PATCH").setBody(body).execute();
-    }
-
     //-------------------------------------------------------------------------
     // "POST"
     //-------------------------------------------------------------------------
@@ -140,16 +130,6 @@ public interface StandaloneWSRequest {
         return setMethod("POST").setBody(body).execute();
     }
 
-    /**
-     * Perform a POST on the request asynchronously.
-     *
-     * @param body the body of request
-     * @return a promise to the response
-     */
-    default <U> CompletionStage<? extends StandaloneWSResponse> post(Source<ByteString, U> body) {
-        return setMethod("POST").setBody(body).execute();
-    }
-
     //-------------------------------------------------------------------------
     // "PUT"
     //-------------------------------------------------------------------------
@@ -194,16 +174,6 @@ public interface StandaloneWSRequest {
      * @return a promise to the response
      */
     default CompletionStage<? extends StandaloneWSResponse> put(File body) {
-        return setMethod("PUT").setBody(body).execute();
-    }
-
-    /**
-     * Perform a PUT on the request asynchronously.
-     *
-     * @param body the body of request
-     * @return a promise to the response
-     */
-    default <U> CompletionStage<? extends StandaloneWSResponse> put(Source<ByteString, U> body) {
         return setMethod("PUT").setBody(body).execute();
     }
 


### PR DESCRIPTION
If we use a Source<ByteString> then we can get a conflict on Source<Multipart> in Play WS.

The correct thing to do is to make there be only one body that takes a type parameter, but this 
will work for now.