### PR TITLE
Update sbt-assembly version

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -5,7 +5,7 @@ resolvers += Resolver.typesafeRepo("releases")
 addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "1.1")
 addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.0.0")
 
-addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.3")
+addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.5")
 
 addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.3")
 


### PR DESCRIPTION
Motivation is to get to the latest version of jarjar, to fix
a bug in shading of classes containing lambdas that is reported
under JDK 9.

Fixes #173