### PR TITLE
Add methods to get header values

### DIFF
--- a/play-ahc-ws-standalone/src/main/java/play/libs/ws/ahc/StandaloneAhcWSResponse.java
+++ b/play-ahc-ws-standalone/src/main/java/play/libs/ws/ahc/StandaloneAhcWSResponse.java
@@ -67,7 +67,7 @@ public class StandaloneAhcWSResponse implements StandaloneWSResponse {
      * Get all the HTTP headers of the response as a case-insensitive map
      */
     @Override
-    public Map<String, List<String>> getAllHeaders() {
+    public Map<String, List<String>> getHeaders() {
         final Map<String, List<String>> headerMap = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
         final HttpHeaders headers = ahcResponse.getHeaders();
         for (String name : headers.names()) {
@@ -75,14 +75,6 @@ public class StandaloneAhcWSResponse implements StandaloneWSResponse {
             headerMap.put(name, values);
         }
         return headerMap;
-    }
-
-    /**
-     * Get the given HTTP header of the response
-     */
-    @Override
-    public String getHeader(String key) {
-        return ahcResponse.getHeader(key);
     }
 
     /**

--- a/play-ahc-ws-standalone/src/main/scala/play/api/libs/ws/ahc/StandaloneAhcWSResponse.scala
+++ b/play-ahc-ws-standalone/src/main/scala/play/api/libs/ws/ahc/StandaloneAhcWSResponse.scala
@@ -24,7 +24,7 @@ class StandaloneAhcWSResponse(ahcResponse: AHCResponse) extends StandaloneWSResp
   /**
    * Return the headers of the response as a case-insensitive map
    */
-  lazy val allHeaders: Map[String, Seq[String]] = {
+  lazy val headers: Map[String, Seq[String]] = {
     val headers: HttpHeaders = ahcResponse.getHeaders
     headersToMap(headers)
   }
@@ -43,11 +43,6 @@ class StandaloneAhcWSResponse(ahcResponse: AHCResponse) extends StandaloneWSResp
    * The response status message.
    */
   def statusText: String = ahcResponse.getStatusText
-
-  /**
-   * Get a response header.
-   */
-  def header(key: String): Option[String] = Option(ahcResponse.getHeader(key))
 
   /**
    * Get all the cookies.

--- a/play-ahc-ws-standalone/src/test/scala/play/api/libs/ws/ahc/AhcWSRequestSpec.scala
+++ b/play-ahc-ws-standalone/src/test/scala/play/api/libs/ws/ahc/AhcWSRequestSpec.scala
@@ -253,10 +253,60 @@ class AhcWSRequestSpec extends Specification with Mockito with AfterAll {
         val req: AHCRequest = client
           .url("http://playframework.com/")
           .withHttpHeaders("key" -> "value1", "KEY" -> "value2")
-
           .asInstanceOf[StandaloneAhcWSRequest]
           .buildRequest()
         req.getHeaders.getAll("key").asScala must containTheSameElementsAs(Seq("value1", "value2"))
+      }
+    }
+
+    "get a single header" in {
+      withClient { client =>
+        val req = client
+          .url("http://playframework.com/")
+          .withHttpHeaders("Key1" -> "value1", "Key2" -> "value2")
+
+        req.header("Key1") must beSome("value1")
+      }
+    }
+
+    "get all values for a header" in {
+      withClient { client =>
+        val req = client
+          .url("http://playframework.com/")
+          .withHttpHeaders("Key1" -> "value1", "Key1" -> "value2", "Key2" -> "some")
+
+        req.headerValues("Key1") must containTheSameElementsAs(Seq("value1", "value2"))
+      }
+    }
+
+    "get none when header is not present" in {
+      withClient { client =>
+        val req = client
+          .url("http://playframework.com/")
+          .withHttpHeaders("Key1" -> "value1", "Key1" -> "value2", "Key2" -> "some")
+
+        req.header("Non") must beNone
+      }
+    }
+
+    "get an empty seq when header has no values" in {
+      withClient { client =>
+        val req = client
+          .url("http://playframework.com/")
+          .withHttpHeaders("Key1" -> "value1", "Key1" -> "value2", "Key2" -> "some")
+
+        req.headerValues("Non") must beEmpty
+      }
+    }
+
+    "get all the header" in {
+      withClient { client =>
+        val req = client
+          .url("http://playframework.com/")
+          .withHttpHeaders("Key1" -> "value1", "Key1" -> "value2", "Key2" -> "value")
+
+        req.headers("Key1") must containTheSameElementsAs(Seq("value1", "value2"))
+        req.headers("Key2") must containTheSameElementsAs(Seq("value"))
       }
     }
   }

--- a/play-ahc-ws-standalone/src/test/scala/play/api/libs/ws/ahc/AhcWSResponseSpec.scala
+++ b/play-ahc-ws-standalone/src/test/scala/play/api/libs/ws/ahc/AhcWSResponseSpec.scala
@@ -93,12 +93,49 @@ class AhcWSResponseSpec extends Specification with Mockito {
       ahcHeaders.add("Bar", "baz")
       ahcResponse.getHeaders returns ahcHeaders
       val response = StandaloneAhcWSResponse(ahcResponse)
-      val headers = response.allHeaders
+      val headers = response.headers
       headers must beEqualTo(Map("Foo" -> Seq("bar", "baz"), "Bar" -> Seq("baz")))
       headers.contains("foo") must beTrue
       headers.contains("Foo") must beTrue
       headers.contains("BAR") must beTrue
       headers.contains("Bar") must beTrue
+    }
+
+    "get a single header" in {
+      val ahcResponse: AHCResponse = mock[AHCResponse]
+      val ahcHeaders = new DefaultHttpHeaders(true)
+      ahcHeaders.add("Foo", "bar")
+      ahcHeaders.add("Foo", "baz")
+      ahcHeaders.add("Bar", "baz")
+      ahcResponse.getHeaders returns ahcHeaders
+      val response = StandaloneAhcWSResponse(ahcResponse)
+
+      response.header("Foo") must beSome("bar")
+      response.header("Bar") must beSome("baz")
+    }
+
+    "get none when header does not exists" in {
+      val ahcResponse: AHCResponse = mock[AHCResponse]
+      val ahcHeaders = new DefaultHttpHeaders(true)
+      ahcHeaders.add("Foo", "bar")
+      ahcHeaders.add("Foo", "baz")
+      ahcHeaders.add("Bar", "baz")
+      ahcResponse.getHeaders returns ahcHeaders
+      val response = StandaloneAhcWSResponse(ahcResponse)
+
+      response.header("Non") must beNone
+    }
+
+    "get all values for a header" in {
+      val ahcResponse: AHCResponse = mock[AHCResponse]
+      val ahcHeaders = new DefaultHttpHeaders(true)
+      ahcHeaders.add("Foo", "bar")
+      ahcHeaders.add("Foo", "baz")
+      ahcHeaders.add("Bar", "baz")
+      ahcResponse.getHeaders returns ahcHeaders
+      val response = StandaloneAhcWSResponse(ahcResponse)
+
+      response.headerValues("Foo") must beEqualTo(Seq("bar", "baz"))
     }
   }
 

--- a/play-ahc-ws-standalone/src/test/scala/play/libs/ws/ahc/AhcWSRequestSpec.scala
+++ b/play-ahc-ws-standalone/src/test/scala/play/libs/ws/ahc/AhcWSRequestSpec.scala
@@ -11,6 +11,7 @@ import play.libs.oauth.OAuth
 import play.shaded.ahc.io.netty.handler.codec.http.HttpHeaders
 
 import scala.collection.JavaConverters._
+import scala.compat.java8.OptionConverters._
 
 class AhcWSRequestSpec extends Specification with Mockito {
 
@@ -220,6 +221,54 @@ class AhcWSRequestSpec extends Specification with Mockito {
 
         request.getHeaders.getAll("header1").asScala must contain("value1")
         request.getHeaders.getAll("header1").asScala must contain("value2")
+      }
+
+      "get a single header" in {
+        val client = mock[StandaloneAhcWSClient]
+        val request = new StandaloneAhcWSRequest(client, "http://example.com", /*materializer*/ null)
+          .addHeader("header1", "value1")
+          .addHeader("header1", "value2")
+
+        request.getHeader("header1").asScala must beSome("value1")
+      }
+
+      "get an empty optional when header is not present" in {
+        val client = mock[StandaloneAhcWSClient]
+        val request = new StandaloneAhcWSRequest(client, "http://example.com", /*materializer*/ null)
+          .addHeader("header1", "value1")
+          .addHeader("header1", "value2")
+
+        request.getHeader("non").asScala must beNone
+      }
+
+      "get all values for a header" in {
+        val client = mock[StandaloneAhcWSClient]
+        val request = new StandaloneAhcWSRequest(client, "http://example.com", /*materializer*/ null)
+          .addHeader("header1", "value1")
+          .addHeader("header1", "value2")
+
+        request.getHeaderValues("header1").asScala must containTheSameElementsAs(Seq("value1", "value2"))
+      }
+
+      "get an empty list when header is not present" in {
+        val client = mock[StandaloneAhcWSClient]
+        val request = new StandaloneAhcWSRequest(client, "http://example.com", /*materializer*/ null)
+          .addHeader("header1", "value1")
+          .addHeader("header1", "value2")
+
+        request.getHeaderValues("Non").asScala must beEmpty
+      }
+
+      "get all headers" in {
+        val client = mock[StandaloneAhcWSClient]
+        val request = new StandaloneAhcWSRequest(client, "http://example.com", /*materializer*/ null)
+          .addHeader("header1", "Value1ForHeader1")
+          .addHeader("header1", "Value2ForHeader1")
+          .addHeader("header2", "Value1ForHeader2")
+
+        val headers = request.getHeaders.asScala
+        headers("header1").asScala must containTheSameElementsAs(Seq("Value1ForHeader1", "Value2ForHeader1"))
+        headers("header2").asScala must containTheSameElementsAs(Seq("Value1ForHeader2"))
       }
 
     }

--- a/play-ws-standalone/src/main/java/play/libs/ws/StandaloneWSRequest.java
+++ b/play-ws-standalone/src/main/java/play/libs/ws/StandaloneWSRequest.java
@@ -10,8 +10,10 @@ import com.fasterxml.jackson.databind.JsonNode;
 
 import java.io.File;
 import java.io.InputStream;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.CompletionStage;
 
 /**
@@ -482,6 +484,29 @@ public interface StandaloneWSRequest {
      * @return the headers (a copy to prevent side-effects). This has not passed through an internal request builder and so will not be signed.
      */
     Map<String, List<String>> getHeaders();
+
+    /**
+     * Get all the values of header with the specified name. If there are no values for
+     * the header with the specified name, than an empty List is returned.
+     *
+     * @param name the header name.
+     * @return all the values for this header name.
+     */
+    default List<String> getHeaderValues(String name) {
+        return getHeaders().getOrDefault(name, Collections.emptyList());
+    }
+
+    /**
+     * Get the value of the header with the specified name. If there are more than one values
+     * for this header, the first value is returned. If there are no values, than an empty
+     * Optional is returned.
+     *
+     * @param name the header name
+     * @return the header value
+     */
+    default Optional<String> getHeader(String name) {
+        return getHeaderValues(name).stream().findFirst();
+    }
 
     /**
      * @return the query parameters (a copy to prevent side-effects). This has not passed through an internal request builder and so will not be signed.

--- a/play-ws-standalone/src/main/java/play/libs/ws/StandaloneWSResponse.java
+++ b/play-ws-standalone/src/main/java/play/libs/ws/StandaloneWSResponse.java
@@ -9,8 +9,10 @@ import play.libs.ws.WSCookie;
 
 import java.io.InputStream;
 import java.net.URI;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 /**
  * This is the WS response from the server.
@@ -19,14 +21,52 @@ public interface StandaloneWSResponse {
 
     /**
      * @return all the headers from the response.
+     *
+     * @deprecated Since 1.0.0. Use {@link #getHeaders()} instead.
      */
-    Map<String, List<String>> getAllHeaders();
+    @Deprecated
+    default Map<String, List<String>> getAllHeaders() {
+        return getHeaders();
+    }
 
     /**
      * @param key the header's name
      * @return a single header value from the response.
+     *
+     * @deprecated Since 1.0.0. Use {@link #getSingleHeader(String)} instead.
      */
-    String getHeader(String key);
+    @Deprecated
+    default String getHeader(String key) {
+        return getSingleHeader(key).orElse(null);
+    }
+
+    /**
+     * @return all the headers from the response.
+     */
+    Map<String, List<String>> getHeaders();
+
+    /**
+     * Get all the values of header with the specified name. If there are no values for
+     * the header with the specified name, than an empty List is returned.
+     *
+     * @param name the header name.
+     * @return all the values for this header name.
+     */
+    default List<String> getHeaderValues(String name) {
+        return getHeaders().getOrDefault(name, Collections.emptyList());
+    }
+
+    /**
+     * Get the value of the header with the specified name. If there are more than one values
+     * for this header, the first value is returned. If there are no values, than an empty
+     * Optional is returned.
+     *
+     * @param name the header name
+     * @return the header value
+     */
+    default Optional<String> getSingleHeader(String name) {
+        return getHeaderValues(name).stream().findFirst();
+    }
 
     /**
      * @return the underlying implementation response object, if any.

--- a/play-ws-standalone/src/main/scala/play/api/libs/ws/StandaloneWSRequest.scala
+++ b/play-ws-standalone/src/main/scala/play/api/libs/ws/StandaloneWSRequest.scala
@@ -54,6 +54,25 @@ trait StandaloneWSRequest {
   def headers: Map[String, Seq[String]]
 
   /**
+   * Get the value of the header with the specified name. If there are more than one values
+   * for this header, the first value is returned. If there are no values, than a None is
+   * returned.
+   *
+   * @param name the header name
+   * @return the header value
+   */
+  def header(name: String): Option[String] = headerValues(name).headOption
+
+  /**
+   * Get all the values of header with the specified name. If there are no values for
+   * the header with the specified name, than an empty sequence is returned.
+   *
+   * @param name the header name.
+   * @return all the values for this header name.
+   */
+  def headerValues(name: String): Seq[String] = headers.getOrElse(name, Seq.empty)
+
+  /**
    * The query string for this request
    */
   def queryString: Map[String, Seq[String]]

--- a/play-ws-standalone/src/main/scala/play/api/libs/ws/StandaloneWSResponse.scala
+++ b/play-ws-standalone/src/main/scala/play/api/libs/ws/StandaloneWSResponse.scala
@@ -9,14 +9,39 @@ import play.api.libs.json.JsValue
 import scala.xml.Elem
 
 /**
- *
+ * A WS HTTP response.
  */
 trait StandaloneWSResponse {
 
   /**
    * Return the current headers of the request being constructed
    */
-  def allHeaders: Map[String, Seq[String]]
+  @deprecated("Use headers instead", "1.0.0")
+  def allHeaders: Map[String, Seq[String]] = headers
+
+  /**
+   * Return the current headers of the request being constructed
+   */
+  def headers: Map[String, Seq[String]]
+
+  /**
+   * Get the value of the header with the specified name. If there are more than one values
+   * for this header, the first value is returned. If there are no values, than a None is
+   * returned.
+   *
+   * @param name the header name
+   * @return the header value
+   */
+  def header(name: String): Option[String] = headerValues(name).headOption
+
+  /**
+   * Get all the values of header with the specified name. If there are no values for
+   * the header with the specified name, than an empty sequence is returned.
+   *
+   * @param name the header name.
+   * @return all the values for this header name.
+   */
+  def headerValues(name: String): Seq[String] = headers.getOrElse(name, Seq.empty)
 
   /**
    * Get the underlying response object.
@@ -32,11 +57,6 @@ trait StandaloneWSResponse {
    * The response status message.
    */
   def statusText: String
-
-  /**
-   * Get a response header.
-   */
-  def header(key: String): Option[String]
 
   /**
    * Get all the cookies.


### PR DESCRIPTION
## Fixes

Fixes #88 and #101.

## Purpose

Add methods to get header values, for both Scala and Java APIs.