### PR TITLE
Catch IllegalArgumentException for invalid URI from AHC

### DIFF
--- a/integration-tests/src/test/scala/play/api/libs/ws/ahc/AhcWSClientSpec.scala
+++ b/integration-tests/src/test/scala/play/api/libs/ws/ahc/AhcWSClientSpec.scala
@@ -44,13 +44,13 @@ class AhcWSClientSpec(implicit val executionEnv: ExecutionEnv) extends Specifica
   "url" should {
     "throw an exception on invalid url" in {
       withClient() { client =>
-        { client.url("localhost") } must throwA[Throwable]
+        { client.url("localhost") } must throwAn[IllegalArgumentException]
       }
     }
 
     "not throw exception on valid url" in {
       withClient() { client =>
-        { client.url(s"http://localhost:$testServerPort") } must not(throwA[Throwable])
+        { client.url(s"http://localhost:$testServerPort") } must not(throwAn[IllegalArgumentException])
       }
     }
   }


### PR DESCRIPTION
Now AHC can return an `IllegalArgumentException` if a URI is invalid, so catch that and properly pass it on to the user.

Also `transform` expects a total function or else it will result in a `MatchError`.