### PR TITLE
Add consistent String body handling and documentation

### DIFF
--- a/integration-tests/src/test/java/play/libs/ws/ahc/ByteStringRequestTest.java
+++ b/integration-tests/src/test/java/play/libs/ws/ahc/ByteStringRequestTest.java
@@ -17,6 +17,7 @@ import org.junit.Test;
 import play.libs.ws.DefaultBodyReadables;
 import play.shaded.ahc.org.asynchttpclient.Response;
 
+import java.nio.charset.StandardCharsets;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ExecutionException;
 
@@ -30,11 +31,37 @@ public class ByteStringRequestTest implements DefaultBodyReadables {
         final Response ahcResponse = mock(Response.class);
         final StandaloneAhcWSResponse response = new StandaloneAhcWSResponse(ahcResponse);
         when(ahcResponse.getContentType()).thenReturn(null);
-        when(ahcResponse.getResponseBody()).thenReturn("wsBody");
+        when(ahcResponse.getResponseBody(StandardCharsets.UTF_8)).thenReturn("wsBody");
 
         final String body = response.getBody();
-        verify(ahcResponse, times(1)).getResponseBody();
+        verify(ahcResponse, times(1)).getResponseBody(any());
         assertThat(body).isEqualTo("wsBody");
+    }
+
+    @Test
+    public void testGetBodyAsString_applicationJson() {
+        final Response ahcResponse = mock(Response.class);
+        final String bodyString = "{\"foo\": \"☺\"}";
+        final StandaloneAhcWSResponse response = new StandaloneAhcWSResponse(ahcResponse);
+        when(ahcResponse.getContentType()).thenReturn("application/json");
+        when(ahcResponse.getResponseBody(StandardCharsets.UTF_8)).thenReturn(bodyString);
+
+        final String body = response.getBody();
+        verify(ahcResponse, times(1)).getResponseBody(any());
+        assertThat(body).isEqualTo("{\"foo\": \"☺\"}");
+    }
+
+    @Test
+    public void testGetBodyAsString_textHtml() {
+        final Response ahcResponse = mock(Response.class);
+        final StandaloneAhcWSResponse response = new StandaloneAhcWSResponse(ahcResponse);
+        final String bodyString = "<html><body>☺</body></html>";
+        when(ahcResponse.getContentType()).thenReturn("text/html");
+        when(ahcResponse.getResponseBody(StandardCharsets.ISO_8859_1)).thenReturn(bodyString);
+
+        final String body = response.getBody();
+        verify(ahcResponse, times(1)).getResponseBody(any());
+        assertThat(body).isEqualTo(bodyString);
     }
 
     @Test

--- a/integration-tests/src/test/scala/play/api/libs/ws/ahc/XMLRequestSpec.scala
+++ b/integration-tests/src/test/scala/play/api/libs/ws/ahc/XMLRequestSpec.scala
@@ -4,6 +4,8 @@
 
 package play.api.libs.ws.ahc
 
+import java.nio.charset.StandardCharsets
+
 import akka.actor.ActorSystem
 import akka.stream.ActorMaterializer
 import akka.util.ByteString
