### PR TITLE
Remove deprecated methods

### DIFF
--- a/integration-tests/src/test/scala/play/api/libs/ws/ahc/AhcWSRequestFilterSpec.scala
+++ b/integration-tests/src/test/scala/play/api/libs/ws/ahc/AhcWSRequestFilterSpec.scala
@@ -54,13 +54,13 @@ class AhcWSRequestFilterSpec(implicit val executionEnv: ExecutionEnv) extends Sp
 
     class HeaderAppendingFilter(key: String, value: String) extends WSRequestFilter {
       override def apply(executor: WSRequestExecutor): WSRequestExecutor = {
-        WSRequestExecutor(r => executor(r.withHeaders((key, value))))
+        WSRequestExecutor(r => executor(r.withHttpHeaders((key, value))))
       }
     }
 
     "work with adhoc request filter" in {
       client.url(s"http://localhost:$testServerPort").withRequestFilter(WSRequestFilter { e =>
-        WSRequestExecutor(r => e.apply(r.withQueryString("key" -> "some string")))
+        WSRequestExecutor(r => e.apply(r.withQueryStringParameters("key" -> "some string")))
       }).get().map { response =>
         response.body must contain("some string")
       }.await(retries = 0, timeout = defaultTimeout)
@@ -94,7 +94,7 @@ class AhcWSRequestFilterSpec(implicit val executionEnv: ExecutionEnv) extends Sp
       client.url(s"http://localhost:$testServerPort")
         .withRequestFilter(new HeaderAppendingFilter(appendedHeader, appendedHeaderValue))
         .get().map { response ⇒
-          response.allHeaders("X-Request-Id").head must be_==("someid")
+          response.headerValues("X-Request-Id").head must be_==("someid")
         }
         .await(retries = 0, timeout = defaultTimeout)
     }

--- a/integration-tests/src/test/scala/play/libs/ws/ahc/AhcWSRequestFilterSpec.scala
+++ b/integration-tests/src/test/scala/play/libs/ws/ahc/AhcWSRequestFilterSpec.scala
@@ -90,7 +90,7 @@ class AhcWSRequestFilterSpec(implicit executionEnv: ExecutionEnv) extends Specif
         .get())
 
       responseFuture.map { response =>
-        response.getAllHeaders.get("X-Request-Id").get(0) must be_==("someid")
+        response.getHeaders.get("X-Request-Id").get(0) must be_==("someid")
       }.await(retries = 0, timeout = 5.seconds)
     }
   }

--- a/play-ahc-ws-standalone/src/main/java/play/libs/ws/ahc/StandaloneAhcWSRequest.java
+++ b/play-ahc-ws-standalone/src/main/java/play/libs/ws/ahc/StandaloneAhcWSRequest.java
@@ -224,15 +224,6 @@ public class StandaloneAhcWSRequest implements StandaloneWSRequest {
     }
 
     @Override
