### PR TITLE
fix possible NPE when 'Content-Type' header is absent in HTTP response

### DIFF
--- a/play-ahc-ws-standalone/src/main/scala/play/api/libs/ws/ahc/cache/CacheableResponse.scala
+++ b/play-ahc-ws-standalone/src/main/scala/play/api/libs/ws/ahc/cache/CacheableResponse.scala
@@ -113,7 +113,7 @@ case class CacheableResponse(
   }
 
   private def computeCharset(charset: Charset): Charset = {
-    Option(charset).orElse(Option(parseCharset(getContentType))).getOrElse(DEFAULT_CHARSET)
+    Option(charset).orElse(Option(getContentType).map(parseCharset)).getOrElse(DEFAULT_CHARSET)
   }
 
   @throws(classOf[IOException])


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [x] Have you signed the [Typesafe CLA](https://www.typesafe.com/contribute/cla)?
* [x] Have you [squashed your commits](https://www.playframework.com/documentation/latest/WorkingWithGit#Squashing-commits)?
* [x] Have you added copyright headers to new files?
* [x] Have you checked that both Scala and Java APIs are updated?
* [x] Have you updated the documentation for both Scala and Java sections?
* [x] Have you added tests for any changed functionality?

## Fixes

Fixes possible NullPointerException when 'Content-Type' header is absent in HTTP response.

## Purpose

Fix the bug.

## Background Context

## References
