### PR TITLE
Fix NPE in response.body when content type lacks charset

### DIFF
--- a/play-ahc-ws-standalone/src/main/scala/play/api/libs/ws/ahc/cache/CacheableResponse.scala
+++ b/play-ahc-ws-standalone/src/main/scala/play/api/libs/ws/ahc/cache/CacheableResponse.scala
@@ -113,7 +113,11 @@ case class CacheableResponse(
   }
 
   private def computeCharset(charset: Charset): Charset = {
-    Option(charset).orElse(Option(getContentType).map(parseCharset)).getOrElse(DEFAULT_CHARSET)
+    Option(charset)
+      .orElse(
+        Option(getContentType)
+          .flatMap(ct => Option(parseCharset(ct)))
+      ).getOrElse(DEFAULT_CHARSET)
   }
 
   @throws(classOf[IOException])

--- a/play-ahc-ws-standalone/src/test/scala/play/api/libs/ws/ahc/cache/CacheAsyncHandlerSpec.scala
+++ b/play-ahc-ws-standalone/src/test/scala/play/api/libs/ws/ahc/cache/CacheAsyncHandlerSpec.scala
@@ -1,8 +1,6 @@
 /*
  * Copyright (C) 2009-2017 Lightbend Inc. <https://www.lightbend.com>
- *
  */
-
 package play.api.libs.ws.ahc.cache
 
 import org.specs2.mutable.Specification

--- a/play-ahc-ws-standalone/src/test/scala/play/api/libs/ws/ahc/cache/CacheableResponseSpec.scala
+++ b/play-ahc-ws-standalone/src/test/scala/play/api/libs/ws/ahc/cache/CacheableResponseSpec.scala
@@ -4,7 +4,7 @@
 package play.api.libs.ws.ahc.cache
 
 import org.specs2.mutable.Specification
-import play.shaded.ahc.io.netty.handler.codec.http.HttpHeaders
+import play.shaded.ahc.io.netty.handler.codec.http.HttpHeaders.Names._
 
 class CacheableResponseSpec extends Specification {
 
@@ -13,7 +13,7 @@ class CacheableResponseSpec extends Specification {
     "get body" in {
 
       "when it is text/plain" in {
-        val response = CacheableResponse(200, "https://playframework.com/", "PlayFramework Homepage").withHeaders(HttpHeaders.Names.CONTENT_TYPE -> "text/plain")
+        val response = CacheableResponse(200, "https://playframework.com/", "PlayFramework Homepage").withHeaders(CONTENT_TYPE -> "text/plain")
         response.getResponseBody must beEqualTo("PlayFramework Homepage")
         response.getContentType must beEqualTo("text/plain")
       }

--- a/play-ahc-ws-standalone/src/test/scala/play/api/libs/ws/ahc/cache/CacheableResponseSpec.scala
+++ b/play-ahc-ws-standalone/src/test/scala/play/api/libs/ws/ahc/cache/CacheableResponseSpec.scala
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2009-2017 Lightbend Inc. <https://www.lightbend.com>
+ */
+package play.api.libs.ws.ahc.cache
+
+import org.specs2.mutable.Specification
+import play.shaded.ahc.io.netty.handler.codec.http.HttpHeaders
+
+class CacheableResponseSpec extends Specification {
+
+  "CacheableResponse" should {
+
+    "get body" in {
+
+      "when it is text/plain" in {
+        val response = CacheableResponse(200, "https://playframework.com/", "PlayFramework Homepage").withHeaders(HttpHeaders.Names.CONTENT_TYPE -> "text/plain")
+        response.getResponseBody must beEqualTo("PlayFramework Homepage")
+        response.getContentType must beEqualTo("text/plain")
+      }
+
+      "when it is application/json" in {
+        val response = CacheableResponse(200, "https://playframework.com/", """{ "a": "b" }""").withHeaders("Content-Type" -> "application/json")
+        response.getResponseBody must beEqualTo("""{ "a": "b" }""")
+        response.getContentType must beEqualTo("application/json")
+      }
+
+      "when it is application/json; charset=utf-8" in {
+        val response = CacheableResponse(200, "https://playframework.com/", """{ "a": "b" }""").withHeaders("Content-Type" -> "application/json; charset=utf-8")
+        response.getResponseBody must beEqualTo("""{ "a": "b" }""")
+        response.getContentType must beEqualTo("application/json; charset=utf-8")
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Fixes

Fixes #182.

## Purpose

Avoid a `NullPointerException` when the `Content-Type` has no charset defined and response cache is enabled.