### PR TITLE
#87 add original + shaded configuration properties

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -128,6 +128,7 @@ val ahcMerge: MergeStrategy = new MergeStrategy {
       // so we have to manually tweak the resource file to match.
       val shadedline = line.replace("org.asynchttpclient", "play.shaded.ahc.org.asynchttpclient")
       IO.append(file, line)
+      IO.append(file, IO.Newline.getBytes(IO.defaultCharset))
       IO.append(file, shadedline)
       IO.append(file, IO.Newline.getBytes(IO.defaultCharset))
     }

--- a/build.sbt
+++ b/build.sbt
@@ -127,6 +127,7 @@ val ahcMerge: MergeStrategy = new MergeStrategy {
       // In AsyncHttpClientConfigDefaults.java, the shading renames the resource keys
       // so we have to manually tweak the resource file to match.
       val shadedline = line.replace("org.asynchttpclient", "play.shaded.ahc.org.asynchttpclient")
+      IO.append(file, line)
       IO.append(file, shadedline)
       IO.append(file, IO.Newline.getBytes(IO.defaultCharset))
     }


### PR DESCRIPTION
completely replacing the configuration properties resulted in errors when users
where using the unshaded AHC-Client in their applications together with play-ws.
As a workaround we take the original properties and _add_ our own properties to the
file. This way, the unshaded client still finds its properties while our own version can
be configured independently
