### PR TITLE
Fix sonatype release by adding sonatypeProfileName

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -352,6 +352,9 @@ lazy val root = project
 //---------------------------------------------------------------
 import sbtrelease.ReleasePlugin.autoImport.ReleaseTransformations._
 
+// otherwise same as orgname, and "sonatypeList" says "No staging profile is found for com.typesafe.play"
+sonatypeProfileName := "com.typesafe"
+
 releaseProcess := Seq[ReleaseStep](
   checkSnapshotDependencies,
   inquireVersions,


### PR DESCRIPTION
Fixed play-ws to find the sonatype staging repository (which is "com.typesafe", not "com.typesafe.play").  It is overridden with `sonatypeProfileName`.  

After merging this, we should be able to use "sbt release" by itself to do releases without having to go to oss.sonatype.org/#stagingRepositories and stage the repositories oureslves.

Also see https://github.com/xerial/sbt-sonatype/issues/35 and https://github.com/playframework/play-plugins/blob/master/redis/build.sbt#L41