### PR TITLE
Use a java.time.Duration to configure request timeout

### DIFF
--- a/play-ahc-ws-standalone/src/main/java/play/libs/ws/ahc/StandaloneAhcWSRequest.java
+++ b/play-ahc-ws-standalone/src/main/java/play/libs/ws/ahc/StandaloneAhcWSRequest.java
@@ -32,6 +32,8 @@ import java.net.URI;
 import java.nio.ByteBuffer;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.time.temporal.ChronoUnit;
 import java.util.*;
 import java.util.concurrent.CompletionStage;
 
@@ -58,7 +60,7 @@ public class StandaloneAhcWSRequest implements StandaloneWSRequest {
     private final Materializer materializer;
     private final ObjectMapper objectMapper;
 
-    private int timeout = 0;
+    private Duration timeout = Duration.ZERO;
     private boolean followRedirects;
     private String virtualHost = null;
 
@@ -221,7 +223,16 @@ public class StandaloneAhcWSRequest implements StandaloneWSRequest {
         if (timeout < -1 || timeout > Integer.MAX_VALUE) {
             throw new IllegalArgumentException("Timeout must be between -1 and " + Integer.MAX_VALUE + " inclusive");
         }
-        this.timeout = (int) timeout;
+        this.timeout = Duration.of(timeout, ChronoUnit.MILLIS);
+        return this;
+    }
+
+    @Override
+    public StandaloneAhcWSRequest setRequestTimeout(Duration timeout) {
+        if (timeout == null) {
+            throw new IllegalArgumentException("Timeout must not be null.");
+        }
+        this.timeout = timeout;
         return this;
     }
 
@@ -331,7 +342,7 @@ public class StandaloneAhcWSRequest implements StandaloneWSRequest {
     }
 
     @Override
-    public long getRequestTimeout() {
+    public Duration getRequestTimeoutDuration() {
         return this.timeout;
     }
 
@@ -455,8 +466,8 @@ public class StandaloneAhcWSRequest implements StandaloneWSRequest {
 
         builder.setHeaders(possiblyModifiedHeaders);
 
-        if (this.timeout == -1 || this.timeout > 0) {
-            builder.setRequestTimeout(this.timeout);
+        if (this.timeout.isNegative() || this.timeout.compareTo(Duration.ZERO) > 0) {
+            builder.setRequestTimeout(((int) this.timeout.toMillis()));
         }
 
         builder.setFollowRedirect(this.followRedirects);

--- a/play-ahc-ws-standalone/src/main/java/play/libs/ws/ahc/StandaloneAhcWSRequest.java
+++ b/play-ahc-ws-standalone/src/main/java/play/libs/ws/ahc/StandaloneAhcWSRequest.java
@@ -42,6 +42,8 @@ import java.util.concurrent.CompletionStage;
  */
 public class StandaloneAhcWSRequest implements StandaloneWSRequest {
 
+    private static final Duration INFINITE = Duration.ofMillis(-1);
+
     private Object body = null;
 
     private final String url;
@@ -466,7 +468,9 @@ public class StandaloneAhcWSRequest implements StandaloneWSRequest {
 
         builder.setHeaders(possiblyModifiedHeaders);
 
-        if (this.timeout.isNegative() || this.timeout.compareTo(Duration.ZERO) > 0) {
+        if (this.timeout.isNegative()) {
+            builder.setRequestTimeout(((int) INFINITE.toMillis()));
+        } else if (this.timeout.compareTo(Duration.ZERO) > 0) {
             builder.setRequestTimeout(((int) this.timeout.toMillis()));
         }
 

--- a/play-ahc-ws-standalone/src/test/scala/play/libs/ws/ahc/AhcWSRequestSpec.scala
+++ b/play-ahc-ws-standalone/src/test/scala/play/libs/ws/ahc/AhcWSRequestSpec.scala
@@ -108,7 +108,8 @@ class AhcWSRequestSpec extends Specification with Mockito {
       called must beTrue
     }
 
-    "Request timeout" should {
+    "setRequestTimeout(long)" should {
+
       "support setting a request timeout" in {
         requestWithTimeout(1000) must beEqualTo(1000)
       }
@@ -124,13 +125,23 @@ class AhcWSRequestSpec extends Specification with Mockito {
       "not support setting a request timeout > Integer.MAX_VALUE" in {
         requestWithTimeout(Int.MaxValue.toLong + 1) must throwA[IllegalArgumentException]
       }
+    }
+
+    "setRequestTimeout(java.time.Duration)" should {
 
       "support setting a request timeout to a duration" in {
         requestWithTimeout(Duration.ofSeconds(1)) must beEqualTo(1000)
       }
 
-      "support setting a request timeout duration to infinite" in {
+      "support setting a request timeout duration to infinite using -1" in {
         requestWithTimeout(Duration.ofMillis(-1)) must beEqualTo(-1)
+      }
+
+      "support setting a request timeout duration to infinite using any negative duration" in {
+        requestWithTimeout(Duration.ofMillis(-2)) must beEqualTo(-1)
+        requestWithTimeout(Duration.ofMillis(-15)) must beEqualTo(-1)
+        requestWithTimeout(Duration.ofSeconds(-1)) must beEqualTo(-1)
+        requestWithTimeout(Duration.ofMillis(java.lang.Integer.MIN_VALUE)) must beEqualTo(-1)
       }
 
       "support setting a request timeout duration to Long.MAX_VALUE as infinite" in {

--- a/play-ws-standalone/src/main/java/play/libs/ws/StandaloneWSRequest.java
+++ b/play-ws-standalone/src/main/java/play/libs/ws/StandaloneWSRequest.java
@@ -10,6 +10,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 
 import java.io.File;
 import java.io.InputStream;
+import java.time.Duration;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -451,8 +452,40 @@ public interface StandaloneWSRequest {
      *
      * @param timeout the request timeout in milliseconds. A value of -1 indicates an infinite request timeout.
      * @return the modified WSRequest.
+     *
+     * @deprecated Since 1.0.0. Use {@link #setRequestTimeout(Duration)} instead.
      */
+    @Deprecated
     StandaloneWSRequest setRequestTimeout(long timeout);
+
+    /**
+     * Sets the request timeout duration. Java {@link Duration} class does not have a specific instance
+     * to represent an infinite timeout, but according to the docs, in practice, you can somehow emulate
+     * it:
+     *
+     * <blockquote>
+     *     A physical duration could be of infinite length. For practicality, the duration is stored
+     *     with constraints similar to Instant. The duration uses nanosecond resolution with a maximum
+     *     value of the seconds that can be held in a long. This is greater than the current estimated
+     *     age of the universe.
+     * </blockquote>
+     *
+     * Play WS uses the convention of setting a duration of -1 seconds to have an infinite timeout. So you will have:
+     * <code>java.time.Duration timeout = Duration.ofSeconds(-1);</code>.
+     *
+     * In practice, you can also have an extreme long duration, like:
+     *
+     * <code>
+     *     java.time.Duration timeout = Duration.ofMillis(Long.MAX_VALUE);
+     * </code>
+     *
+     * And, as the {@link Duration} docs states, this will be good enough since this duration is greater than
+     * the current estimate age of the universe.
+     *
+     * @param timeout the request timeout in milliseconds. A duration of -1 indicates an infinite request timeout.
+     * @return the modified WSRequest.
+     */
+    StandaloneWSRequest setRequestTimeout(Duration timeout);
 
     /**
      * Adds a request filter.
@@ -538,8 +571,20 @@ public interface StandaloneWSRequest {
      * request as input.
      *
      * @return the timeout
+     *
+     * @deprecated Since 1.0.0. Use {@link #getRequestTimeoutDuration()} instead.
      */
-    long getRequestTimeout();
+    @Deprecated
+    default long getRequestTimeout() {
+        return getRequestTimeoutDuration().toMillis();
+    }
+
+    /**
+     * Gets the original request timeout duration, passed into the request as input.
+     *
+     * @return the timeout duration.
+     */
+    Duration getRequestTimeoutDuration();
 
     /**
      * @return true if the request is configure to follow redirect, false if it is configure not to, null if nothing is configured and the global client preference should be used instead.

--- a/play-ws-standalone/src/main/java/play/libs/ws/StandaloneWSRequest.java
+++ b/play-ws-standalone/src/main/java/play/libs/ws/StandaloneWSRequest.java
@@ -470,14 +470,14 @@ public interface StandaloneWSRequest {
      *     age of the universe.
      * </blockquote>
      *
-     * Play WS uses the convention of setting a duration of -1 seconds to have an infinite timeout. So you will have:
-     * <code>java.time.Duration timeout = Duration.ofSeconds(-1);</code>.
+     * Play WS uses the convention of setting a duration with negative value to have an infinite timeout.
+     * So you will have:
+     *
+     * <pre>java.time.Duration timeout = Duration.ofSeconds(-1);</pre>.
      *
      * In practice, you can also have an extreme long duration, like:
      *
-     * <code>
-     *     java.time.Duration timeout = Duration.ofMillis(Long.MAX_VALUE);
-     * </code>
+     * <pre>java.time.Duration timeout = Duration.ofMillis(Long.MAX_VALUE);</pre>
      *
      * And, as the {@link Duration} docs states, this will be good enough since this duration is greater than
      * the current estimate age of the universe.


### PR DESCRIPTION
## Fixes

Fixes #22.

## Purpose

Use `java.time.Duration` to set request timeout.