### PR TITLE
Remove implicits from BodyReadable and BodyWritable

### DIFF
--- a/play-ahc-ws-standalone/src/test/scala/play/api/libs/ws/ahc/AhcWSRequestSpec.scala
+++ b/play-ahc-ws-standalone/src/test/scala/play/api/libs/ws/ahc/AhcWSRequestSpec.scala
@@ -21,7 +21,7 @@ import scala.collection.JavaConverters._
 import scala.concurrent.duration._
 import scala.language.implicitConversions
 
-class AhcWSRequestSpec extends Specification with Mockito with AfterAll {
+class AhcWSRequestSpec extends Specification with Mockito with AfterAll with DefaultBodyReadables with DefaultBodyWritables {
 
   sequential
 

--- a/play-ahc-ws-standalone/src/test/scala/play/api/libs/ws/ahc/AhcWSResponseSpec.scala
+++ b/play-ahc-ws-standalone/src/test/scala/play/api/libs/ws/ahc/AhcWSResponseSpec.scala
@@ -8,7 +8,7 @@ import java.util
 import akka.util.ByteString
 import org.specs2.mock.Mockito
 import org.specs2.mutable.Specification
-import play.api.libs.ws.WSCookie
+import play.api.libs.ws._
 import play.shaded.ahc.io.netty.handler.codec.http.DefaultHttpHeaders
 import play.shaded.ahc.org.asynchttpclient.cookie.{ Cookie => AHCCookie }
 import play.shaded.ahc.org.asynchttpclient.{ Response => AHCResponse }
@@ -16,7 +16,7 @@ import play.shaded.ahc.org.asynchttpclient.{ Response => AHCResponse }
 /**
  *
  */
-class AhcWSResponseSpec extends Specification with Mockito {
+class AhcWSResponseSpec extends Specification with Mockito with DefaultBodyReadables with DefaultBodyWritables {
 
   "Ahc WS Response" should {
     "get cookies from an AHC response" in {

--- a/play-ahc-ws-standalone/src/test/scala/play/libs/ws/ahc/AhcWSRequestSpec.scala
+++ b/play-ahc-ws-standalone/src/test/scala/play/libs/ws/ahc/AhcWSRequestSpec.scala
@@ -17,7 +17,7 @@ import play.shaded.ahc.org.asynchttpclient.{ Request, RequestBuilderBase, Signat
 import scala.collection.JavaConverters._
 import scala.compat.java8.OptionConverters._
 
-class AhcWSRequestSpec extends Specification with Mockito with DefaultBodyWritables {
+class AhcWSRequestSpec extends Specification with Mockito with DefaultBodyReadables with DefaultBodyWritables {
 
   "AhcWSRequest" should {
 

--- a/play-ahc-ws-standalone/src/test/scala/play/libs/ws/ahc/AhcWSResponseSpec.scala
+++ b/play-ahc-ws-standalone/src/test/scala/play/libs/ws/ahc/AhcWSResponseSpec.scala
@@ -7,14 +7,14 @@ import java.nio.charset.StandardCharsets
 
 import org.specs2.mock.Mockito
 import org.specs2.mutable._
-import play.libs.ws.DefaultBodyReadables
+import play.libs.ws._
 import play.shaded.ahc.io.netty.handler.codec.http.DefaultHttpHeaders
 import play.shaded.ahc.org.asynchttpclient.Response
 
 import scala.collection.JavaConverters._
 import scala.compat.java8.OptionConverters._
 
-class AhcWSResponseSpec extends Specification with Mockito with DefaultBodyReadables {
+class AhcWSResponseSpec extends Specification with Mockito with DefaultBodyReadables with DefaultBodyWritables {
 
   private val emptyMap = new java.util.HashMap[String, java.util.Collection[String]]
 

--- a/play-ws-standalone/src/main/scala/play/api/libs/ws/Body.scala
+++ b/play-ws-standalone/src/main/scala/play/api/libs/ws/Body.scala
@@ -35,7 +35,7 @@ case class SourceBody(source: Source[ByteString, _]) extends WSBody
 )
 class BodyReadable[+R](val transform: StandaloneWSResponse => R)
 
-object BodyReadable extends DefaultBodyReadables {
+object BodyReadable {
   def apply[R](transform: StandaloneWSResponse => R): BodyReadable[R] = new BodyReadable[R](transform)
 }
 
@@ -49,7 +49,7 @@ class BodyWritable[-A](val transform: A => WSBody, val contentType: String) {
   def map[B](f: B => A): BodyWritable[B] = new BodyWritable(b => transform(f(b)), contentType)
 }
 
-object BodyWritable extends DefaultBodyWritables {
+object BodyWritable {
   def apply[A](transform: (A => WSBody), contentType: String): BodyWritable[A] =
     new BodyWritable(transform, contentType)
 }


### PR DESCRIPTION
This is a continuation of #188.

After trying to integrate with Play I realized that it's annoying to have these implicits in the companion object. That means to make it compatible with the non-standalone WS wrapper we have to do hacks to maintain backwards compatibility, in order to keep the methods on the `ws` package object (for source and binary compatibility) while also avoiding implicit resolution conflicts between the implicits on the companion and the implicits on the package object.

I also noticed that we actually tell people to import the readables and writables in the readme: https://github.com/playframework/play-ws#scala

Note that we have not yet done a release with the implicits in tho companion object yet so there are no compatibility issues with this PR specifically for play-ws-standalone.