### PR TITLE
[BugFix] Streamed WS requests do not apply filters at Scala API.

### DIFF
--- a/integration-tests/src/test/scala/play/api/libs/ws/ahc/AhcWSRequestFilterSpec.scala
+++ b/integration-tests/src/test/scala/play/api/libs/ws/ahc/AhcWSRequestFilterSpec.scala
@@ -39,7 +39,7 @@ class AhcWSRequestFilterSpec(implicit val executionEnv: ExecutionEnv) extends Sp
     }
   }
 
-  override def afterAll = {
+  override def afterAll: Unit = {
     super.afterAll()
     client.close()
   }
@@ -95,7 +95,7 @@ class AhcWSRequestFilterSpec(implicit val executionEnv: ExecutionEnv) extends Sp
         .await(retries = 0, timeout = defaultTimeout)
     }
 
-    "execute with three request filter" in {
+    "execute with three request filters" in {
       val callList = scala.collection.mutable.ArrayBuffer[Int]()
       client.url(s"http://localhost:$testServerPort")
         .withRequestFilter(new CallbackRequestFilter(callList, 1))
@@ -107,7 +107,7 @@ class AhcWSRequestFilterSpec(implicit val executionEnv: ExecutionEnv) extends Sp
         .await(retries = 0, timeout = defaultTimeout)
     }
 
-    "stream with three request filter" in {
+    "stream with three request filters" in {
       val callList = scala.collection.mutable.ArrayBuffer[Int]()
       client.url(s"http://localhost:$testServerPort")
         .withRequestFilter(new CallbackRequestFilter(callList, 1))
@@ -119,7 +119,7 @@ class AhcWSRequestFilterSpec(implicit val executionEnv: ExecutionEnv) extends Sp
         .await(retries = 0, timeout = defaultTimeout)
     }
 
-    "should allow filters to modify the executed request" in {
+    "allow filters to modify the executing request" in {
       val appendedHeader = "X-Request-Id"
       val appendedHeaderValue = "someid"
       client.url(s"http://localhost:$testServerPort")
@@ -130,7 +130,7 @@ class AhcWSRequestFilterSpec(implicit val executionEnv: ExecutionEnv) extends Sp
         .await(retries = 0, timeout = defaultTimeout)
     }
 
-    "should allow filters to modify the streamed request" in {
+    "allow filters to modify the streaming request" in {
       val appendedHeader = "X-Request-Id"
       val appendedHeaderValue = "someid"
       client.url(s"http://localhost:$testServerPort")

--- a/integration-tests/src/test/scala/play/api/libs/ws/ahc/AhcWSRequestFilterSpec.scala
+++ b/integration-tests/src/test/scala/play/api/libs/ws/ahc/AhcWSRequestFilterSpec.scala
@@ -59,7 +59,7 @@ class AhcWSRequestFilterSpec(implicit val executionEnv: ExecutionEnv) extends Sp
       }
     }
 
-    "work with adhoc request filter" in {
+    "execute with adhoc request filter" in {
       client.url(s"http://localhost:$testServerPort").withRequestFilter(WSRequestFilter { e =>
         WSRequestExecutor(r => e.apply(r.withQueryStringParameters("key" -> "some string")))
       }).get().map { response =>
@@ -67,7 +67,15 @@ class AhcWSRequestFilterSpec(implicit val executionEnv: ExecutionEnv) extends Sp
       }.await(retries = 0, timeout = defaultTimeout)
     }
 
-    "work with one request filter" in {
+    "stream with adhoc request filter" in {
+      client.url(s"http://localhost:$testServerPort").withRequestFilter(WSRequestFilter { e =>
+        WSRequestExecutor(r => e.apply(r.withQueryStringParameters("key" -> "some string")))
+      }).withMethod("GET").stream().map { response =>
+        response.body[String] must contain("some string")
+      }.await(retries = 0, timeout = defaultTimeout)
+    }
+
+    "execute with one request filter" in {
       val callList = scala.collection.mutable.ArrayBuffer[Int]()
       client.url(s"http://localhost:$testServerPort")
         .withRequestFilter(new CallbackRequestFilter(callList, 1))
@@ -77,7 +85,17 @@ class AhcWSRequestFilterSpec(implicit val executionEnv: ExecutionEnv) extends Sp
         .await(retries = 0, timeout = defaultTimeout)
     }
 
-    "work with three request filter" in {
+    "stream with one request filter" in {
+      val callList = scala.collection.mutable.ArrayBuffer[Int]()
+      client.url(s"http://localhost:$testServerPort")
+        .withRequestFilter(new CallbackRequestFilter(callList, 1))
+        .withMethod("GET").stream().map { _ =>
+          callList must contain(1)
+        }
+        .await(retries = 0, timeout = defaultTimeout)
+    }
+
+    "execute with three request filter" in {
       val callList = scala.collection.mutable.ArrayBuffer[Int]()
       client.url(s"http://localhost:$testServerPort")
         .withRequestFilter(new CallbackRequestFilter(callList, 1))
@@ -89,12 +107,35 @@ class AhcWSRequestFilterSpec(implicit val executionEnv: ExecutionEnv) extends Sp
         .await(retries = 0, timeout = defaultTimeout)
     }
 
-    "should allow filters to modify the request" in {
+    "stream with three request filter" in {
+      val callList = scala.collection.mutable.ArrayBuffer[Int]()
+      client.url(s"http://localhost:$testServerPort")
+        .withRequestFilter(new CallbackRequestFilter(callList, 1))
+        .withRequestFilter(new CallbackRequestFilter(callList, 2))
+        .withRequestFilter(new CallbackRequestFilter(callList, 3))
+        .withMethod("GET").stream().map { _ =>
+          callList must containTheSameElementsAs(Seq(1, 2, 3))
+        }
+        .await(retries = 0, timeout = defaultTimeout)
+    }
+
+    "should allow filters to modify the executed request" in {
       val appendedHeader = "X-Request-Id"
       val appendedHeaderValue = "someid"
       client.url(s"http://localhost:$testServerPort")
         .withRequestFilter(new HeaderAppendingFilter(appendedHeader, appendedHeaderValue))
         .get().map { response ⇒
+          response.headers("X-Request-Id").head must be_==("someid")
+        }
+        .await(retries = 0, timeout = defaultTimeout)
+    }
+
+    "should allow filters to modify the streamed request" in {
+      val appendedHeader = "X-Request-Id"
+      val appendedHeaderValue = "someid"
+      client.url(s"http://localhost:$testServerPort")
+        .withRequestFilter(new HeaderAppendingFilter(appendedHeader, appendedHeaderValue))
+        .withMethod("GET").stream().map { response ⇒
           response.headers("X-Request-Id").head must be_==("someid")
         }
         .await(retries = 0, timeout = defaultTimeout)

--- a/play-ahc-ws-standalone/src/main/scala/play/api/libs/ws/ahc/StandaloneAhcWSRequest.scala
+++ b/play-ahc-ws-standalone/src/main/scala/play/api/libs/ws/ahc/StandaloneAhcWSRequest.scala
@@ -198,7 +198,11 @@ case class StandaloneAhcWSRequest(
   }
 
   override def stream(): Future[Response] = {
-    client.executeStream(buildRequest())
+    val executor = filterWSRequestExecutor(WSRequestExecutor { request =>
+      client.executeStream(request.asInstanceOf[StandaloneAhcWSRequest].buildRequest())
+    })
+
+    executor(this)
   }
 
   /**


### PR DESCRIPTION
Had to merge 2 commits according to [rules](https://www.playframework.com/documentation/latest/WorkingWithGit#Squashing-commits).

The first commit's message is:

[Bug] Streamed WS requests do not apply filters at Scala API. Test that reproduces a bug.

This is the 2nd commit message:

[BugFix] Streamed WS requests also should be made with applied filters.
Same as at Java `play.libs.ws.ahc.StandaloneAhcWSRequest`.

# Pull Request Checklist

* [x] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [x] Have you signed the [Typesafe CLA](https://www.typesafe.com/contribute/cla)?
* [x] Have you [squashed your commits](https://www.playframework.com/documentation/latest/WorkingWithGit#Squashing-commits)?
* [ ] Have you added copyright headers to new files? - **No, haven't added any new files.**
* [x] Have you checked that both Scala and Java APIs are updated?
* [ ] Have you updated the documentation for both Scala and Java sections? - **No, docs are fine.**
* [x] Have you added tests for any changed functionality?

## Fixes

_Fixes_ issue that I haven't create at bug tracker. Issue is: when streaming request/response with Scala API no filter applied.

## Purpose

_What does this PR do?_  - This PR brings Scala API to parity with Java API.

## Background Context

_Why did you take this approach?_  - Need some point where I can modify request and response in cohesion-ish way while streaming from remote WS. Had to use Scala because of my team members.

## References

_Are there any relevant issues / PRs / mailing lists discussions?_  - No, haven't made any.