### PR TITLE
[WIP]: Better content-type manipulation in Scala API

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,10 +1,13 @@
 import Dependencies._
 import com.typesafe.sbt.SbtScalariform.ScalariformKeys
-import com.typesafe.tools.mima.plugin.MimaPlugin.mimaDefaultSettings
 import sbtassembly.AssemblyPlugin.autoImport._
 import sbtassembly.MergeStrategy
 
 import scalariform.formatter.preferences._
+
+import com.typesafe.tools.mima.core._
+import com.typesafe.tools.mima.core.ProblemFilters._
+import com.typesafe.tools.mima.plugin.MimaPlugin.mimaDefaultSettings
 
 //---------------------------------------------------------------
 // Shading and Project Settings
@@ -22,7 +25,13 @@ val javacSettings = Seq(
   "-Xlint:unchecked"
 )
 
-lazy val commonSettings = mimaDefaultSettings ++ Seq(
+lazy val mimaSettingsAndFilters = mimaDefaultSettings ++ Seq(
+  mimaBinaryIssueFilters ++= Seq(
+    ProblemFilters.exclude[ReversedMissingMethodProblem]("play.api.libs.ws.StandaloneWSRequest.withContentType")
+  )
+)
+
+lazy val commonSettings = mimaSettingsAndFilters ++ Seq(
   organization := "com.typesafe.play",
   scalaVersion := "2.12.2",
   crossScalaVersions := Seq("2.12.2", "2.11.11"),

--- a/play-ahc-ws-standalone/src/main/scala/play/api/libs/ws/ahc/StandaloneAhcWSRequest.scala
+++ b/play-ahc-ws-standalone/src/main/scala/play/api/libs/ws/ahc/StandaloneAhcWSRequest.scala
@@ -155,10 +155,9 @@ case class StandaloneAhcWSRequest(
   }
 
   private def withBodyAndContentType(wsBody: WSBody, contentType: String): Self = {
-    if (headers.contains(HttpHeaders.Names.CONTENT_TYPE)) {
-      copy(body = wsBody)
-    } else {
-      copy(body = wsBody).addHttpHeaders(HttpHeaders.Names.CONTENT_TYPE -> contentType)
+    this.contentType match {
+      case Some(_) => copy(body = wsBody)
+      case None => copy(body = wsBody).withContentType(contentType)
     }
   }
 
@@ -227,7 +226,7 @@ case class StandaloneAhcWSRequest(
    */
   def requestQueryParams: Map[String, Seq[String]] = {
     val params: java.util.List[Param] = buildRequest().getQueryParams
-    params.asScala.toSeq.groupBy(_.getName).mapValues(_.map(_.getValue))
+    params.asScala.groupBy(_.getName).mapValues(_.map(_.getValue))
   }
 
   /**

--- a/play-ahc-ws-standalone/src/main/scala/play/api/libs/ws/ahc/StandaloneAhcWSRequest.scala
+++ b/play-ahc-ws-standalone/src/main/scala/play/api/libs/ws/ahc/StandaloneAhcWSRequest.scala
@@ -317,7 +317,7 @@ case class StandaloneAhcWSRequest(
     for {
       header <- updatedHeaders
       value <- header._2
-    } builder.addHeader(header._1, value)
+    } builderWithBody.addHeader(header._1, value)
 
     // Set the signature calculator.
     calc.map {
@@ -328,7 +328,7 @@ case class StandaloneAhcWSRequest(
     }
 
     // cookies
-    cookies.foreach(c => builder.addCookie(asCookie(c)))
+    cookies.foreach(c => builderWithBody.addCookie(asCookie(c)))
 
     builderWithBody.build()
   }

--- a/play-ahc-ws-standalone/src/main/scala/play/api/libs/ws/ahc/StandaloneAhcWSRequest.scala
+++ b/play-ahc-ws-standalone/src/main/scala/play/api/libs/ws/ahc/StandaloneAhcWSRequest.scala
@@ -77,12 +77,12 @@ case class StandaloneAhcWSRequest(
     }
 
     // preserve the content type
-    newHeaders = contentType match {
-      case Some(ct) =>
-        newHeaders.updated(HttpHeaders.Names.CONTENT_TYPE, Seq(ct))
-      case None =>
-        newHeaders
-    }
+    //    newHeaders = contentType match {
+    //      case Some(ct) =>
+    //        newHeaders.updated(HttpHeaders.Names.CONTENT_TYPE, Seq(ct))
+    //      case None =>
+    //        newHeaders
+    //    }
 
     copy(headers = newHeaders)
   }

--- a/play-ahc-ws-standalone/src/main/scala/play/api/libs/ws/ahc/StandaloneAhcWSRequest.scala
+++ b/play-ahc-ws-standalone/src/main/scala/play/api/libs/ws/ahc/StandaloneAhcWSRequest.scala
@@ -47,6 +47,10 @@ case class StandaloneAhcWSRequest(
   require(client != null, "A StandaloneAhcWSClient is required, but it is null")
   require(url != null, "A url is required, but it is null")
 
+  override def withContentType(contentTypes: String): StandaloneWSRequest = copy(
+    headers = this.headers.updated(HttpHeaders.Names.CONTENT_TYPE, Seq(contentTypes))
+  )
+
   override def contentType: Option[String] = this.headers.get(HttpHeaders.Names.CONTENT_TYPE).map(_.head)
 
   override lazy val uri: URI = {

--- a/play-ahc-ws-standalone/src/main/scala/play/api/libs/ws/ahc/StandaloneAhcWSRequest.scala
+++ b/play-ahc-ws-standalone/src/main/scala/play/api/libs/ws/ahc/StandaloneAhcWSRequest.scala
@@ -47,10 +47,6 @@ case class StandaloneAhcWSRequest(
   require(client != null, "A StandaloneAhcWSClient is required, but it is null")
   require(url != null, "A url is required, but it is null")
 
-  override def withContentType(contentTypes: String): StandaloneWSRequest = copy(
-    headers = this.headers.updated(HttpHeaders.Names.CONTENT_TYPE, Seq(contentTypes))
-  )
-
   override def contentType: Option[String] = this.headers.get(HttpHeaders.Names.CONTENT_TYPE).map(_.head)
 
   override lazy val uri: URI = {
@@ -68,6 +64,10 @@ case class StandaloneAhcWSRequest(
 
   override def withAuth(username: String, password: String, scheme: WSAuthScheme): Self =
     copy(auth = Some((username, password, scheme)))
+
+  override def withContentType(contentType: String): StandaloneWSRequest = copy(
+    headers = this.headers.updated(HttpHeaders.Names.CONTENT_TYPE, Seq(contentType))
+  )
 
   override def withHttpHeaders(hdrs: (String, String)*): Self = {
     val newHeaders = hdrs.foldLeft(TreeMap[String, Seq[String]]()(CaseInsensitiveOrdered)) {

--- a/play-ahc-ws-standalone/src/test/scala/play/api/libs/ws/ahc/AhcWSRequestSpec.scala
+++ b/play-ahc-ws-standalone/src/test/scala/play/api/libs/ws/ahc/AhcWSRequestSpec.scala
@@ -557,4 +557,54 @@ class AhcWSRequestSpec extends Specification with Mockito with AfterAll {
     req.getHeaders.getAll(HttpHeaders.Names.CONTENT_TYPE).asScala must_== Seq("text/plain; charset=US-ASCII")
   }
 
+  "For the Content-Type" should {
+
+    "set a new content type value" in withClient { client =>
+      val req = client.url("http://playframework.com/")
+        .withContentType("application/json")
+        .asInstanceOf[StandaloneAhcWSRequest]
+        .buildRequest()
+      req.getHeaders.getAll(HttpHeaders.Names.CONTENT_TYPE).asScala must_== Seq("application/json")
+    }
+
+    "use the given content type when setting headers" in withClient { client =>
+      val req = client.url("http://playframework.com/")
+        .withBody("Hello World Body") // text/plain content type
+        .withHttpHeaders(HttpHeaders.Names.CONTENT_TYPE -> "application/json") // override the content type
+        .asInstanceOf[StandaloneAhcWSRequest]
+        .buildRequest()
+
+      req.getHeaders.getAll(HttpHeaders.Names.CONTENT_TYPE).asScala must_== Seq("application/json")
+    }
+
+    "use the given content type when adding headers" in withClient { client =>
+      val req = client.url("http://playframework.com/")
+        .withBody("Hello World Body") // text/plain content type
+        .addHttpHeaders(HttpHeaders.Names.CONTENT_TYPE -> "application/json") // override the content type
+        .asInstanceOf[StandaloneAhcWSRequest]
+        .buildRequest()
+
+      req.getHeaders.getAll(HttpHeaders.Names.CONTENT_TYPE).asScala must_== Seq("application/json")
+    }
+
+    "use the body content type when no content type is configured" in withClient { client =>
+      val req = client.url("http://playframework.com/")
+        .withBody("Hello World Body") // text/plain content type
+        .addHttpHeaders(HttpHeaders.Names.CONTENT_TYPE -> "application/json") // override the content type
+        .asInstanceOf[StandaloneAhcWSRequest]
+        .buildRequest()
+
+      req.getHeaders.getAll(HttpHeaders.Names.CONTENT_TYPE).asScala must_== Seq("application/json")
+    }
+
+    "preserve the content type when setting a new body" in withClient { client =>
+      val req = client.url("http://playframework.com/")
+        .addHttpHeaders(HttpHeaders.Names.CONTENT_TYPE -> "application/json") // override the content type
+        .withBody("Hello World Body") // text/plain content type
+        .asInstanceOf[StandaloneAhcWSRequest]
+        .buildRequest()
+
+      req.getHeaders.getAll(HttpHeaders.Names.CONTENT_TYPE).asScala must_== Seq("application/json")
+    }
+  }
 }

--- a/play-ahc-ws-standalone/src/test/scala/play/api/libs/ws/ahc/AhcWSRequestSpec.scala
+++ b/play-ahc-ws-standalone/src/test/scala/play/api/libs/ws/ahc/AhcWSRequestSpec.scala
@@ -600,10 +600,20 @@ class AhcWSRequestSpec extends Specification with Mockito with AfterAll {
       req.getHeaders.getAll(HttpHeaders.Names.CONTENT_TYPE).asScala must_== Seq("application/json")
     }
 
-    "preserve the content type when setting a new body" in withClient { client =>
+    "preserve the existing content type when setting a new body" in withClient { client =>
       val req = client.url("http://playframework.com/")
         .addHttpHeaders(HttpHeaders.Names.CONTENT_TYPE -> "application/json") // override the content type
         .withBody("Hello World Body") // text/plain content type
+        .asInstanceOf[StandaloneAhcWSRequest]
+        .buildRequest()
+
+      req.getHeaders.getAll(HttpHeaders.Names.CONTENT_TYPE).asScala must_== Seq("application/json")
+    }
+
+    "preserve the existing content type when setting new headers without a new content type" in withClient { client =>
+      val req = client.url("http://playframework.com/")
+        .withContentType("application/json")
+        .withHttpHeaders("Some-Header" -> "header value")
         .asInstanceOf[StandaloneAhcWSRequest]
         .buildRequest()
 

--- a/play-ahc-ws-standalone/src/test/scala/play/api/libs/ws/ahc/AhcWSRequestSpec.scala
+++ b/play-ahc-ws-standalone/src/test/scala/play/api/libs/ws/ahc/AhcWSRequestSpec.scala
@@ -376,7 +376,9 @@ class AhcWSRequestSpec extends Specification with Mockito with AfterAll {
           .withBody("HELLO WORLD") // and body is set to string (see #5221)
           .asInstanceOf[StandaloneAhcWSRequest]
           .buildRequest()
+
         (new String(req.getByteData, "UTF-8")) must be_==("HELLO WORLD") // should result in byte data.
+        req.getHeaders.getAll(HttpHeaders.Names.CONTENT_TYPE).asScala must_== Seq("application/x-www-form-urlencoded")
       }
     }
 
@@ -535,7 +537,8 @@ class AhcWSRequestSpec extends Specification with Mockito with AfterAll {
     val consumerKey = ConsumerKey("key", "secret")
     val requestToken = RequestToken("token", "secret")
     val calc = OAuthCalculator(consumerKey, requestToken)
-    val req: AHCRequest = client.url("http://playframework.com/").withBody(Map("param1" -> Seq("value1")))
+    val req: AHCRequest = client.url("http://playframework.com/")
+      .withBody(Map("param1" -> Seq("value1")))
       .withHttpHeaders("Content-Length" -> "9001") // add a meaningless content length here...
       .sign(calc) // this is signed, so content length is no longer valid per #5221
       .asInstanceOf[StandaloneAhcWSRequest]

--- a/play-ahc-ws-standalone/src/test/scala/play/libs/ws/ahc/AhcWSRequestSpec.scala
+++ b/play-ahc-ws-standalone/src/test/scala/play/libs/ws/ahc/AhcWSRequestSpec.scala
@@ -68,7 +68,7 @@ class AhcWSRequestSpec extends Specification with Mockito with DefaultBodyWritab
           .asInstanceOf[StandaloneAhcWSRequest]
           .buildRequest()
 
-        // Must set the form url encoding autoomatically.
+        // Must set the form url encoding automatically.
         req.getHeaders.get("Content-Type") must be_==("application/x-www-form-urlencoded")
 
         // Note we use getFormParams instead of getByteData here.
@@ -159,7 +159,7 @@ class AhcWSRequestSpec extends Specification with Mockito with DefaultBodyWritab
       request.addHeader("Content-Type", "application/json")
       request.addHeader("Content-Type", "application/xml")
       val req = request.buildRequest()
-      req.getHeaders.get("Content-Type") must be_==("application/json")
+      req.getHeaders.getAll(HttpHeaders.Names.CONTENT_TYPE).asScala must_== Seq("application/json")
     }
 
     "only send first content type header and keep the charset if it has been set manually with a charset" in {
@@ -169,7 +169,7 @@ class AhcWSRequestSpec extends Specification with Mockito with DefaultBodyWritab
       request.addHeader("Content-Type", "application/json; charset=US-ASCII")
       request.addHeader("Content-Type", "application/xml")
       val req = request.buildRequest()
-      req.getHeaders.get("Content-Type") must be_==("application/json; charset=US-ASCII")
+      req.getHeaders.getAll(HttpHeaders.Names.CONTENT_TYPE).asScala must_== Seq("application/json; charset=US-ASCII")
     }
 
     "Set Realm.UsePreemptiveAuth to false when WSAuthScheme.DIGEST being used" in {

--- a/play-ws-standalone/src/main/scala/play/api/libs/ws/StandaloneWSRequest.scala
+++ b/play-ws-standalone/src/main/scala/play/api/libs/ws/StandaloneWSRequest.scala
@@ -112,14 +112,6 @@ trait StandaloneWSRequest {
   def proxyServer: Option[WSProxyServer]
 
   /**
-   * Set the Content-Type for this request.
-   *
-   * @param contentType the content type value.
-   * @return the modified request.
-   */
-  def withContentType(contentType: String): Self
-
-  /**
    * sets the signature calculator for the request
    * @param calc the signature calculator
    */
@@ -129,6 +121,14 @@ trait StandaloneWSRequest {
    * sets the authentication realm
    */
   def withAuth(username: String, password: String, scheme: WSAuthScheme): Self
+
+  /**
+   * Set the Content-Type for this request.
+   *
+   * @param contentType the content type value.
+   * @return the modified request.
+   */
+  def withContentType(contentType: String): Self
 
   /**
    * Returns this request with the given headers, discarding the existing ones.

--- a/play-ws-standalone/src/main/scala/play/api/libs/ws/StandaloneWSRequest.scala
+++ b/play-ws-standalone/src/main/scala/play/api/libs/ws/StandaloneWSRequest.scala
@@ -112,6 +112,14 @@ trait StandaloneWSRequest {
   def proxyServer: Option[WSProxyServer]
 
   /**
+   * Set the Content-Type for this request.
+   *
+   * @param contentType the content type value.
+   * @return the modified request.
+   */
+  def withContentType(contentType: String): Self
+
+  /**
    * sets the signature calculator for the request
    * @param calc the signature calculator
    */

--- a/play-ws-standalone/src/main/scala/play/api/libs/ws/StandaloneWSRequest.scala
+++ b/play-ws-standalone/src/main/scala/play/api/libs/ws/StandaloneWSRequest.scala
@@ -143,7 +143,6 @@ trait StandaloneWSRequest {
    * @param hdrs the headers to be added
    */
   def addHttpHeaders(hdrs: (String, String)*): Self = {
-    val contentType = hdrs.find(_._1.equalsIgnoreCase("Content-Type"))
     val newHeaders = headers.toList.flatMap { param =>
       param._2.map(p => param._1 -> p)
     } ++ hdrs
@@ -152,7 +151,7 @@ trait StandaloneWSRequest {
     // https://tools.ietf.org/html/rfc7231#section-3.1.1.5
     //
     // So we should undo the append made above.
-    contentType match {
+    hdrs.find(_._1.equalsIgnoreCase("Content-Type")) match {
       case Some((_, contentTypeValue)) =>
         withHttpHeaders(newHeaders: _*).withContentType(contentTypeValue)
       case None =>


### PR DESCRIPTION
# WIP DO NOT MERGE

This is a work in progress and needs further discussion with @wsargent.

Also **this is not backward compatible**.

## Fixes

Fixes #158.

## Purpose

There were some specific cases where users we not able to override the `Content-Type` of a request, for example, after using `withBody`, which derivates the `Content-Type` from the body:

```scala
request
  .withBody("Something") // content-type to text/plain
  .withHttpHeaders("Content-Type" -> "application/octet-stream")
```

The result `Content-Type` was `text/plain`. Changing the order will make it work:

```scala
request
  .withBody("Something") // content-type to text/plain
  .withHttpHeaders("Content-Type" -> "application/octet-stream")
```

But then the API is less intuitive.  This PR then:

1. Adds a new method `withContentType` which always overrides the existing value for the `Content-Type` header. This also made Scala and Java APIs more consistent since the Java API has such method.
2. Changes `withHttpHeaders` to accept a new `Content-Type` or preserve the existing one if present.
3. Changes `addHttpHeader` to accept a new `Content-Type` by replacing the existing one if necessary.

## Needs discussion

In the Java API is not possible to set the `Content-Type` after it is configured. See [this test](https://github.com/playframework/play-ws/blob/master/play-ahc-ws-standalone/src/test/scala/play/libs/ws/ahc/AhcWSRequestSpec.scala#L155-L173). [`StandaloneAhcWSRequest.setContentType`](https://github.com/playframework/play-ws/blob/master/play-ahc-ws-standalone/src/main/java/play/libs/ws/ahc/StandaloneAhcWSRequest.java#L233-L236) method uses `addHeader`, so it has the same effect. Is this intentional?