@@ -46,7 +48,8 @@ class XMLRequestSpec extends Specification with Mockito with AfterAll {
     import XMLBodyReadables._
 
     val ahcResponse = mock[AHCResponse]
-    ahcResponse.getResponseBody returns "<hello><test></test></hello>"
+    ahcResponse.getContentType() returns "application/xml"
+    ahcResponse.getResponseBody(StandardCharsets.UTF_8) returns "<hello><test></test></hello>"
     val response = new StandaloneAhcWSResponse(ahcResponse)
 
     val expected = XML.parser.loadString("<hello><test></test></hello>")

--- a/play-ahc-ws-standalone/src/main/java/play/libs/ws/ahc/StandaloneAhcWSResponse.java
+++ b/play-ahc-ws-standalone/src/main/java/play/libs/ws/ahc/StandaloneAhcWSResponse.java
@@ -5,6 +5,7 @@
 package play.libs.ws.ahc;
 
 import akka.util.ByteString;
+import play.api.libs.ws.ahc.AhcWSUtils;
 import play.libs.ws.BodyReadable;
 import play.libs.ws.StandaloneWSResponse;
 import play.libs.ws.WSCookie;
@@ -102,11 +103,7 @@ public class StandaloneAhcWSResponse implements StandaloneWSResponse {
 
     @Override
     public String getBody() {
-        // https://tools.ietf.org/html/rfc7231#section-3.1.1.3
-        // https://tools.ietf.org/html/rfc7231#appendix-B
-        // The default charset of ISO-8859-1 for text media types has been
-        // removed; the default is now whatever the media type definition says.
-        return this.ahcResponse.getResponseBody();
+        return AhcWSUtils.getResponseBody(ahcResponse);
     }
 
     @Override

--- a/play-ahc-ws-standalone/src/main/java/play/libs/ws/ahc/StreamedResponse.java
+++ b/play-ahc-ws-standalone/src/main/java/play/libs/ws/ahc/StreamedResponse.java
@@ -6,6 +6,7 @@ package play.libs.ws.ahc;
 import akka.stream.javadsl.Source;
 import akka.util.ByteString;
 import org.reactivestreams.Publisher;
+import play.api.libs.ws.ahc.AhcWSUtils;
 import play.libs.ws.BodyReadable;
 import play.libs.ws.StandaloneWSResponse;
 import play.libs.ws.WSCookie;
@@ -93,7 +94,7 @@ public class StreamedResponse implements StandaloneWSResponse, CookieBuilder {
 
     @Override
     public String getBody() {
-        return getBodyAsBytes().utf8String();
+        return getBodyAsBytes().decodeString(AhcWSUtils.getCharset(getContentType()));
     }
 
     @Override

--- a/play-ahc-ws-standalone/src/main/scala/play/api/libs/ws/ahc/AhcWSUtils.scala
+++ b/play-ahc-ws-standalone/src/main/scala/play/api/libs/ws/ahc/AhcWSUtils.scala
@@ -1,0 +1,24 @@
+package play.api.libs.ws.ahc
+
+import play.shaded.ahc.org.asynchttpclient.util.HttpUtils
+import java.nio.charset.{ Charset, StandardCharsets }
+
+/**
+ * INTERNAL API: Utilities for handling the response for both Java and Scala APIs
+ */
+private[ws] object AhcWSUtils {
+  def getResponseBody(ahcResponse: play.shaded.ahc.org.asynchttpclient.Response): String = {
+    val contentType = Option(ahcResponse.getContentType).getOrElse("application/octet-stream")
+    val charset = getCharset(contentType)
+    ahcResponse.getResponseBody(charset)
+  }
+
+  def getCharset(contentType: String): Charset = {
+    Option(HttpUtils.parseCharset(contentType)).getOrElse {
+      if (contentType.startsWith("text/"))
+        StandardCharsets.ISO_8859_1
+      else
+        StandardCharsets.UTF_8
+    }
+  }
+}

--- a/play-ahc-ws-standalone/src/main/scala/play/api/libs/ws/ahc/StandaloneAhcWSResponse.scala
+++ b/play-ahc-ws-standalone/src/main/scala/play/api/libs/ws/ahc/StandaloneAhcWSResponse.scala
@@ -32,15 +32,8 @@ class StandaloneAhcWSResponse(ahcResponse: AHCResponse) extends StandaloneWSResp
 
   override def toString: String = s"StandaloneAhcWSResponse($status, $statusText)"
 
-  /**
-   * The response body as String.
-   */
   override lazy val body: String = {
-    // https://tools.ietf.org/html/rfc7231#section-3.1.1.3
-    // https://tools.ietf.org/html/rfc7231#appendix-B
-    // The default charset of ISO-8859-1 for text media types has been
-    // removed; the default is now whatever the media type definition says.
-    ahcResponse.getResponseBody()
+    AhcWSUtils.getResponseBody(ahcResponse)
   }
 
   /**

--- a/play-ahc-ws-standalone/src/main/scala/play/api/libs/ws/ahc/StreamedResponse.scala
+++ b/play-ahc-ws-standalone/src/main/scala/play/api/libs/ws/ahc/StreamedResponse.scala
@@ -46,14 +46,23 @@ class StreamedResponse(
    */
   override def cookie(name: String): Option[WSCookie] = cookies.find(_.name == name)
 
-  override lazy val body: String = bodyAsBytes.utf8String
+  /**
+   * THIS IS A BLOCKING OPERATION. It should not be used in production.
+   *
+   * Note that this is not a charset aware operation, as the stream does not have access to the underlying machinery
+   * that disambiguates responses.
+   *
+   * @return the body as a String
+   */
+  override lazy val body: String = bodyAsBytes.decodeString(AhcWSUtils.getCharset(contentType))
 
   /**
-   * THIS IS A BLOCKING OPERATION.  It should not be used in production.
+   * THIS IS A BLOCKING OPERATION. It should not be used in production.
    *
-   * Note that this is not a charset aware operation, as the
-   * stream does not have access to the underlying machinery that disambiguates responses.
-   * @return a UTF-8 string constructed from the bytestring.
+   * Note that this is not a charset aware operation, as the stream does not have access to the underlying machinery
+   * that disambiguates responses.
+   *
+   * @return the body as a ByteString
    */
   override lazy val bodyAsBytes: ByteString = client.blockingToByteString(bodyAsSource)
 

--- a/play-ahc-ws-standalone/src/test/scala/play/api/libs/ws/ahc/AhcWSResponseSpec.scala
+++ b/play-ahc-ws-standalone/src/test/scala/play/api/libs/ws/ahc/AhcWSResponseSpec.scala
@@ -3,6 +3,7 @@
  */
 package play.api.libs.ws.ahc
 
+import java.nio.charset.StandardCharsets
 import java.util
 
 import akka.util.ByteString
@@ -13,9 +14,6 @@ import play.shaded.ahc.io.netty.handler.codec.http.DefaultHttpHeaders
 import play.shaded.ahc.org.asynchttpclient.cookie.{ Cookie => AHCCookie }
 import play.shaded.ahc.org.asynchttpclient.{ Response => AHCResponse }
 
-/**
- *
- */
 class AhcWSResponseSpec extends Specification with Mockito with DefaultBodyReadables with DefaultBodyWritables {
 
   "Ahc WS Response" should {
@@ -85,6 +83,26 @@ class AhcWSResponseSpec extends Specification with Mockito with DefaultBodyReada
       ahcResponse.getResponseBodyAsBytes returns bytes.toArray
       val response = StandaloneAhcWSResponse(ahcResponse)
       response.body[ByteString] must_== bytes
+    }
+
+    "get JSON body as a string from the AHC response" in {
+      val ahcResponse: AHCResponse = mock[AHCResponse]
+      val json = """{ "foo": "☺" }"""
+      val ahcHeaders = new DefaultHttpHeaders(true)
+      ahcResponse.getContentType returns "application/json"
+      ahcResponse.getHeaders returns ahcHeaders
+      ahcResponse.getResponseBody(StandardCharsets.UTF_8) returns json
+      val response = StandaloneAhcWSResponse(ahcResponse)
+      response.body must_== json
+    }
+
+    "get text body as a string from the AHC response" in {
+      val ahcResponse: AHCResponse = mock[AHCResponse]
+      val text = "Hello ☺"
+      ahcResponse.getContentType returns "text/plain"
+      ahcResponse.getResponseBody(StandardCharsets.ISO_8859_1) returns text
+      val response = StandaloneAhcWSResponse(ahcResponse)
+      response.body must_== text
     }
 
     "get headers from an AHC response in a case insensitive map" in {

--- a/play-ws-standalone/src/main/java/play/libs/ws/DefaultBodyReadables.java
+++ b/play-ws-standalone/src/main/java/play/libs/ws/DefaultBodyReadables.java
@@ -29,7 +29,10 @@ public interface DefaultBodyReadables {
     }
 
     /**
-     * Converts a response body into a String:
+     * Converts a response body into a String.
+     *
+     * Note: this is only a best-guess effort and does not handle all content types. See
+     * {@link StandaloneWSResponse#getBody()} for more information.
      *
      * {{{
      * String string = response.body(string())

--- a/play-ws-standalone/src/main/java/play/libs/ws/StandaloneWSResponse.java
+++ b/play-ws-standalone/src/main/java/play/libs/ws/StandaloneWSResponse.java
@@ -113,6 +113,20 @@ public interface StandaloneWSResponse {
      */
     <T> T getBody(BodyReadable<T> readable);
 
+    /**
+     * The response body decoded as String, using a simple algorithm to guess the encoding.
+     *
+     * This decodes the body to a string representation based on the following algorithm:
+     *
+     *  1. Look for a "charset" parameter on the Content-Type. If it exists, set `charset` to its value and goto step 3.
+     *  2. If the Content-Type is of type "text", set $charset to "ISO-8859-1"; else set `charset` to "UTF-8".
+     *  3. Decode the raw bytes of the body using `charset`.
+     *
+     * Note that this does not take into account any special cases for specific content types. For example, for
+     * application/json, we do not support encoding autodetection and will trust the charset parameter if provided.
+     *
+     * @return the response body parsed as a String using the above algorithm.
+     */
     String getBody();
 
     ByteString getBodyAsBytes();

--- a/play-ws-standalone/src/main/scala/play/api/libs/ws/DefaultBodyReadables.scala
+++ b/play-ws-standalone/src/main/scala/play/api/libs/ws/DefaultBodyReadables.scala
@@ -24,7 +24,10 @@ trait DefaultBodyReadables {
   implicit val readableAsByteString: BodyReadable[ByteString] = BodyReadable(_.bodyAsBytes)
 
   /**
-   * Converts a response body into a String:
+   * Converts a response body into a String.
+   *
+   * Note: this is only a best-guess effort and does not handle all content types. See
+   * [[StandaloneWSResponse.body:String*]] for more information.
    *
    * {{{
    * val string = response.body[String]

--- a/play-ws-standalone/src/main/scala/play/api/libs/ws/StandaloneWSResponse.scala
+++ b/play-ws-standalone/src/main/scala/play/api/libs/ws/StandaloneWSResponse.scala
@@ -93,7 +93,18 @@ trait StandaloneWSResponse {
   }
 
   /**
-   * @return the response body as String
+   * The response body decoded as String, using a simple algorithm to guess the encoding.
+   *
+   * This decodes the body to a string representation based on the following algorithm:
+   *
+   *  1. Look for a "charset" parameter on the Content-Type. If it exists, set `charset` to its value and go to step 3.
+   *  2. If the Content-Type is of type "text", set charset to "ISO-8859-1"; else set `charset` to "UTF-8".
+   *  3. Decode the raw bytes of the body using `charset`.
+   *
+   * Note that this does not take into account any special cases for specific content types. For example, for
+   * application/json, we do not support encoding autodetection and will trust the charset parameter if provided..
+   *
+   * @return the response body parsed as a String using the above algorithm.
    */
   def body: String
 


### PR DESCRIPTION
 - Change the decoding of response body string back to the Play 2.5.x behavior: use the `charset` parameter if it exists, and fall back to `iso-8859-1` for `text/*` and `utf-8` otherwise. This is good enough most of the time for common charsets including `application/json`.
 - Update the documentation for the `StandaloneWSResponse#body: String` and related methods to clarify that the decoding is only a best-guess effort and it should be used with caution.
 - Make the decoding of the body use the same algorithm for `StreamedResponse` and `StandaloneAhcWSResponse`.

Fixes #187