### PR TITLE
Java version of curl request filter

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -38,7 +38,21 @@ lazy val mimaSettings = mimaDefaultSettings ++ Seq(
   mimaBinaryIssueFilters ++= Seq(
     ProblemFilters.exclude[DirectMissingMethodProblem]("play.libs.ws.ahc.StandaloneAhcWSResponse.getBodyAsSource"),
     ProblemFilters.exclude[MissingClassProblem]("play.api.libs.ws.package$"),
-    ProblemFilters.exclude[MissingClassProblem]("play.api.libs.ws.package")
+    ProblemFilters.exclude[MissingClassProblem]("play.api.libs.ws.package"),
+
+    // Implemented as a default method at the interface
+    ProblemFilters.exclude[DirectMissingMethodProblem]("play.libs.ws.ahc.StandaloneAhcWSResponse.getBodyAsSource"),
+    // Added to have better parity between Java and Scala APIs
+    ProblemFilters.exclude[ReversedMissingMethodProblem]("play.libs.ws.StandaloneWSRequest.getBody"),
+    ProblemFilters.exclude[ReversedMissingMethodProblem]("play.libs.ws.StandaloneWSRequest.getAuth"),
+    ProblemFilters.exclude[ReversedMissingMethodProblem]("play.libs.ws.StandaloneWSRequest.getMethod"),
+    ProblemFilters.exclude[ReversedMissingMethodProblem]("play.libs.ws.StandaloneWSRequest.setAuth"),
+
+    // Now have a default implementation at the interface
+    ProblemFilters.exclude[DirectMissingMethodProblem]("play.libs.ws.ahc.StandaloneAhcWSRequest.getPassword"),
+    ProblemFilters.exclude[DirectMissingMethodProblem]("play.libs.ws.ahc.StandaloneAhcWSRequest.getUsername"),
+    ProblemFilters.exclude[DirectMissingMethodProblem]("play.libs.ws.ahc.StandaloneAhcWSRequest.setAuth"),
+    ProblemFilters.exclude[DirectMissingMethodProblem]("play.libs.ws.ahc.StandaloneAhcWSRequest.getScheme")
   )
 )
 

--- a/build.sbt
+++ b/build.sbt
@@ -42,6 +42,7 @@ lazy val mimaSettings = mimaDefaultSettings ++ Seq(
 
     // Implemented as a default method at the interface
     ProblemFilters.exclude[DirectMissingMethodProblem]("play.libs.ws.ahc.StandaloneAhcWSResponse.getBodyAsSource"),
+
     // Added to have better parity between Java and Scala APIs
     ProblemFilters.exclude[ReversedMissingMethodProblem]("play.libs.ws.StandaloneWSRequest.getBody"),
     ProblemFilters.exclude[ReversedMissingMethodProblem]("play.libs.ws.StandaloneWSRequest.getAuth"),
@@ -52,7 +53,11 @@ lazy val mimaSettings = mimaDefaultSettings ++ Seq(
     ProblemFilters.exclude[DirectMissingMethodProblem]("play.libs.ws.ahc.StandaloneAhcWSRequest.getPassword"),
     ProblemFilters.exclude[DirectMissingMethodProblem]("play.libs.ws.ahc.StandaloneAhcWSRequest.getUsername"),
     ProblemFilters.exclude[DirectMissingMethodProblem]("play.libs.ws.ahc.StandaloneAhcWSRequest.setAuth"),
-    ProblemFilters.exclude[DirectMissingMethodProblem]("play.libs.ws.ahc.StandaloneAhcWSRequest.getScheme")
+    ProblemFilters.exclude[DirectMissingMethodProblem]("play.libs.ws.ahc.StandaloneAhcWSRequest.getScheme"),
+
+    // Add getUri method
+    ProblemFilters.exclude[ReversedMissingMethodProblem]("play.libs.ws.StandaloneWSResponse.getUri"),
+    ProblemFilters.exclude[ReversedMissingMethodProblem]("play.api.libs.ws.StandaloneWSResponse.uri")
   )
 )
 
@@ -283,10 +288,6 @@ lazy val `play-ws-standalone` = project
   .in(file("play-ws-standalone"))
   .settings(commonSettings ++ Seq(
     libraryDependencies ++= standaloneApiWSDependencies,
-    mimaBinaryIssueFilters ++= Seq(
-      ProblemFilters.exclude[ReversedMissingMethodProblem]("play.libs.ws.StandaloneWSResponse.getUri"),
-      ProblemFilters.exclude[ReversedMissingMethodProblem]("play.api.libs.ws.StandaloneWSResponse.uri")
-    ),
     mimaPreviousArtifacts := mimaPreviousArtifactFor(scalaVersion.value, "com.typesafe.play" %% "play-ws-standalone" % "1.0.0"))
   )
   .disablePlugins(sbtassembly.AssemblyPlugin)
@@ -318,9 +319,6 @@ lazy val `play-ahc-ws-standalone` = project
       Tests.Argument(TestFrameworks.JUnit, "-a", "-v")),
     libraryDependencies ++= standaloneAhcWSDependencies,
     mimaPreviousArtifacts := mimaPreviousArtifactFor(scalaVersion.value, "com.typesafe.play" %% "play-ahc-ws-standalone" % "1.0.0"),
