### PR TITLE
Clean up API to return Optional and use duration

### DIFF
--- a/play-ahc-ws-standalone/src/main/java/play/libs/ws/ahc/StandaloneAhcWSRequest.java
+++ b/play-ahc-ws-standalone/src/main/java/play/libs/ws/ahc/StandaloneAhcWSRequest.java
@@ -34,7 +34,6 @@ import java.nio.ByteBuffer;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
-import java.time.temporal.ChronoUnit;
 import java.util.*;
 import java.util.concurrent.CompletionStage;
 
@@ -64,7 +63,7 @@ public class StandaloneAhcWSRequest implements StandaloneWSRequest {
     private final ObjectMapper objectMapper;
 
     private Duration timeout = Duration.ZERO;
-    private boolean followRedirects;
+    private Boolean followRedirects = null;
     private String virtualHost = null;
 
     private final List<WSRequestFilter> filters = new ArrayList<>();
@@ -238,12 +237,12 @@ public class StandaloneAhcWSRequest implements StandaloneWSRequest {
     }
 
     @Override
-    public String getContentType() {
+    public Optional<String> getContentType() {
         final List<String> values = headers.get(HttpHeaders.Names.CONTENT_BASE);
         if (values == null) {
-            return null;
+            return Optional.empty();
         } else {
-            return values.get(0);
+            return Optional.ofNullable(values.get(0));
         }
     }
 
@@ -294,38 +293,38 @@ public class StandaloneAhcWSRequest implements StandaloneWSRequest {
     }
 
     @Override
-    public String getUsername() {
-        return this.username;
+    public Optional<String> getUsername() {
+        return Optional.ofNullable(this.username);
     }
 
     @Override
-    public String getPassword() {
-        return this.password;
+    public Optional<String> getPassword() {
+        return Optional.ofNullable(this.password);
     }
 
     @Override
-    public WSAuthScheme getScheme() {
-        return this.scheme;
+    public Optional<WSAuthScheme> getScheme() {
+        return Optional.ofNullable(this.scheme);
     }
 
     @Override
-    public WSSignatureCalculator getCalculator() {
-        return this.calculator;
+    public Optional<WSSignatureCalculator> getCalculator() {
+        return Optional.ofNullable(this.calculator);
     }
 
     @Override
-    public Duration getRequestTimeoutDuration() {
-        return this.timeout;
+    public Optional<Duration> getRequestTimeout() {
+        return Optional.ofNullable(this.timeout);
     }
 
     @Override
-    public boolean getFollowRedirects() {
-        return this.followRedirects;
+    public Optional<Boolean> getFollowRedirects() {
+        return Optional.ofNullable(this.followRedirects);
     }
 
     // Intentionally package public.
-    String getVirtualHost() {
-        return this.virtualHost;
+    Optional<String> getVirtualHost() {
+        return Optional.ofNullable(this.virtualHost);
     }
 
     @SuppressWarnings("unchecked")
@@ -445,11 +444,9 @@ public class StandaloneAhcWSRequest implements StandaloneWSRequest {
             builder.setRequestTimeout(((int) this.timeout.toMillis()));
         }
 
-        builder.setFollowRedirect(this.followRedirects);
+        getFollowRedirects().map(builder::setFollowRedirect);
 
-        if (this.virtualHost != null) {
-            builder.setVirtualHost(this.virtualHost);
-        }
+        getVirtualHost().map(builder::setVirtualHost);
 
         if (this.username != null && this.password != null && this.scheme != null) {
             builder.setRealm(auth(this.username, this.password, this.scheme));

--- a/play-ahc-ws-standalone/src/main/scala/play/api/libs/ws/ahc/StandaloneAhcWSRequest.scala
+++ b/play-ahc-ws-standalone/src/main/scala/play/api/libs/ws/ahc/StandaloneAhcWSRequest.scala
@@ -37,7 +37,7 @@ case class StandaloneAhcWSRequest(
     calc: Option[WSSignatureCalculator] = None,
     auth: Option[(String, String, WSAuthScheme)] = None,
     followRedirects: Option[Boolean] = None,
-    requestTimeout: Option[Int] = None,
+    requestTimeout: Option[Duration] = None,
     virtualHost: Option[String] = None,
     proxyServer: Option[WSProxyServer] = None,
     disableUrlEncoding: Option[Boolean] = None,
@@ -97,11 +97,11 @@ case class StandaloneAhcWSRequest(
   override def withRequestTimeout(timeout: Duration): Self = {
     timeout match {
       case Duration.Inf =>
-        copy(requestTimeout = Some(-1))
+        copy(requestTimeout = Some(timeout))
       case d =>
         val millis = d.toMillis
         require(millis >= 0 && millis <= Int.MaxValue, s"Request timeout must be between 0 and ${Int.MaxValue} milliseconds")
-        copy(requestTimeout = Some(millis.toInt))
+        copy(requestTimeout = Some(timeout))
     }
   }
 
@@ -260,7 +260,12 @@ case class StandaloneAhcWSRequest(
     virtualHost.foreach(builder.setVirtualHost)
     followRedirects.foreach(builder.setFollowRedirect)
     proxyServer.foreach(p => builder.setProxyServer(createProxy(p)))
-    requestTimeout.foreach(builder.setRequestTimeout)
+    requestTimeout.foreach {
+      case d if d == Duration.Inf =>
+        builder.setRequestTimeout(-1)
+      case d =>
+        builder.setRequestTimeout(d.toMillis.toInt)
+    }
 
     val (builderWithBody, updatedHeaders) = body match {
       case EmptyBody => (builder, this.headers)

--- a/play-ws-standalone/src/main/java/play/libs/ws/StandaloneWSRequest.java
+++ b/play-ws-standalone/src/main/java/play/libs/ws/StandaloneWSRequest.java
@@ -367,39 +367,39 @@ public interface StandaloneWSRequest {
     Map<String, List<String>> getQueryParameters();
 
     /**
-     * @return the auth username, null if not an authenticated request.
+     * @return the auth username, Optional.empty() if not an authenticated request.
      */
-    String getUsername();
+    Optional<String> getUsername();
 
     /**
-     * @return the auth password, null if not an authenticated request
+     * @return the auth password, Optional.empty() if not an authenticated request
      */
-    String getPassword();
+    Optional<String> getPassword();
 
     /**
-     * @return the auth scheme, null if not an authenticated request.
+     * @return the auth scheme, Optional.empty() if not an authenticated request.
      */
-    WSAuthScheme getScheme();
+    Optional<WSAuthScheme> getScheme();
 
     /**
-     * @return the signature calculator (example: OAuth), null if none is set.
+     * @return the signature calculator (example: OAuth), or Optional.empty() if none is set.
      */
-    WSSignatureCalculator getCalculator();
+    Optional<WSSignatureCalculator> getCalculator();
 
     /**
      * Gets the original request timeout duration, passed into the request as input.
      *
      * @return the timeout duration.
      */
-    Duration getRequestTimeoutDuration();
+    Optional<Duration> getRequestTimeout();
 
     /**
-     * @return true if the request is configure to follow redirect, false if it is configure not to, null if nothing is configured and the global client preference should be used instead.
+     * @return true if the request is configure to follow redirect, false if it is configure not to, Optional.empty() if nothing is configured and the global client preference should be used instead.
      */
-    boolean getFollowRedirects();
+    Optional<Boolean> getFollowRedirects();
 
     /**
-     * @return the content type, if any, or null.
+     * @return the content type, if any, or Optional.empty() if no content type is found.
      */
-    String getContentType();
+    Optional<String> getContentType();
 }

--- a/play-ws-standalone/src/main/scala/play/api/libs/ws/StandaloneWSRequest.scala
+++ b/play-ws-standalone/src/main/scala/play/api/libs/ws/StandaloneWSRequest.scala
@@ -99,7 +99,7 @@ trait StandaloneWSRequest {
   /**
    * The timeout for the request
    */
-  def requestTimeout: Option[Int]
+  def requestTimeout: Option[Duration]
 
   /**
    * The virtual host this request will use


### PR DESCRIPTION
Ensure that the Java API uses Optional<> for nullable values.
Remove the requestTimeoutDuration method and return `Optional<Duration>` on getRequestTimeout().