-    public StandaloneAhcWSRequest setRequestTimeout(long timeout) {
-        if (timeout < -1 || timeout > Integer.MAX_VALUE) {
-            throw new IllegalArgumentException("Timeout must be between -1 and " + Integer.MAX_VALUE + " inclusive");
-        }
-        this.timeout = Duration.of(timeout, ChronoUnit.MILLIS);
-        return this;
-    }
-
-    @Override
     public StandaloneAhcWSRequest setRequestTimeout(Duration timeout) {
         if (timeout == null) {
             throw new IllegalArgumentException("Timeout must not be null.");

--- a/play-ahc-ws-standalone/src/test/scala/play/api/libs/ws/ahc/AhcWSRequestSpec.scala
+++ b/play-ahc-ws-standalone/src/test/scala/play/api/libs/ws/ahc/AhcWSRequestSpec.scala
@@ -46,14 +46,14 @@ class AhcWSRequestSpec extends Specification with Mockito with AfterAll {
       val request = StandaloneAhcWSRequest(client, "http://example.com")
 
       request.uri.toString must equalTo("http://example.com")
-      request.withQueryString("bar" -> "baz").uri.toString must equalTo("http://example.com?bar=baz")
-      request.withQueryString("bar" -> "baz", "bar" -> "bah").uri.toString must equalTo("http://example.com?bar=bah&bar=baz")
+      request.withQueryStringParameters("bar" -> "baz").uri.toString must equalTo("http://example.com?bar=baz")
+      request.withQueryStringParameters("bar" -> "baz", "bar" -> "bah").uri.toString must equalTo("http://example.com?bar=bah&bar=baz")
     }
 
     "correctly URL-encode the query string part" in {
       val request = StandaloneAhcWSRequest(client, "http://example.com")
 
-      request.withQueryString("&" -> "=").uri.toString must equalTo("http://example.com?%26=%3D")
+      request.withQueryStringParameters("&" -> "=").uri.toString must equalTo("http://example.com?%26=%3D")
     }
 
     "set all query string parameters" in {
@@ -538,7 +538,7 @@ class AhcWSRequestSpec extends Specification with Mockito with AfterAll {
   "Verify Content-Type header is passed through correctly" in withClient { client =>
     import scala.collection.JavaConverters._
     val req: AHCRequest = client.url("http://playframework.com/")
-      .withHeaders(HttpHeaders.Names.CONTENT_TYPE -> "text/plain; charset=US-ASCII")
+      .withHttpHeaders(HttpHeaders.Names.CONTENT_TYPE -> "text/plain; charset=US-ASCII")
       .withBody("HELLO WORLD")
       .asInstanceOf[StandaloneAhcWSRequest]
       .buildRequest()

--- a/play-ahc-ws-standalone/src/test/scala/play/libs/ws/ahc/AhcWSRequestSpec.scala
+++ b/play-ahc-ws-standalone/src/test/scala/play/libs/ws/ahc/AhcWSRequestSpec.scala
@@ -108,25 +108,6 @@ class AhcWSRequestSpec extends Specification with Mockito {
       called must beTrue
     }
 
-    "setRequestTimeout(long)" should {
-
-      "support setting a request timeout" in {
-        requestWithTimeout(1000) must beEqualTo(1000)
-      }
-
-      "support setting an infinite request timeout" in {
-        requestWithTimeout(-1) must beEqualTo(-1)
-      }
-
-      "not support setting a request timeout < -1" in {
-        requestWithTimeout(-2) must throwA[IllegalArgumentException]
-      }
-
-      "not support setting a request timeout > Integer.MAX_VALUE" in {
-        requestWithTimeout(Int.MaxValue.toLong + 1) must throwA[IllegalArgumentException]
-      }
-    }
-
     "setRequestTimeout(java.time.Duration)" should {
 
       "support setting a request timeout to a duration" in {
@@ -157,8 +138,8 @@ class AhcWSRequestSpec extends Specification with Mockito {
       val client = mock[StandaloneAhcWSClient]
       val request = new StandaloneAhcWSRequest(client, "http://example.com", /*materializer*/ null)
       request.setBody(client.body("HELLO WORLD"))
-      request.setHeader("Content-Type", "application/json")
-      request.setHeader("Content-Type", "application/xml")
+      request.addHeader("Content-Type", "application/json")
+      request.addHeader("Content-Type", "application/xml")
       val req = request.buildRequest()
       req.getHeaders.get("Content-Type") must be_==("application/json")
     }
@@ -167,8 +148,8 @@ class AhcWSRequestSpec extends Specification with Mockito {
       val client = mock[StandaloneAhcWSClient]
       val request = new StandaloneAhcWSRequest(client, "http://example.com", /*materializer*/ null)
       request.setBody(client.body("HELLO WORLD"))
-      request.setHeader("Content-Type", "application/json; charset=US-ASCII")
-      request.setHeader("Content-Type", "application/xml")
+      request.addHeader("Content-Type", "application/json; charset=US-ASCII")
+      request.addHeader("Content-Type", "application/xml")
       val req = request.buildRequest()
       req.getHeaders.get("Content-Type") must be_==("application/json; charset=US-ASCII")
     }
@@ -448,13 +429,6 @@ class AhcWSRequestSpec extends Specification with Mockito {
   }
 
   def requestWithTimeout(timeout: Duration) = {
-    val client = mock[StandaloneAhcWSClient]
-    val request = new StandaloneAhcWSRequest(client, "http://example.com", /*materializer*/ null)
-    request.setRequestTimeout(timeout)
-    request.buildRequest().getRequestTimeout()
-  }
-
-  def requestWithTimeout(timeout: Long) = {
     val client = mock[StandaloneAhcWSClient]
     val request = new StandaloneAhcWSRequest(client, "http://example.com", /*materializer*/ null)
     request.setRequestTimeout(timeout)

--- a/play-ahc-ws-standalone/src/test/scala/play/libs/ws/ahc/AhcWSResponseSpec.scala
+++ b/play-ahc-ws-standalone/src/test/scala/play/libs/ws/ahc/AhcWSResponseSpec.scala
@@ -38,7 +38,7 @@ class AhcWSResponseSpec extends Specification with Mockito {
         .add("Bar", "baz")
       srcResponse.getHeaders returns srcHeaders
       val response = new StandaloneAhcWSResponse(srcResponse)
-      val headers = response.getAllHeaders
+      val headers = response.getHeaders
       headers.get("foo").asScala must_== Seq("a", "b", "b")
       headers.get("BAR").asScala must_== Seq("baz")
     }

--- a/play-ws-standalone/src/main/java/play/libs/ws/StandaloneWSRequest.java
+++ b/play-ws-standalone/src/main/java/play/libs/ws/StandaloneWSRequest.java
@@ -151,22 +151,6 @@ public interface StandaloneWSRequest {
     StandaloneWSRequest setBody(WSBody body);
 
     /**
-     * Adds a header to the request.  Note that duplicate headers are allowed
-     * by the HTTP specification, and removing a header is not available
-     * through this API.
-     *
-     * @param name  the header name
-     * @param value the header value
-     * @return the modified WSRequest.
-     *
-     * @deprecated Since 1.0.0. Use {@link #addHeader(String, String)} or {@link #setHeaders(Map)}.
-     */
-    @Deprecated
-    default StandaloneWSRequest setHeader(String name, String value) {
-        return addHeader(name, value);
-    }
-
-    /**
      * Set headers to the request.  Note that duplicate headers are allowed
      * by the HTTP specification, and removing a header is not available
      * through this API. Any existing header will be discarded here.
@@ -194,20 +178,6 @@ public interface StandaloneWSRequest {
      * @return the modified WSRequest.
      */
     StandaloneWSRequest setQueryString(String query);
-
-    /**
-     * Sets a query parameter with the given name, this can be called repeatedly.  Duplicate query parameters are allowed.
-     *
-     * @param name  the query parameter name
-     * @param value the query parameter value
-     * @return the modified WSRequest.
-     *
-     * @deprecated Since 1.0.0. Use {@link #addQueryParameter(String, String)}, {@link #setQueryString(String)} or {@link #setQueryString(Map)} instead.
-     */
-    @Deprecated
-    default StandaloneWSRequest setQueryParameter(String name, String value) {
-        return addQueryParameter(name, value);
-    }
 
     /**
      * Adds a query parameter with the given name, this can be called repeatedly and will preserve existing values.
@@ -307,17 +277,6 @@ public interface StandaloneWSRequest {
      * @return the modified WSRequest
      */
     StandaloneWSRequest setVirtualHost(String virtualHost);
-
-    /**
-     * Sets the request timeout in milliseconds.
-     *
-     * @param timeout the request timeout in milliseconds. A value of -1 indicates an infinite request timeout.
-     * @return the modified WSRequest.
-     *
-     * @deprecated Since 1.0.0. Use {@link #setRequestTimeout(Duration)} instead.
-     */
-    @Deprecated
-    StandaloneWSRequest setRequestTimeout(long timeout);
 
     /**
      * Sets the request timeout duration. Java {@link Duration} class does not have a specific instance
@@ -426,19 +385,6 @@ public interface StandaloneWSRequest {
      * @return the signature calculator (example: OAuth), null if none is set.
      */
     WSSignatureCalculator getCalculator();
-
-    /**
-     * Gets the original request timeout in milliseconds, passed into the
-     * request as input.
-     *
-     * @return the timeout
-     *
-     * @deprecated Since 1.0.0. Use {@link #getRequestTimeoutDuration()} instead.
-     */
-    @Deprecated
-    default long getRequestTimeout() {
-        return getRequestTimeoutDuration().toMillis();
-    }
 
     /**
      * Gets the original request timeout duration, passed into the request as input.

--- a/play-ws-standalone/src/main/java/play/libs/ws/StandaloneWSResponse.java
+++ b/play-ws-standalone/src/main/java/play/libs/ws/StandaloneWSResponse.java
@@ -21,27 +21,6 @@ public interface StandaloneWSResponse {
 
     /**
      * @return all the headers from the response.
-     *
-     * @deprecated Since 1.0.0. Use {@link #getHeaders()} instead.
-     */
-    @Deprecated
-    default Map<String, List<String>> getAllHeaders() {
-        return getHeaders();
-    }
-
-    /**
-     * @param key the header's name
-     * @return a single header value from the response.
-     *
-     * @deprecated Since 1.0.0. Use {@link #getSingleHeader(String)} instead.
-     */
-    @Deprecated
-    default String getHeader(String key) {
-        return getSingleHeader(key).orElse(null);
-    }
-
-    /**
-     * @return all the headers from the response.
      */
     Map<String, List<String>> getHeaders();
 

--- a/play-ws-standalone/src/main/scala/play/api/libs/ws/StandaloneWSRequest.scala
+++ b/play-ws-standalone/src/main/scala/play/api/libs/ws/StandaloneWSRequest.scala
@@ -132,14 +132,6 @@ trait StandaloneWSRequest {
   /**
    * Returns this request with the given headers, preserving the existing ones.
    *
-   * @param headers the headers to be used
-   */
-  @deprecated("Use withHttpHeaders or addHttpHeaders", "1.0.0")
-  def withHeaders(headers: (String, String)*): Self = addHttpHeaders(headers: _*)
-
-  /**
-   * Returns this request with the given headers, preserving the existing ones.
-   *
    * @param hdrs the headers to be added
    */
   def addHttpHeaders(hdrs: (String, String)*): Self = {
@@ -155,14 +147,6 @@ trait StandaloneWSRequest {
    * @param parameters the query string parameters
    */
   def withQueryStringParameters(parameters: (String, String)*): Self
-
-  /**
-   * Returns this request with the given query string parameters, preserving the existing ones.
-   *
-   * @param parameters the query string parameters
-   */
-  @deprecated("Use withQueryStringParameters or addQueryStringParameter", "1.0.0")
-  def withQueryString(parameters: (String, String)*): Self = addQueryStringParameter(parameters: _*)
 
   /**
    * Returns this request with the given query string parameters, preserving the existing ones.

--- a/play-ws-standalone/src/main/scala/play/api/libs/ws/StandaloneWSResponse.scala
+++ b/play-ws-standalone/src/main/scala/play/api/libs/ws/StandaloneWSResponse.scala
@@ -16,12 +16,6 @@ trait StandaloneWSResponse {
   /**
    * Return the current headers for this response.
    */
-  @deprecated("Use headers instead", "1.0.0")
-  def allHeaders: Map[String, Seq[String]] = headers
-
-  /**
-   * Return the current headers for this response.
-   */
   def headers: Map[String, Seq[String]]
 
   /**


### PR DESCRIPTION
Remove deprecated methods -- we can add them in Play-WS as deprecated, but since this is a pre-1.0 standalone version, there's no reason it has to be deprecated in this project.