-    mimaBinaryIssueFilters ++= Seq(
-      ProblemFilters.exclude[DirectMissingMethodProblem](
-        "play.libs.ws.ahc.StandaloneAhcWSResponse.getBodyAsSource")),
     // This will not work if you do a publishLocal, because that uses ivy...
     pomPostProcess := {
       (node: xml.Node) => addShadedDeps(List(

--- a/integration-tests/src/test/java/play/libs/ws/ahc/AhcCurlRequestLoggerSpec.scala
+++ b/integration-tests/src/test/java/play/libs/ws/ahc/AhcCurlRequestLoggerSpec.scala
@@ -97,7 +97,7 @@ class AhcCurlRequestLoggerSpec(implicit val executionEnv: ExecutionEnv) extends 
         .toScala
         .awaitFor(defaultTimeout)
 
-      testLogger.getLoggingEvents.asScala.map(_.getMessage) must containMatch("""--header "Authorization: Basic""")
+      testLogger.getLoggingEvents.asScala.map(_.getMessage) must containMatch("""--header 'Authorization: Basic dXNlcm5hbWU6cGFzc3dvcmQ='""")
     }
 
     "handle body" in {
@@ -152,7 +152,7 @@ class AhcCurlRequestLoggerSpec(implicit val executionEnv: ExecutionEnv) extends 
            |curl \\
            |  --verbose \\
            |  --request GET \\
-           |  --header "Authorization: Basic dXNlcm5hbWU6cGFzc3dvcmQ=" \\
+           |  --header 'Authorization: Basic dXNlcm5hbWU6cGFzc3dvcmQ=' \\
            |  --header 'My-Header: My-Header-Value' \\
            |  --header 'Content-Type: text/plain' \\
            |  --data 'the-body' \\

--- a/integration-tests/src/test/java/play/libs/ws/ahc/AhcCurlRequestLoggerSpec.scala
+++ b/integration-tests/src/test/java/play/libs/ws/ahc/AhcCurlRequestLoggerSpec.scala
@@ -154,7 +154,6 @@ class AhcCurlRequestLoggerSpec(implicit val executionEnv: ExecutionEnv) extends 
            |  --request GET \\
            |  --header "Authorization: Basic dXNlcm5hbWU6cGFzc3dvcmQ=" \\
            |  --header 'My-Header: My-Header-Value' \\
-           |  --header 'Content-Type: text/plain' \\
            |  --data 'the-body' \\
            |  'http://localhost:$testServerPort/'
         """.stripMargin.trim)

--- a/integration-tests/src/test/java/play/libs/ws/ahc/AhcCurlRequestLoggerSpec.scala
+++ b/integration-tests/src/test/java/play/libs/ws/ahc/AhcCurlRequestLoggerSpec.scala
@@ -1,0 +1,136 @@
+/*
+ * Copyright (C) 2009-2017 Lightbend Inc. <https://www.lightbend.com>
+ */
+package play.libs.ws.ahc
+
+import akka.http.scaladsl.server.Route
+import org.specs2.concurrent.{ ExecutionEnv, FutureAwait }
+import org.specs2.mutable.Specification
+
+import play.AkkaServerProvider
+import play.libs.ws.{ DefaultBodyWritables, WSAuthScheme, WSAuthInfo }
+
+import uk.org.lidalia.slf4jext.Level
+import uk.org.lidalia.slf4jtest.{ TestLogger, TestLoggerFactory }
+
+import scala.collection.JavaConverters._
+import scala.compat.java8.FutureConverters._
+
+class AhcCurlRequestLoggerSpec(implicit val executionEnv: ExecutionEnv) extends Specification
+    with AkkaServerProvider
+    with StandaloneWSClientSupport
+    with FutureAwait
+    with DefaultBodyWritables {
+
+  override def routes: Route = {
+    import akka.http.scaladsl.server.Directives._
+    get {
+      complete("<h1>Say hello to akka-http</h1>")
+    } ~
+      post {
+        entity(as[String]) { echo =>
+          complete(echo)
+        }
+      }
+  }
+
+  // Level.OFF because we don't want to pollute the test output
+  def createTestLogger: TestLogger = new TestLoggerFactory(Level.OFF).getLogger("test-logger")
+
+  "Logging request as curl" should {
+
+    "be verbose" in withClient() { client =>
+
+      val testLogger = createTestLogger
+      val curlRequestLogger = new AhcCurlRequestLogger(testLogger)
+
+      client.url(s"http://localhost:$testServerPort/")
+        .setRequestFilter(curlRequestLogger)
+        .get()
+        .toScala
+        .awaitFor(defaultTimeout)
+
+      testLogger.getLoggingEvents.asScala.map(_.getMessage) must containMatch("--verbose")
+    }
+
+    "add all headers" in withClient() { client =>
+
+      val testLogger = createTestLogger
+      val curlRequestLogger = new AhcCurlRequestLogger(testLogger)
+
+      client.url(s"http://localhost:$testServerPort/")
+        .addHeader("My-Header", "My-Header-Value")
+        .setRequestFilter(curlRequestLogger)
+        .get()
+        .toScala
+        .awaitFor(defaultTimeout)
+
+      val messages = testLogger.getLoggingEvents.asScala.map(_.getMessage)
+
+      messages must containMatch("My-Header")
+      messages must containMatch("My-Header-Value")
+    }
+
+    "add method" in withClient() { client =>
+
+      val testLogger = createTestLogger
+      val curlRequestLogger = new AhcCurlRequestLogger(testLogger)
+
+      client.url(s"http://localhost:$testServerPort/")
+        .setRequestFilter(curlRequestLogger)
+        .get()
+        .toScala
+        .awaitFor(defaultTimeout)
+
+      testLogger.getLoggingEvents.asScala.map(_.getMessage) must containMatch("--request GET")
+    }
+
+    "add authorization header" in withClient() { client =>
+
+      val testLogger = createTestLogger
+      val curlRequestLogger = new AhcCurlRequestLogger(testLogger)
+
+      client.url(s"http://localhost:$testServerPort/")
+        .setAuth(new WSAuthInfo("username", "password", WSAuthScheme.BASIC))
+        .setRequestFilter(curlRequestLogger)
+        .get()
+        .toScala
+        .awaitFor(defaultTimeout)
+
+      testLogger.getLoggingEvents.asScala.map(_.getMessage) must containMatch("""--header "Authorization: Basic""")
+    }
+
+    "handle body" in {
+
+      "add when in memory" in withClient() { client =>
+
+        val testLogger = createTestLogger
+        val curlRequestLogger = new AhcCurlRequestLogger(testLogger)
+
+        client.url(s"http://localhost:$testServerPort/")
+          .setBody(body("the-body"))
+          .setRequestFilter(curlRequestLogger)
+          .get()
+          .toScala
+          .awaitFor(defaultTimeout)
+
+        testLogger.getLoggingEvents.asScala.map(_.getMessage) must containMatch("the-body")
+      }
+
+      "do nothing for empty bodies" in withClient() { client =>
+
+        val testLogger = createTestLogger
+        val curlRequestLogger = new AhcCurlRequestLogger(testLogger)
+
+        // no body setBody, so body is "empty"
+        client.url(s"http://localhost:$testServerPort/")
+          .setRequestFilter(curlRequestLogger)
+          .get()
+          .toScala
+          .awaitFor(defaultTimeout)
+
+        testLogger.getLoggingEvents.asScala.map(_.getMessage) must not containMatch ("--data")
+      }
+    }
+  }
+}

--- a/integration-tests/src/test/java/play/libs/ws/ahc/AhcCurlRequestLoggerSpec.scala
+++ b/integration-tests/src/test/java/play/libs/ws/ahc/AhcCurlRequestLoggerSpec.scala
@@ -17,10 +17,10 @@ import scala.collection.JavaConverters._
 import scala.compat.java8.FutureConverters._
 
 class AhcCurlRequestLoggerSpec(implicit val executionEnv: ExecutionEnv) extends Specification
