### PR TITLE
Use URL constructor instead of URI.create

### DIFF
--- a/play-ahc-ws-standalone/src/main/java/play/libs/ws/ahc/StandaloneAhcWSRequest.java
+++ b/play-ahc-ws-standalone/src/main/java/play/libs/ws/ahc/StandaloneAhcWSRequest.java
@@ -21,6 +21,8 @@ import play.shaded.ahc.org.asynchttpclient.util.HttpUtils;
 
 import java.net.MalformedURLException;
 import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URL;
 import java.nio.ByteBuffer;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
@@ -65,18 +67,26 @@ public class StandaloneAhcWSRequest implements StandaloneWSRequest {
 
     public StandaloneAhcWSRequest(StandaloneAhcWSClient client, String url, Materializer materializer) {
         this.client = client;
-        URI reference = URI.create(url);
+        try {
+            // Per https://github.com/playframework/playframework/issues/7444
+            // we should not allow the string to undergo URL decoding, which was
+            // being done by URI.create, which expects a completely valid URI as
+            // input.
+            URL reference = new java.net.URL(url);
 
-        this.url = url;
-        this.materializer = materializer;
-        this.bodyWritable = null;
+            this.url = url;
+            this.materializer = materializer;
+            this.bodyWritable = null;
 
-        String userInfo = reference.getUserInfo();
-        if (userInfo != null) {
-            this.setAuth(userInfo);
-        }
-        if (reference.getQuery() != null) {
-            this.setQueryString(reference.getQuery());
+            String userInfo = reference.getUserInfo();
+            if (userInfo != null) {
+                this.setAuth(userInfo);
+            }
+            if (reference.getQuery() != null) {
+                this.setQueryString(reference.getQuery());
+            }
+        } catch (MalformedURLException e) {
+            throw new RuntimeException(e);
         }
     }
 

--- a/play-ahc-ws-standalone/src/test/scala/play/libs/ws/ahc/AhcWSRequestSpec.scala
+++ b/play-ahc-ws-standalone/src/test/scala/play/libs/ws/ahc/AhcWSRequestSpec.scala
@@ -376,6 +376,17 @@ class AhcWSRequestSpec extends Specification with Mockito with DefaultBodyWritab
         requestWithQueryString("q=scala=playframework&src=typd") must throwA[RuntimeException]
       }
 
+      "support a query string parameter with an encoded equals sign" in {
+        import scala.collection.JavaConverters._
+        val client = mock[StandaloneAhcWSClient]
+        val request = new StandaloneAhcWSRequest(client, "http://example.com?bar=F%3Dma", /*materializer*/ null)
+        val queryParams = request.buildRequest().getQueryParams.asScala
+        val p = queryParams(0)
+
+        p.getName must beEqualTo("bar")
+        p.getValue must beEqualTo("F%253Dma")
+      }
+
       "not support a query string if it starts with = and is empty" in {
         requestWithQueryString("=&src=typd") must throwA[RuntimeException]
       }


### PR DESCRIPTION
Fixes https://github.com/playframework/playframework/issues/7444

Previously this was managed by setting the URL on the builder directly, but URI.create() makes assumptions about input which are not warrented, and the Javadoc says to use the constructor in the case of possibly invalid input.

See https://github.com/playframework/playframework/commit/50f391baf11aebe165c20ae7e9d8529fbfc7f21f#diff-5d483e96ccf6f80c115c5122cd8a8baaR50 for the attached blame.