### PR TITLE
Sets content type when the body is set if its presented.

### DIFF
--- a/play-ahc-ws-standalone/src/main/java/play/libs/ws/ahc/StandaloneAhcWSRequest.java
+++ b/play-ahc-ws-standalone/src/main/java/play/libs/ws/ahc/StandaloneAhcWSRequest.java
@@ -248,6 +248,7 @@ public class StandaloneAhcWSRequest implements StandaloneWSRequest {
 
     /**
      * Sets a BodyWritable directly.  See {@link DefaultBodyWritables} for common bodies.
+     * Also sets a Content-Type header if its presented in BodyWritable.
      *
      * @param bodyWritable the bodyWritable to set.
      * @return the request with body
@@ -255,6 +256,12 @@ public class StandaloneAhcWSRequest implements StandaloneWSRequest {
     @Override
     public StandaloneAhcWSRequest setBody(BodyWritable bodyWritable) {
         this.bodyWritable = bodyWritable;
+
+        String contentType = bodyWritable.contentType();
+        if (!headers.containsKey(HttpHeaders.Names.CONTENT_TYPE) && contentType != null) {
+            this.addHeader(HttpHeaders.Names.CONTENT_TYPE, bodyWritable.contentType());
+        }
+
         return this;
     }
 

--- a/play-ahc-ws-standalone/src/test/scala/play/libs/ws/ahc/AhcWSRequestSpec.scala
+++ b/play-ahc-ws-standalone/src/test/scala/play/libs/ws/ahc/AhcWSRequestSpec.scala
@@ -179,7 +179,6 @@ class AhcWSRequestSpec extends Specification with Mockito with DefaultBodyReadab
       request.addHeader("Content-Type", "application/xml")
       request.setBody(body("HELLO WORLD")) // content type is not overwritten here as its already set before
       val req = request.buildRequest()
-      println("Headers:" + req.getHeaders)
       req.getHeaders.get("Content-Type") must be_==("application/json; charset=US-ASCII")
     }
 

--- a/play-ahc-ws-standalone/src/test/scala/play/libs/ws/ahc/AhcWSRequestSpec.scala
+++ b/play-ahc-ws-standalone/src/test/scala/play/libs/ws/ahc/AhcWSRequestSpec.scala
@@ -48,6 +48,17 @@ class AhcWSRequestSpec extends Specification with Mockito with DefaultBodyReadab
         req.getStringData must be_==("HELLO WORLD")
       }
 
+      "sets content type based on a body when its not explicitly set" in {
+        val client = mock[StandaloneAhcWSClient]
+        val req = new StandaloneAhcWSRequest(client, "http://playframework.com/", null)
+          .setBody(body("HELLO WORLD")) // set body with a content type
+          .asInstanceOf[StandaloneAhcWSRequest]
+          .buildRequest()
+
+        req.getHeaders.get(HttpHeaders.Names.CONTENT_TYPE) must be_==("text/plain")
+        req.getStringData must be_==("HELLO WORLD")
+      }
+
       "keep existing content type when setting body" in {
         val client = mock[StandaloneAhcWSClient]
         val req = new StandaloneAhcWSRequest(client, "http://playframework.com/", null)
@@ -156,19 +167,19 @@ class AhcWSRequestSpec extends Specification with Mockito with DefaultBodyReadab
       val client = mock[StandaloneAhcWSClient]
       val request = new StandaloneAhcWSRequest(client, "http://example.com", /*materializer*/ null)
       request.setBody(body("HELLO WORLD"))
-      request.addHeader("Content-Type", "application/json")
-      request.addHeader("Content-Type", "application/xml")
+      request.addHeader("Content-Type", "application/json") // will be ignored since body already sets content type
       val req = request.buildRequest()
-      req.getHeaders.get("Content-Type") must be_==("application/json")
+      req.getHeaders.get("Content-Type") must be_==("text/plain")
     }
 
     "only send first content type header and keep the charset if it has been set manually with a charset" in {
       val client = mock[StandaloneAhcWSClient]
       val request = new StandaloneAhcWSRequest(client, "http://example.com", /*materializer*/ null)
-      request.setBody(body("HELLO WORLD"))
       request.addHeader("Content-Type", "application/json; charset=US-ASCII")
       request.addHeader("Content-Type", "application/xml")
+      request.setBody(body("HELLO WORLD")) // content type is not overwritten here as its already set before
       val req = request.buildRequest()
+      println("Headers:" + req.getHeaders)
       req.getHeaders.get("Content-Type") must be_==("application/json; charset=US-ASCII")
     }
 

--- a/play-ahc-ws-standalone/src/test/scala/play/libs/ws/ahc/AhcWSRequestSpec.scala
+++ b/play-ahc-ws-standalone/src/test/scala/play/libs/ws/ahc/AhcWSRequestSpec.scala
@@ -163,6 +163,15 @@ class AhcWSRequestSpec extends Specification with Mockito with DefaultBodyReadab
       }
     }
 
+    "set content type explicitly if its not set with a body" in {
+      val client = mock[StandaloneAhcWSClient]
+      val request = new StandaloneAhcWSRequest(client, "http://example.com", /*materializer*/ null)
+      request.setBody(body("HELLO WORLD", null)) // content type is not set
+      request.addHeader("Content-Type", "application/json") // will be ignored since body already sets content type
+      val req = request.buildRequest()
+      req.getHeaders.get("Content-Type") must be_==("application/json")
+    }
+
     "only send first content type header and add charset=utf-8 to the Content-Type header if it's manually adding but lacking charset" in {
       val client = mock[StandaloneAhcWSClient]
       val request = new StandaloneAhcWSRequest(client, "http://example.com", /*materializer*/ null)

--- a/play-ahc-ws-standalone/src/test/scala/play/libs/ws/ahc/AhcWSRequestSpec.scala
+++ b/play-ahc-ws-standalone/src/test/scala/play/libs/ws/ahc/AhcWSRequestSpec.scala
@@ -167,7 +167,7 @@ class AhcWSRequestSpec extends Specification with Mockito with DefaultBodyReadab
       val client = mock[StandaloneAhcWSClient]
       val request = new StandaloneAhcWSRequest(client, "http://example.com", /*materializer*/ null)
       request.setBody(body("HELLO WORLD", null)) // content type is not set
-      request.addHeader("Content-Type", "application/json") // will be ignored since body already sets content type
+      request.addHeader("Content-Type", "application/json") // will be used as content type is not set with a body
       val req = request.buildRequest()
       req.getHeaders.get("Content-Type") must be_==("application/json")
     }


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [x] Have you signed the [Typesafe CLA](https://www.typesafe.com/contribute/cla)?
* [x] Have you [squashed your commits](https://www.playframework.com/documentation/latest/WorkingWithGit#Squashing-commits)?
* [x] Have you added copyright headers to new files?
* [x] Have you checked that both Scala and Java APIs are updated?
* [x] Have you updated the documentation for both Scala and Java sections?
* [x] Have you added tests for any changed functionality?

## Fixes

Fixes #179 

## Purpose

Sets content type header if its presented when the body is set.