-    with AkkaServerProvider
-    with StandaloneWSClientSupport
-    with FutureAwait
-    with DefaultBodyWritables {
+  with AkkaServerProvider
+  with StandaloneWSClientSupport
+  with FutureAwait
+  with DefaultBodyWritables {
 
   override def routes: Route = {
     import akka.http.scaladsl.server.Directives._
@@ -154,6 +154,7 @@ class AhcCurlRequestLoggerSpec(implicit val executionEnv: ExecutionEnv) extends 
            |  --request GET \\
            |  --header "Authorization: Basic dXNlcm5hbWU6cGFzc3dvcmQ=" \\
            |  --header 'My-Header: My-Header-Value' \\
+           |  --header 'Content-Type: text/plain' \\
            |  --data 'the-body' \\
            |  'http://localhost:$testServerPort/'
         """.stripMargin.trim)

--- a/integration-tests/src/test/java/play/libs/ws/ahc/StandaloneWSClientSupport.scala
+++ b/integration-tests/src/test/java/play/libs/ws/ahc/StandaloneWSClientSupport.scala
@@ -1,0 +1,24 @@
+/*
+ * Copyright (C) 2009-2017 Lightbend Inc. <https://www.lightbend.com>
+ */
+package play.libs.ws.ahc
+
+import akka.stream.Materializer
+import org.specs2.execute.Result
+import play.api.libs.ws.ahc.{ AhcConfigBuilder, AhcWSClientConfig, AhcWSClientConfigFactory => ScalaAhcWSClientConfigFactory }
+import play.shaded.ahc.org.asynchttpclient.DefaultAsyncHttpClient
+
+trait StandaloneWSClientSupport {
+
+  def materializer: Materializer
+
+  def withClient(config: AhcWSClientConfig = ScalaAhcWSClientConfigFactory.forConfig())(block: StandaloneAhcWSClient => Result): Result = {
+    val asyncHttpClient = new DefaultAsyncHttpClient(new AhcConfigBuilder(config).build())
+    val client = new StandaloneAhcWSClient(asyncHttpClient, materializer)
+    try {
+      block(client)
+    } finally {
+      client.close()
+    }
+  }
+}

--- a/integration-tests/src/test/scala/play/api/libs/ws/ahc/AhcCurlRequestLoggerSpec.scala
+++ b/integration-tests/src/test/scala/play/api/libs/ws/ahc/AhcCurlRequestLoggerSpec.scala
@@ -14,10 +14,10 @@ import uk.org.lidalia.slf4jtest.{ TestLogger, TestLoggerFactory }
 import scala.collection.JavaConverters._
 
 class AhcCurlRequestLoggerSpec(implicit val executionEnv: ExecutionEnv) extends Specification
-    with AkkaServerProvider
-    with StandaloneWSClientSupport
-    with FutureAwait
-    with DefaultBodyWritables {
+  with AkkaServerProvider
+  with StandaloneWSClientSupport
+  with FutureAwait
+  with DefaultBodyWritables {
 
   override def routes: Route = {
     import akka.http.scaladsl.server.Directives._

--- a/integration-tests/src/test/scala/play/api/libs/ws/ahc/AhcCurlRequestLoggerSpec.scala
+++ b/integration-tests/src/test/scala/play/api/libs/ws/ahc/AhcCurlRequestLoggerSpec.scala
@@ -1,0 +1,127 @@
+/*
+ * Copyright (C) 2009-2017 Lightbend Inc. <https://www.lightbend.com>
+ */
+package play.api.libs.ws.ahc
+
+import akka.http.scaladsl.server.Route
+import org.specs2.concurrent.{ ExecutionEnv, FutureAwait }
+import org.specs2.mutable.Specification
+import play.AkkaServerProvider
+import play.api.libs.ws.{ DefaultBodyWritables, EmptyBody, WSAuthScheme }
+import uk.org.lidalia.slf4jext.Level
+import uk.org.lidalia.slf4jtest.{ TestLogger, TestLoggerFactory }
+
+import scala.collection.JavaConverters._
+
+class AhcCurlRequestLoggerSpec(implicit val executionEnv: ExecutionEnv) extends Specification
+    with AkkaServerProvider
+    with StandaloneWSClientSupport
+    with FutureAwait
+    with DefaultBodyWritables {
+
+  override def routes: Route = {
+    import akka.http.scaladsl.server.Directives._
+    get {
+      complete("<h1>Say hello to akka-http</h1>")
+    } ~
+      post {
+        entity(as[String]) { echo =>
+          complete(echo)
+        }
+      }
+  }
+
+  // Level.OFF because we don't want to pollute the test output
+  def createTestLogger: TestLogger = new TestLoggerFactory(Level.OFF).getLogger("test-logger")
+
+  "Logging request as curl" should {
+
+    "be verbose" in withClient() { client =>
+
+      val testLogger = createTestLogger
+      val curlRequestLogger = AhcCurlRequestLogger(testLogger)
+
+      client.url(s"http://localhost:$testServerPort/")
+        .withRequestFilter(curlRequestLogger)
+        .get()
+        .awaitFor(defaultTimeout)
+
+      testLogger.getLoggingEvents.asScala.map(_.getMessage) must containMatch("--verbose")
+    }
+
+    "add all headers" in withClient() { client =>
+
+      val testLogger = createTestLogger
+      val curlRequestLogger = AhcCurlRequestLogger(testLogger)
+
+      client.url(s"http://localhost:$testServerPort/")
+        .addHttpHeaders("My-Header" -> "My-Header-Value")
+        .withRequestFilter(curlRequestLogger)
+        .get()
+        .awaitFor(defaultTimeout)
+
+      val messages = testLogger.getLoggingEvents.asScala.map(_.getMessage)
+
+      messages must containMatch("My-Header")
+      messages must containMatch("My-Header-Value")
+    }
+
+    "add method" in withClient() { client =>
+
+      val testLogger = createTestLogger
+      val curlRequestLogger = AhcCurlRequestLogger(testLogger)
+
+      client.url(s"http://localhost:$testServerPort/")
+        .withRequestFilter(curlRequestLogger)
+        .get()
+        .awaitFor(defaultTimeout)
+
+      testLogger.getLoggingEvents.asScala.map(_.getMessage) must containMatch("--request GET")
+    }
+
+    "add authorization header" in withClient() { client =>
+
+      val testLogger = createTestLogger
+      val curlRequestLogger = AhcCurlRequestLogger(testLogger)
+
+      client.url(s"http://localhost:$testServerPort/")
+        .withAuth("username", "password", WSAuthScheme.BASIC)
+        .withRequestFilter(curlRequestLogger)
+        .get()
+        .awaitFor(defaultTimeout)
+
+      testLogger.getLoggingEvents.asScala.map(_.getMessage) must containMatch("""--header "Authorization: Basic""")
+    }
+
+    "handle body" in {
+
+      "add when in memory" in withClient() { client =>
+
+        val testLogger = createTestLogger
+        val curlRequestLogger = AhcCurlRequestLogger(testLogger)
+
+        client.url(s"http://localhost:$testServerPort/")
+          .withBody("the-body")
+          .withRequestFilter(curlRequestLogger)
+          .get()
+          .awaitFor(defaultTimeout)
+
+        testLogger.getLoggingEvents.asScala.map(_.getMessage) must containMatch("the-body")
+      }
+
+      "do nothing for empty bodies" in withClient() { client =>
+
+        val testLogger = createTestLogger
+        val curlRequestLogger = AhcCurlRequestLogger(testLogger)
+
+        client.url(s"http://localhost:$testServerPort/")
+          .withBody(EmptyBody)
+          .withRequestFilter(curlRequestLogger)
+          .get()
+          .awaitFor(defaultTimeout)
+
+        testLogger.getLoggingEvents.asScala.map(_.getMessage) must not containMatch ("--data")
+      }
+    }
+  }
+}

--- a/integration-tests/src/test/scala/play/api/libs/ws/ahc/AhcCurlRequestLoggerSpec.scala
+++ b/integration-tests/src/test/scala/play/api/libs/ws/ahc/AhcCurlRequestLoggerSpec.scala
@@ -123,5 +123,31 @@ class AhcCurlRequestLoggerSpec(implicit val executionEnv: ExecutionEnv) extends 
         testLogger.getLoggingEvents.asScala.map(_.getMessage) must not containMatch ("--data")
       }
     }
