### PR TITLE
Fix problem with Java API getBodyAsSource

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,9 @@
 import Dependencies._
 import com.typesafe.sbt.SbtScalariform.ScalariformKeys
+
+import com.typesafe.tools.mima.core._
 import com.typesafe.tools.mima.plugin.MimaPlugin.mimaDefaultSettings
+
 import sbtassembly.AssemblyPlugin.autoImport._
 import sbtassembly.MergeStrategy
 
@@ -22,7 +25,13 @@ val javacSettings = Seq(
   "-Xlint:unchecked"
 )
 
-lazy val commonSettings = mimaDefaultSettings ++ Seq(
+lazy val mimaSettings = mimaDefaultSettings ++ Seq(
+  mimaBinaryIssueFilters ++= Seq(
+    ProblemFilters.exclude[DirectMissingMethodProblem]("play.libs.ws.ahc.StandaloneAhcWSResponse.getBodyAsSource")
+  )
+)
+
+lazy val commonSettings = mimaSettings ++ Seq(
   organization := "com.typesafe.play",
   scalaVersion := "2.12.2",
   crossScalaVersions := Seq("2.12.2", "2.11.11"),

--- a/integration-tests/src/test/java/play/libs/ws/ahc/ByteStringRequestTest.java
+++ b/integration-tests/src/test/java/play/libs/ws/ahc/ByteStringRequestTest.java
@@ -4,22 +4,29 @@
 
 package play.libs.ws.ahc;
 
+import akka.Done;
+import akka.actor.ActorSystem;
+import akka.stream.ActorMaterializer;
+import akka.stream.Materializer;
+import akka.stream.javadsl.Sink;
+import akka.stream.javadsl.Source;
+import akka.util.ByteString;
+
 import org.junit.Test;
+
 import play.libs.ws.DefaultBodyReadables;
 import play.shaded.ahc.org.asynchttpclient.Response;
 
-import java.nio.charset.StandardCharsets;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.ExecutionException;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.*;
 
-/**
- *
- */
 public class ByteStringRequestTest implements DefaultBodyReadables {
 
     @Test
-    public void testBody() {
+    public void testGetBodyAsString() {
         final Response ahcResponse = mock(Response.class);
         final StandaloneAhcWSResponse response = new StandaloneAhcWSResponse(ahcResponse);
         when(ahcResponse.getContentType()).thenReturn(null);
@@ -30,48 +37,37 @@ public class ByteStringRequestTest implements DefaultBodyReadables {
         assertThat(body).isEqualTo("wsBody");
     }
 
-    public void testBodyAsDefault() {
+    @Test
+    public void testGetBodyAsBytes() {
         final Response ahcResponse = mock(Response.class);
         final StandaloneAhcWSResponse response = new StandaloneAhcWSResponse(ahcResponse);
         when(ahcResponse.getContentType()).thenReturn(null);
-        when(ahcResponse.getResponseBody()).thenReturn("wsBody");
+        when(ahcResponse.getResponseBodyAsBytes()).thenReturn("wsBody".getBytes());
 
-        final String body = response.getBody();
-        verify(ahcResponse, times(1)).getResponseBody();
+        final String body = response.getBodyAsBytes().utf8String();
+        verify(ahcResponse, times(1)).getResponseBodyAsBytes();
         assertThat(body).isEqualTo("wsBody");
     }
-//
-//        "get the getBody as UTF-8 by default when no content type" in {
-//            val ahcResponse = mock[Response]
-//            val response = new StandaloneAhcWSResponse(ahcResponse)
-//            ahcResponse.getContentType returns null
-//            ahcResponse.getResponseBody(any) returns "wsBody"
-//
-//            val body = response.getBody(string())
-//            there was one(ahcResponse).getResponseBody(StandardCharsets.UTF_8)
-//            body must be_==("wsBody")
-//        }
 
-//        "get the getBody as ISO_8859_1 by default when content type text/plain without charset" in {
-//            val ahcResponse = mock[Response]
-//            val response = new StandaloneAhcWSResponse(ahcResponse)
-//            ahcResponse.getContentType returns "text/plain"
-//            ahcResponse.getResponseBody(any) returns "wsBody"
-//
-//            val body = response.getBody(string())
-//            there was one(ahcResponse).getResponseBody(StandardCharsets.ISO_8859_1)
-//            body must be_==("wsBody")
-//        }
-//
-//        "get the getBody as given charset when content type has explicit charset" in {
-//            val ahcResponse = mock[Response]
-//            val response = new StandaloneAhcWSResponse(ahcResponse)
-//            ahcResponse.getContentType returns "text/plain; charset=UTF-16"
-//            ahcResponse.getResponseBody(any) returns "wsBody"
-//
-//            val body = response.getBody(string())
-//            there was one(ahcResponse).getResponseBody(StandardCharsets.UTF_16)
-//            body must be_==("wsBody")
-//        }
+    @Test
+    public void testGetBodyAsSource() throws ExecutionException, InterruptedException {
+        final Response ahcResponse = mock(Response.class);
+        final StandaloneAhcWSResponse response = new StandaloneAhcWSResponse(ahcResponse);
+        when(ahcResponse.getContentType()).thenReturn(null);
+        when(ahcResponse.getResponseBodyAsBytes()).thenReturn("wsBody".getBytes());
 
+        final StringBuilder result = new StringBuilder();
+
+        final ActorSystem system = ActorSystem.create("test-body-as-bytes");
+        final Materializer materializer = ActorMaterializer.create(system);
+
+        Source<String, ?> bodyAsSource = response.getBodyAsSource().map(ByteString::utf8String);
+        Sink<String, CompletionStage<Done>> appender = Sink.foreach(result::append);
+
+        // run and wait for completion
+        bodyAsSource.runWith(appender, materializer).toCompletableFuture().get();
+
+        verify(ahcResponse, times(1)).getResponseBodyAsBytes();
+        assertThat(result.toString()).isEqualTo("wsBody");
+    }
 }

--- a/play-ahc-ws-standalone/src/main/java/play/libs/ws/ahc/StandaloneAhcWSResponse.java
+++ b/play-ahc-ws-standalone/src/main/java/play/libs/ws/ahc/StandaloneAhcWSResponse.java
@@ -4,16 +4,12 @@
 
 package play.libs.ws.ahc;
 
-import akka.stream.javadsl.Source;
 import akka.util.ByteString;
-import org.reactivestreams.Publisher;
 import play.libs.ws.BodyReadable;
 import play.libs.ws.StandaloneWSResponse;
 import play.libs.ws.WSCookie;
 import play.libs.ws.WSCookieBuilder;
 import play.shaded.ahc.io.netty.handler.codec.http.HttpHeaders;
-import play.shaded.ahc.org.asynchttpclient.HttpResponseBodyPart;
-import play.shaded.ahc.org.asynchttpclient.Response;
 import play.shaded.ahc.org.asynchttpclient.cookie.Cookie;
 
 import java.net.URI;
@@ -110,20 +106,12 @@ public class StandaloneAhcWSResponse implements StandaloneWSResponse {
         // https://tools.ietf.org/html/rfc7231#appendix-B
         // The default charset of ISO-8859-1 for text media types has been
         // removed; the default is now whatever the media type definition says.
-        Response underlying = (Response) getUnderlying();
-        return underlying.getResponseBody();
+        return this.ahcResponse.getResponseBody();
     }
 
     @Override
     public ByteString getBodyAsBytes() {
-        Response underlying = (Response) getUnderlying();
-        return ByteString.fromArray(underlying.getResponseBodyAsBytes());
-    }
-
-    @Override
-    public Source<ByteString, ?> getBodyAsSource() {
-        @SuppressWarnings("unchecked") Publisher<HttpResponseBodyPart> publisher = (Publisher<HttpResponseBodyPart>) getUnderlying();
-        return Source.fromPublisher(publisher).map(bodyPart -> ByteString.fromArray(bodyPart.getBodyPartBytes()));
+        return ByteString.fromArray(this.ahcResponse.getResponseBodyAsBytes());
     }
 
     @Override

--- a/play-ahc-ws-standalone/src/main/java/play/libs/ws/ahc/StreamedResponse.java
+++ b/play-ahc-ws-standalone/src/main/java/play/libs/ws/ahc/StreamedResponse.java
@@ -14,7 +14,6 @@ import play.shaded.ahc.org.asynchttpclient.HttpResponseBodyPart;
 import scala.collection.Seq;
 
 import java.net.URI;
-import java.nio.charset.Charset;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;

--- a/play-ws-standalone/src/main/java/play/libs/ws/StandaloneWSResponse.java
+++ b/play-ws-standalone/src/main/java/play/libs/ws/StandaloneWSResponse.java
@@ -122,6 +122,15 @@ public interface StandaloneWSResponse {
      *
      * Note that this is only usable with a streaming request:
      *
+     * <pre>
+     * {@code
+     * wsClient.url("https://playframework.com")
+     *         .stream() // this returns a CompletionStage<StandaloneWSResponse>
+     *         .thenApply(StandaloneWSResponse::getBodyAsSource);
+     * }
+     * </pre>
      */
-    Source<ByteString, ?> getBodyAsSource();
+    default Source<ByteString, ?> getBodyAsSource() {
+        return Source.single(getBodyAsBytes());
+    }
 }


### PR DESCRIPTION
## Fixes

Fixes #175.

## Purpose

While this is supposed to be used with streamed responses we need to ensure the regular version also works. This changes the Java implementation to works as the Scala one.