+
+    "print complete curl command" in withClient() { client =>
+
+      val testLogger = createTestLogger
+      val curlRequestLogger = AhcCurlRequestLogger(testLogger)
+
+      client.url(s"http://localhost:$testServerPort/")
+        .withBody("the-body")
+        .addHttpHeaders("My-Header" -> "My-Header-Value")
+        .withAuth("username", "password", WSAuthScheme.BASIC)
+        .withRequestFilter(curlRequestLogger)
+        .get()
+        .awaitFor(defaultTimeout)
+
+      testLogger.getLoggingEvents.get(0).getMessage must beEqualTo(
+        s"""
+          |curl \\
+          |  --verbose \\
+          |  --request GET \\
+          |  --header "Authorization: Basic dXNlcm5hbWU6cGFzc3dvcmQ=" \\
+          |  --header 'My-Header: My-Header-Value' \\
+          |  --header 'Content-Type: text/plain' \\
+          |  --data 'the-body' \\
+          |  'http://localhost:$testServerPort/'
+        """.stripMargin.trim)
+    }
   }
 }

--- a/integration-tests/src/test/scala/play/api/libs/ws/ahc/AhcCurlRequestLoggerSpec.scala
+++ b/integration-tests/src/test/scala/play/api/libs/ws/ahc/AhcCurlRequestLoggerSpec.scala
@@ -90,7 +90,7 @@ class AhcCurlRequestLoggerSpec(implicit val executionEnv: ExecutionEnv) extends 
         .get()
         .awaitFor(defaultTimeout)
 
-      testLogger.getLoggingEvents.asScala.map(_.getMessage) must containMatch("""--header "Authorization: Basic""")
+      testLogger.getLoggingEvents.asScala.map(_.getMessage) must containMatch("""--header 'Authorization: Basic dXNlcm5hbWU6cGFzc3dvcmQ='""")
     }
 
     "handle body" in {
@@ -142,7 +142,7 @@ class AhcCurlRequestLoggerSpec(implicit val executionEnv: ExecutionEnv) extends 
           |curl \\
           |  --verbose \\
           |  --request GET \\
-          |  --header "Authorization: Basic dXNlcm5hbWU6cGFzc3dvcmQ=" \\
+          |  --header 'Authorization: Basic dXNlcm5hbWU6cGFzc3dvcmQ=' \\
           |  --header 'My-Header: My-Header-Value' \\
           |  --header 'Content-Type: text/plain' \\
           |  --data 'the-body' \\

--- a/integration-tests/src/test/scala/play/api/libs/ws/ahc/AhcWSClientSpec.scala
+++ b/integration-tests/src/test/scala/play/api/libs/ws/ahc/AhcWSClientSpec.scala
@@ -3,10 +3,10 @@
  */
 package play.api.libs.ws.ahc
 
+import akka.http.scaladsl.server.Route
 import akka.stream.scaladsl.Sink
 import akka.util.ByteString
 import org.specs2.concurrent.{ ExecutionEnv, FutureAwait }
-import org.specs2.execute.Result
 import org.specs2.matcher.FutureMatchers
 import org.specs2.mutable.Specification
 import play.AkkaServerProvider
@@ -16,20 +16,12 @@ import scala.concurrent._
 
 class AhcWSClientSpec(implicit val executionEnv: ExecutionEnv) extends Specification
   with AkkaServerProvider
+  with StandaloneWSClientSupport
   with FutureMatchers
   with FutureAwait
   with DefaultBodyReadables {
 
-  def withClient(config: AhcWSClientConfig = AhcWSClientConfigFactory.forConfig())(block: StandaloneAhcWSClient => Result): Result = {
-    val client = StandaloneAhcWSClient(config)
-    try {
-      block(client)
-    } finally {
-      client.close()
-    }
-  }
-
-  override val routes = {
+  override val routes: Route = {
     import akka.http.scaladsl.server.Directives._
     get {
       complete("<h1>Say hello to akka-http</h1>")

--- a/integration-tests/src/test/scala/play/api/libs/ws/ahc/AhcWSRequestFilterSpec.scala
+++ b/integration-tests/src/test/scala/play/api/libs/ws/ahc/AhcWSRequestFilterSpec.scala
@@ -10,17 +10,16 @@ import akka.http.scaladsl.server.Route
 import org.specs2.concurrent.ExecutionEnv
 import org.specs2.matcher.FutureMatchers
 import org.specs2.mutable.Specification
-import org.specs2.specification.AfterAll
 import play.AkkaServerProvider
 import play.api.libs.ws._
 
 import scala.collection.mutable
 
-class AhcWSRequestFilterSpec(implicit val executionEnv: ExecutionEnv) extends Specification with AkkaServerProvider with AfterAll with FutureMatchers {
-  import DefaultBodyReadables._
-
-  // Create the standalone WS client
-  val client = StandaloneAhcWSClient()
+class AhcWSRequestFilterSpec(implicit val executionEnv: ExecutionEnv) extends Specification
+  with AkkaServerProvider
+  with StandaloneWSClientSupport
+  with FutureMatchers
+  with DefaultBodyReadables {
 
   override val routes: Route = {
     import akka.http.scaladsl.server.Directives._
@@ -39,11 +38,6 @@ class AhcWSRequestFilterSpec(implicit val executionEnv: ExecutionEnv) extends Sp
     }
   }
 
-  override def afterAll: Unit = {
-    super.afterAll()
-    client.close()
-  }
-
   "with request filters" should {
 
     class CallbackRequestFilter(callList: mutable.Buffer[Int], value: Int) extends WSRequestFilter {
@@ -59,7 +53,7 @@ class AhcWSRequestFilterSpec(implicit val executionEnv: ExecutionEnv) extends Sp
       }
     }
 
-    "execute with adhoc request filter" in {
+    "work with adhoc request filter" in withClient() { client =>
       client.url(s"http://localhost:$testServerPort").withRequestFilter(WSRequestFilter { e =>
         WSRequestExecutor(r => e.apply(r.withQueryStringParameters("key" -> "some string")))
       }).get().map { response =>
@@ -67,7 +61,7 @@ class AhcWSRequestFilterSpec(implicit val executionEnv: ExecutionEnv) extends Sp
       }.await(retries = 0, timeout = defaultTimeout)
     }
 
-    "stream with adhoc request filter" in {
+    "stream with adhoc request filter" in withClient() { client =>
       client.url(s"http://localhost:$testServerPort").withRequestFilter(WSRequestFilter { e =>
         WSRequestExecutor(r => e.apply(r.withQueryStringParameters("key" -> "some string")))
       }).withMethod("GET").stream().map { response =>
@@ -75,7 +69,7 @@ class AhcWSRequestFilterSpec(implicit val executionEnv: ExecutionEnv) extends Sp
       }.await(retries = 0, timeout = defaultTimeout)
     }
 
-    "execute with one request filter" in {
+    "work with one request filter" in withClient() { client =>
       val callList = scala.collection.mutable.ArrayBuffer[Int]()
       client.url(s"http://localhost:$testServerPort")
         .withRequestFilter(new CallbackRequestFilter(callList, 1))
@@ -85,7 +79,7 @@ class AhcWSRequestFilterSpec(implicit val executionEnv: ExecutionEnv) extends Sp
         .await(retries = 0, timeout = defaultTimeout)
     }
 
-    "stream with one request filter" in {
+    "stream with one request filter" in withClient() { client =>
       val callList = scala.collection.mutable.ArrayBuffer[Int]()
       client.url(s"http://localhost:$testServerPort")
         .withRequestFilter(new CallbackRequestFilter(callList, 1))
@@ -95,7 +89,7 @@ class AhcWSRequestFilterSpec(implicit val executionEnv: ExecutionEnv) extends Sp
         .await(retries = 0, timeout = defaultTimeout)
     }
 
-    "execute with three request filters" in {
+    "work with three request filter" in withClient() { client =>
       val callList = scala.collection.mutable.ArrayBuffer[Int]()
       client.url(s"http://localhost:$testServerPort")
         .withRequestFilter(new CallbackRequestFilter(callList, 1))
@@ -107,7 +101,7 @@ class AhcWSRequestFilterSpec(implicit val executionEnv: ExecutionEnv) extends Sp
         .await(retries = 0, timeout = defaultTimeout)
     }
 
-    "stream with three request filters" in {
+    "stream with three request filters" in withClient() { client =>
       val callList = scala.collection.mutable.ArrayBuffer[Int]()
       client.url(s"http://localhost:$testServerPort")
         .withRequestFilter(new CallbackRequestFilter(callList, 1))
@@ -119,7 +113,7 @@ class AhcWSRequestFilterSpec(implicit val executionEnv: ExecutionEnv) extends Sp
         .await(retries = 0, timeout = defaultTimeout)
     }
 
-    "allow filters to modify the executing request" in {
+    "should allow filters to modify the request" in withClient () { client =>
       val appendedHeader = "X-Request-Id"
       val appendedHeaderValue = "someid"
       client.url(s"http://localhost:$testServerPort")
@@ -130,7 +124,7 @@ class AhcWSRequestFilterSpec(implicit val executionEnv: ExecutionEnv) extends Sp
         .await(retries = 0, timeout = defaultTimeout)
     }
 
-    "allow filters to modify the streaming request" in {
+    "allow filters to modify the streaming request" in withClient() { client =>
       val appendedHeader = "X-Request-Id"
       val appendedHeaderValue = "someid"
       client.url(s"http://localhost:$testServerPort")

--- a/integration-tests/src/test/scala/play/api/libs/ws/ahc/StandaloneWSClientSupport.scala
+++ b/integration-tests/src/test/scala/play/api/libs/ws/ahc/StandaloneWSClientSupport.scala
@@ -1,0 +1,21 @@
+/*
+ * Copyright (C) 2009-2017 Lightbend Inc. <https://www.lightbend.com>
+ */
+package play.api.libs.ws.ahc
+
+import akka.stream.Materializer
+import org.specs2.execute.Result
+
+trait StandaloneWSClientSupport {
+
+  def materializer: Materializer
+
+  def withClient(config: AhcWSClientConfig = AhcWSClientConfigFactory.forConfig())(block: StandaloneAhcWSClient => Result): Result = {
+    val client = StandaloneAhcWSClient(config)(materializer)
+    try {
+      block(client)
+    } finally {
+      client.close()
+    }
+  }
+}

--- a/integration-tests/src/test/scala/play/api/libs/ws/ahc/cache/CachingSpec.scala
+++ b/integration-tests/src/test/scala/play/api/libs/ws/ahc/cache/CachingSpec.scala
@@ -63,15 +63,3 @@ class CachingSpec(implicit val executionEnv: ExecutionEnv) extends Specification
     }
   }
 }
-
-class StubHttpCache(underlying: mutable.HashMap[EffectiveURIKey, ResponseEntry] = new mutable.HashMap()) extends Cache {
-
-  override def remove(key: EffectiveURIKey): Future[Unit] = Future.successful(underlying.remove(key))
-
-  override def put(key: EffectiveURIKey, entry: ResponseEntry): Future[Unit] = Future.successful(underlying.put(key, entry))
-
-  override def get(key: EffectiveURIKey): Future[Option[ResponseEntry]] = Future.successful(underlying.get(key))
-
-  override def close(): Unit = {}
-
-}

--- a/integration-tests/src/test/scala/play/api/libs/ws/ahc/cache/CachingSpec.scala
+++ b/integration-tests/src/test/scala/play/api/libs/ws/ahc/cache/CachingSpec.scala
@@ -17,10 +17,13 @@ import play.AkkaServerProvider
 import play.api.libs.ws.ahc._
 import play.shaded.ahc.org.asynchttpclient._
 
-import scala.collection.mutable
 import scala.concurrent.Future
 
-class CachingSpec(implicit val executionEnv: ExecutionEnv) extends Specification with AkkaServerProvider with AfterAll with FutureMatchers with Mockito {
+class CachingSpec(implicit val executionEnv: ExecutionEnv) extends Specification
+  with AkkaServerProvider
+  with AfterAll
+  with FutureMatchers
+  with Mockito {
 
   val asyncHttpClient: AsyncHttpClient = {
     val config = AhcWSClientConfigFactory.forClientConfig()

--- a/integration-tests/src/test/scala/play/libs/ws/ahc/AhcWSClientSpec.scala
+++ b/integration-tests/src/test/scala/play/libs/ws/ahc/AhcWSClientSpec.scala
@@ -17,11 +17,11 @@ import scala.concurrent.Future
 import scala.concurrent.duration._
 
 class AhcWSClientSpec(implicit val executionEnv: ExecutionEnv) extends Specification
-    with AkkaServerProvider
-    with StandaloneWSClientSupport
-    with FutureMatchers
-    with XMLBodyWritables
-    with XMLBodyReadables {
+  with AkkaServerProvider
+  with StandaloneWSClientSupport
+  with FutureMatchers
+  with XMLBodyWritables
+  with XMLBodyReadables {
 
   override val routes: Route = {
     import akka.http.scaladsl.server.Directives._

--- a/integration-tests/src/test/scala/play/libs/ws/ahc/AhcWSClientSpec.scala
+++ b/integration-tests/src/test/scala/play/libs/ws/ahc/AhcWSClientSpec.scala
@@ -5,37 +5,36 @@ package play.libs.ws.ahc
 
 import akka.actor.ActorSystem
 import akka.http.scaladsl.Http
+import akka.http.scaladsl.server.Route
 import akka.stream.ActorMaterializer
-import akka.stream.javadsl.{ Sink, Source }
+import akka.stream.javadsl.Sink
 import akka.util.ByteString
 import com.typesafe.config.ConfigFactory
 import org.specs2.concurrent.ExecutionEnv
 import org.specs2.matcher.FutureMatchers
 import org.specs2.mutable.Specification
 import org.specs2.specification.AfterAll
+import play.AkkaServerProvider
 import play.libs.ws._
 
 import scala.compat.java8.FutureConverters._
 import scala.concurrent.Future
 import scala.concurrent.duration._
 
-class AhcWSClientSpec(implicit executionEnv: ExecutionEnv) extends Specification with AfterAll with FutureMatchers with XMLBodyWritables with XMLBodyReadables {
-  val testServerPort = 49134
-
-  sequential
-
-  // Create Akka system for thread and streaming management
-  implicit val system = ActorSystem()
-  implicit val materializer = ActorMaterializer()
+class AhcWSClientSpec(implicit val executionEnv: ExecutionEnv) extends Specification
+  with AkkaServerProvider
+  with AfterAll
+  with FutureMatchers
+  with XMLBodyWritables
+  with XMLBodyReadables {
 
   // Create the standalone WS client with no cache
   val client = StandaloneAhcWSClient.create(
     AhcWSClientConfigFactory.forConfig(ConfigFactory.load, this.getClass.getClassLoader),
-    null,
     materializer
   )
 
-  private val route = {
+  override val routes: Route = {
     import akka.http.scaladsl.server.Directives._
     get {
       complete("<h1>Say hello to akka-http</h1>")
@@ -47,14 +46,9 @@ class AhcWSClientSpec(implicit executionEnv: ExecutionEnv) extends Specification
       }
   }
 
-  private val futureServer = {
-    Http().bindAndHandle(route, "localhost", testServerPort)
-  }
-
   override def afterAll = {
-    futureServer.foreach(_.unbind)
     client.close()
-    system.terminate()
+    super.afterAll()
   }
 
   "play.libs.ws.ahc.StandaloneAhcWSClient" should {

--- a/integration-tests/src/test/scala/play/libs/ws/ahc/AhcWSRequestFilterSpec.scala
+++ b/integration-tests/src/test/scala/play/libs/ws/ahc/AhcWSRequestFilterSpec.scala
@@ -91,7 +91,7 @@ class AhcWSRequestFilterSpec(implicit val executionEnv: ExecutionEnv) extends Sp
       }.await(retries = 0, timeout = 5.seconds)
     }
 
-    "allow filters to modify the streaming request" in {
+    "allow filters to modify the streaming request" in withClient() { client =>
       val appendedHeader = "X-Request-Id"
       val appendedHeaderValue = "someid"
       val responseFuture = FutureConverters.toScala(client.url(s"http://localhost:$testServerPort")

--- a/play-ahc-ws-standalone/src/main/java/play/libs/ws/ahc/AhcCurlRequestLogger.java
+++ b/play-ahc-ws-standalone/src/main/java/play/libs/ws/ahc/AhcCurlRequestLogger.java
@@ -12,6 +12,11 @@ import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 import java.util.Optional;
 
+/**
+ * Logs {@link StandaloneWSRequest} and pulls information into Curl format to an SLF4J logger.
+ *
+ * @see <a href="https://curl.haxx.se/">https://curl.haxx.se/</a>
+ */
 public class AhcCurlRequestLogger implements WSRequestFilter {
 
     private final org.slf4j.Logger logger;

--- a/play-ahc-ws-standalone/src/main/java/play/libs/ws/ahc/AhcCurlRequestLogger.java
+++ b/play-ahc-ws-standalone/src/main/java/play/libs/ws/ahc/AhcCurlRequestLogger.java
@@ -26,7 +26,7 @@ public class AhcCurlRequestLogger implements WSRequestFilter {
     }
 
     public AhcCurlRequestLogger() {
-        this(org.slf4j.LoggerFactory.getLogger("play.libs.ws.ahc.AhcCurlRequestLogger"));
+        this(org.slf4j.LoggerFactory.getLogger(AhcCurlRequestLogger.class));
     }
 
     @Override
@@ -61,6 +61,12 @@ public class AhcCurlRequestLogger implements WSRequestFilter {
                     b.append("  --header '").append(quote(name)).append(": ").append(quote(v)).append("'")
                      .append(" \\\n")
                 )
+        );
+
+        // cookies
+        request.getCookies().forEach(cookie ->
+                b.append("  --cookie '").append(cookie.getName()).append("=").append(cookie.getValue()).append("'")
+                 .append(" \\\n")
         );
 
         // body

--- a/play-ahc-ws-standalone/src/main/java/play/libs/ws/ahc/AhcCurlRequestLogger.java
+++ b/play-ahc-ws-standalone/src/main/java/play/libs/ws/ahc/AhcCurlRequestLogger.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright (C) 2009-2017 Lightbend Inc. <https://www.lightbend.com>
+ */
+package play.libs.ws.ahc;
+
+import play.libs.ws.*;
+import play.shaded.ahc.org.asynchttpclient.Request;
+import play.shaded.ahc.org.asynchttpclient.proxy.ProxyServer;
+import play.shaded.ahc.org.asynchttpclient.util.HttpUtils;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.Optional;
+
+public class AhcCurlRequestLogger implements WSRequestFilter {
+
+    private final org.slf4j.Logger logger;
+
+    public AhcCurlRequestLogger(org.slf4j.Logger logger) {
+        this.logger = logger;
+    }
+
+    public AhcCurlRequestLogger() {
+        this(org.slf4j.LoggerFactory.getLogger("play.libs.ws.ahc.AhcCurlRequestLogger"));
+    }
+
+    @Override
+    public WSRequestExecutor apply(WSRequestExecutor requestExecutor) {
+        return request -> {
+            logger.info(toCurl((StandaloneAhcWSRequest)request));
+            return requestExecutor.apply(request);
+        };
+    }
+
+    private String toCurl(StandaloneAhcWSRequest request) {
+        final StringBuilder b = new StringBuilder("curl \\\n");
+
+        // verbose, since it's a fair bet this is for debugging
+        b.append("  --verbose")
+         .append(" \\\n");
+
+        // method
+        b.append("  --request ").append(request.getMethod())
+         .append(" \\\n");
+
+        //authentication
+        request.getAuth().ifPresent(auth -> {
+            String encodedPasswd = Base64.getUrlEncoder().encodeToString((auth.getUsername() + ":" + auth.getPassword()).getBytes(StandardCharsets.US_ASCII));
+            b.append("  --header \"Authorization: Basic ").append(quote(encodedPasswd))
+             .append(" \\\n");
+        });
+
+        // headers
+        request.getHeaders().forEach((name, values) ->
+                values.forEach(v ->
+                    b.append("  --header '").append(quote(name)).append(": ").append(quote(v))
+                     .append(" \\\n")
+                )
+        );
+
+        // body
+        request.getBody().ifPresent(requestBody -> {
+            if (requestBody instanceof InMemoryBodyWritable) {
+                InMemoryBodyWritable inMemoryBody = (InMemoryBodyWritable) requestBody;
+
+                String charset = findCharset(request);
+                String bodyString = inMemoryBody.body().get().decodeString(charset);
+
+                b.append("  --data '").append(quote(bodyString)).append("'")
+                 .append(" \\\n");
+            } else {
+                throw new UnsupportedOperationException("Unsupported body type " + requestBody.getClass());
+            }
+        });
+
+        // pull out some underlying values from the request.  This creates a new Request
+        // but should be harmless.
+        Request ahcRequest = request.buildRequest();
+        ProxyServer proxyServer = ahcRequest.getProxyServer();
+        if (proxyServer != null) {
+            b.append("  --proxy ").append(proxyServer.getHost()).append(":").append(proxyServer.getPort())
+             .append(" \\\n");
+        }
+
+        // url
+        b.append("  '").append(quote(ahcRequest.getUrl())).append("'");
+        return b.toString();
+    }
+
+    private String findCharset(StandaloneAhcWSRequest request) {
+        return Optional.ofNullable(request.getContentType())
+                .map(contentType ->
+                    Optional.ofNullable(HttpUtils.parseCharset(contentType))
+                            .orElse(StandardCharsets.UTF_8).name()
+                ).orElse(StandardCharsets.UTF_8.name());
+    }
+
+    private String quote(String unsafe) {
+        return unsafe.replace("'", "'\\''");
+    }
+
+}

--- a/play-ahc-ws-standalone/src/main/java/play/libs/ws/ahc/AhcCurlRequestLogger.java
+++ b/play-ahc-ws-standalone/src/main/java/play/libs/ws/ahc/AhcCurlRequestLogger.java
@@ -51,7 +51,7 @@ public class AhcCurlRequestLogger implements WSRequestFilter {
         //authentication
         request.getAuth().ifPresent(auth -> {
             String encodedPasswd = Base64.getUrlEncoder().encodeToString((auth.getUsername() + ":" + auth.getPassword()).getBytes(StandardCharsets.US_ASCII));
-            b.append("  --header \"Authorization: Basic ").append(quote(encodedPasswd)).append("\"")
+            b.append("  --header 'Authorization: Basic ").append(quote(encodedPasswd)).append("'")
              .append(" \\\n");
         });
 

--- a/play-ahc-ws-standalone/src/main/java/play/libs/ws/ahc/AhcCurlRequestLogger.java
+++ b/play-ahc-ws-standalone/src/main/java/play/libs/ws/ahc/AhcCurlRequestLogger.java
@@ -46,14 +46,14 @@ public class AhcCurlRequestLogger implements WSRequestFilter {
         //authentication
         request.getAuth().ifPresent(auth -> {
             String encodedPasswd = Base64.getUrlEncoder().encodeToString((auth.getUsername() + ":" + auth.getPassword()).getBytes(StandardCharsets.US_ASCII));
-            b.append("  --header \"Authorization: Basic ").append(quote(encodedPasswd))
+            b.append("  --header \"Authorization: Basic ").append(quote(encodedPasswd)).append("\"")
              .append(" \\\n");
         });
 
         // headers
         request.getHeaders().forEach((name, values) ->
                 values.forEach(v ->
-                    b.append("  --header '").append(quote(name)).append(": ").append(quote(v))
+                    b.append("  --header '").append(quote(name)).append(": ").append(quote(v)).append("'")
                      .append(" \\\n")
                 )
         );

--- a/play-ahc-ws-standalone/src/main/java/play/libs/ws/ahc/StandaloneAhcWSRequest.java
+++ b/play-ahc-ws-standalone/src/main/java/play/libs/ws/ahc/StandaloneAhcWSRequest.java
@@ -20,8 +20,6 @@ import play.shaded.ahc.org.asynchttpclient.cookie.Cookie;
 import play.shaded.ahc.org.asynchttpclient.util.HttpUtils;
 
 import java.net.MalformedURLException;
-import java.net.URI;
-import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.ByteBuffer;
 import java.nio.charset.Charset;
@@ -268,6 +266,11 @@ public class StandaloneAhcWSRequest implements StandaloneWSRequest {
     }
 
     @Override
+    public Optional<BodyWritable> getBody() {
+        return Optional.ofNullable(this.bodyWritable);
+    }
+
+    @Override
     public Map<String, List<String>> getHeaders() {
         return new HashMap<>(this.headers);
     }
@@ -382,8 +385,8 @@ public class StandaloneAhcWSRequest implements StandaloneWSRequest {
     }
 
     Request buildRequest() {
-        boolean validate = true;
-        HttpHeaders possiblyModifiedHeaders = new DefaultHttpHeaders(validate);
+        final boolean validate = true;
+        final HttpHeaders possiblyModifiedHeaders = new DefaultHttpHeaders(validate);
         this.headers.forEach(possiblyModifiedHeaders::add);
 
         RequestBuilder builder = new RequestBuilder(method);
@@ -391,9 +394,7 @@ public class StandaloneAhcWSRequest implements StandaloneWSRequest {
         builder.setUrl(url);
         builder.setQueryParams(queryParameters);
 
-        if (bodyWritable == null) {
-            // do nothing
-        } else {
+        getBody().ifPresent(bodyWritable -> {
             // Detect and maybe add content type
             String contentType = possiblyModifiedHeaders.get(CONTENT_TYPE);
             if (contentType == null) {
@@ -447,7 +448,7 @@ public class StandaloneAhcWSRequest implements StandaloneWSRequest {
             } else {
                 throw new IllegalStateException("Unknown body writable: " + bodyWritable);
             }
-        }
+        });
 
         builder.setHeaders(possiblyModifiedHeaders);
 

--- a/play-ahc-ws-standalone/src/main/scala/play/api/libs/ws/ahc/AhcCurlRequestLogger.scala
+++ b/play-ahc-ws-standalone/src/main/scala/play/api/libs/ws/ahc/AhcCurlRequestLogger.scala
@@ -51,11 +51,10 @@ trait CurlFormat {
 
     //authentication
     request.auth match {
-      case Some((userName, password, WSAuthScheme.BASIC)) => {
+      case Some((userName, password, WSAuthScheme.BASIC)) =>
         val encodedPassword = Base64.getUrlEncoder.encodeToString(s"$userName:$password".getBytes(StandardCharsets.US_ASCII))
         b.append(s"""  --header 'Authorization: Basic ${quote(encodedPassword)}'""")
         b.append(" \\\n")
-      }
       case _ => Unit
     }
 
@@ -102,8 +101,13 @@ trait CurlFormat {
       Option(HttpUtils.parseCharset(ct)).getOrElse {
         StandardCharsets.UTF_8
       }.name()
-    }.getOrElse(HttpUtils.parseCharset("UTF-8").name())
+    }.getOrElse(StandardCharsets.UTF_8.name())
   }
 
   def quote(unsafe: String): String = unsafe.replace("'", "'\\''")
 }
+
+/**
+ * Java API.
+ */
+object JavaCurlFormat extends CurlFormat

--- a/play-ahc-ws-standalone/src/main/scala/play/api/libs/ws/ahc/AhcCurlRequestLogger.scala
+++ b/play-ahc-ws-standalone/src/main/scala/play/api/libs/ws/ahc/AhcCurlRequestLogger.scala
@@ -11,7 +11,7 @@ import play.api.libs.ws._
 import play.shaded.ahc.org.asynchttpclient.util.HttpUtils
 import play.api.libs.ws.EmptyBody
 /**
- * Logs [[StandaloneWSRequest]] and pulls information into Curl format to an SLF4J logger.
+ * Logs StandaloneWSRequest and pulls information into Curl format to an SLF4J logger.
  *
  * @param logger an SLF4J logger
  *

--- a/play-ahc-ws-standalone/src/main/scala/play/api/libs/ws/ahc/AhcCurlRequestLogger.scala
+++ b/play-ahc-ws-standalone/src/main/scala/play/api/libs/ws/ahc/AhcCurlRequestLogger.scala
@@ -11,9 +11,11 @@ import play.api.libs.ws._
 import play.shaded.ahc.org.asynchttpclient.util.HttpUtils
 import play.api.libs.ws.EmptyBody
 /**
- * Logs WSRequest and pulls information into Curl format to an SLF4J logger.
+ * Logs [[StandaloneWSRequest]] and pulls information into Curl format to an SLF4J logger.
  *
  * @param logger an SLF4J logger
+ *
+ * @see <a href="https://curl.haxx.se/">https://curl.haxx.se/</a>
  */
 class AhcCurlRequestLogger(logger: org.slf4j.Logger) extends WSRequestFilter with CurlFormat {
   def apply(executor: WSRequestExecutor): WSRequestExecutor = {
@@ -106,8 +108,3 @@ trait CurlFormat {
 
   def quote(unsafe: String): String = unsafe.replace("'", "'\\''")
 }
-
-/**
- * Java API.
- */
-object JavaCurlFormat extends CurlFormat

--- a/play-ahc-ws-standalone/src/main/scala/play/api/libs/ws/ahc/AhcCurlRequestLogger.scala
+++ b/play-ahc-ws-standalone/src/main/scala/play/api/libs/ws/ahc/AhcCurlRequestLogger.scala
@@ -69,6 +69,12 @@ trait CurlFormat {
         }
     }
 
+    // cookies
+    request.cookies.foreach { cookie =>
+      b.append(s"""  --cookie '${cookie.name}=${cookie.value}'""")
+      b.append(" \\\n")
+    }
+
     // body (note that this has only been checked for text, not binary)
     request.body match {
       case (InMemoryBody(byteString)) =>

--- a/play-ahc-ws-standalone/src/test/scala/play/libs/ws/ahc/AhcWSRequestSpec.scala
+++ b/play-ahc-ws-standalone/src/test/scala/play/libs/ws/ahc/AhcWSRequestSpec.scala
@@ -41,7 +41,7 @@ class AhcWSRequestSpec extends Specification with Mockito with DefaultBodyReadab
       "get method" in {
         val client = mock[StandaloneAhcWSClient]
         val req = new StandaloneAhcWSRequest(client, "http://playframework.com/", null)
-            .setMethod("POST")
+          .setMethod("POST")
 
         req.getMethod must be_==("POST")
       }

--- a/play-ws-standalone/src/main/java/play/libs/ws/BodyWritable.java
+++ b/play-ws-standalone/src/main/java/play/libs/ws/BodyWritable.java
@@ -3,8 +3,6 @@
  */
 package play.libs.ws;
 
-import java.util.function.Supplier;
-
 /**
  * Writes out a {@code WSBody<A>}
  *

--- a/play-ws-standalone/src/main/java/play/libs/ws/InMemoryBodyWritable.java
+++ b/play-ws-standalone/src/main/java/play/libs/ws/InMemoryBodyWritable.java
@@ -7,7 +7,9 @@ package play.libs.ws;
 import akka.util.ByteString;
 
 /**
- * A body writable that takes a bytestring with InMemoryBody.
+ * A body writable that takes a ByteString with InMemoryBody.
+ *
+ * @see ByteString
  */
 public class InMemoryBodyWritable implements BodyWritable<ByteString> {
     private final InMemoryBody body;

--- a/play-ws-standalone/src/main/java/play/libs/ws/StandaloneWSRequest.java
+++ b/play-ws-standalone/src/main/java/play/libs/ws/StandaloneWSRequest.java
@@ -361,6 +361,11 @@ public interface StandaloneWSRequest {
     }
 
     /**
+     * @return the body of the request.
+     */
+    Optional<BodyWritable> getBody();
+
+    /**
      * @return the headers (a copy to prevent side-effects). This has not passed through an internal request builder and so will not be signed.
      */
     Map<String, List<String>> getHeaders();

--- a/play-ws-standalone/src/main/java/play/libs/ws/StandaloneWSRequest.java
+++ b/play-ws-standalone/src/main/java/play/libs/ws/StandaloneWSRequest.java
@@ -5,7 +5,6 @@ package play.libs.ws;
 
 
 import java.time.Duration;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -243,7 +242,9 @@ public interface StandaloneWSRequest {
      * @param password the basic auth password
      * @return the modified WSRequest.
      */
-    StandaloneWSRequest setAuth(String username, String password);
+    default StandaloneWSRequest setAuth(String username, String password) {
+        return setAuth(new WSAuthInfo(username, password, WSAuthScheme.BASIC));
+    }
 
     /**
      * Sets the authentication header for the current request.
@@ -253,7 +254,18 @@ public interface StandaloneWSRequest {
      * @param scheme   authentication scheme
      * @return the modified WSRequest.
      */
-    StandaloneWSRequest setAuth(String username, String password, WSAuthScheme scheme);
+    default StandaloneWSRequest setAuth(String username, String password, WSAuthScheme scheme) {
+        return setAuth(new WSAuthInfo(username, password, scheme));
+    }
+
+    /**
+     * Sets the authentication header for the current request.
+     *
+     * @param authInfo the authentication information.
+     *
+     * @return the modified request.
+     */
+    StandaloneWSRequest setAuth(WSAuthInfo authInfo);
 
     /**
      * Sets an (OAuth) signature calculator.
@@ -380,17 +392,30 @@ public interface StandaloneWSRequest {
     /**
      * @return the auth username, null if not an authenticated request.
      */
-    String getUsername();
+    default String getUsername() {
+        return getAuth().map(WSAuthInfo::getUsername).orElse(null);
+    }
 
     /**
      * @return the auth password, null if not an authenticated request
      */
-    String getPassword();
+    default String getPassword() {
+        return getAuth().map(WSAuthInfo::getPassword).orElse(null);
+    }
 
     /**
      * @return the auth scheme, null if not an authenticated request.
      */
-    WSAuthScheme getScheme();
+    default WSAuthScheme getScheme() {
+        return getAuth().map(WSAuthInfo::getScheme).orElse(null);
+    }
+
+    /**
+     * @return get auth information if present.
+     *
+     * @see WSAuthInfo
+     */
+    Optional<WSAuthInfo> getAuth();
 
     /**
      * @return the signature calculator (example: OAuth), null if none is set.

--- a/play-ws-standalone/src/main/java/play/libs/ws/WSAuthInfo.java
+++ b/play-ws-standalone/src/main/java/play/libs/ws/WSAuthInfo.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C) 2009-2017 Lightbend Inc. <https://www.lightbend.com>
+ */
+package play.libs.ws;
+
+/**
+ * Holds information for request authentication.
+ *
+ * @see WSAuthScheme
+ * @see StandaloneWSRequest#setAuth(String)
+ * @see <a href="https://tools.ietf.org/html/rfc7235">RFC 7235 - Hypertext Transfer Protocol (HTTP/1.1): Authentication</a>
+ */
+public class WSAuthInfo {
+
+    private final String username;
+    private final String password;
+    private final WSAuthScheme scheme;
+
+    public WSAuthInfo(String username, String password, WSAuthScheme scheme) {
+        this.username = username;
+        this.password = password;
+        this.scheme = scheme;
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+
+    public WSAuthScheme getScheme() {
+        return scheme;
+    }
+}


### PR DESCRIPTION
## Purpose

This adds a Java version of curl-logger request filter that is present in the Scala APIs.

To do that, a number of changes we made in the Java version of `StandaloneWSRequest` so that we can access request information and create the `curl` command.

Also, tests were added to both Java and Scala version of the request filter.