### PR TITLE
Add Java 9 to travis configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,10 @@ sudo: false
 group: beta
 scala:
 - 2.12.4
-- 2.11.11
+- 2.11.12
 jdk:
 - oraclejdk8
+- oraclejdk9
 cache:
   directories:
   - "$HOME/.ivy2/cache"
@@ -18,3 +19,9 @@ before_cache:
 notifications:
   slack:
     secure: gEa3XQiBUbMxCy+zzwka1cRcoc/h+lcOYFWiDM7JVxrPJxqAZcrlzSHqMrCEiey39bolMDWdRM9RhrJ/jkjOurHgDWN/oyhV4JRvXQJmipLDErRwuWemo1S15DcVeZ4+3VCmB3KIMKk0AWPjPZb2QEIQfzjNwd9MRXZPyWw9XiNjjUCC4VEjYxYlxIYhha4NaFRy96nTm/Rf6hc55bZeFYYz6Y42pK6sRN+M8ES9KsoW2KQeoxIXHp1bq3WxVPGlUPyhUroh53kehS6iS3tChMVw8fnFUbd8cvtNx/dN847Pwj1E2hLhdD+aTjf8Wjq6V+l+RNWJnWdKIo+4bi0vqLZkUN7XrS9FgwX1cawdC32tNFlKXA4fmvXxtyMh3bGE011NVGtcdE2MBudy6lfYSvxROeDXwd+0xTbvyYd8xQrZv3JL3dTM3Hb+586NeZOTq2BpZJytKh4wIZcHyOeHdq+IbvPviERaem/d/wJ1QLVHspQw7xab8JopMWJ5iyJnCL9nC35hZomvzSyZ8KrVQKyMenbq7Kb8Vp/Lo5kCp1ygK8qfSNVl+sZfoW5D1dlipXDp2EYP399hqGa1kn23cIT1JiAbeQ9SEmhXWj4lPAq2rTAOt90V6OcpTqydJ3k/TVqzraZ3pGDirkrfS4kAvhgeIWIGDUnYXak5tpCoIcY=
+
+# No need to test using Scala 2.11 and Java 9
+matrix:
+  exclude:
+    - scala: 2.11.12
+      jdk: oraclejdk9

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -5,7 +5,7 @@ resolvers += Resolver.typesafeRepo("releases")
 addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "2.0")
 addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.1.0")
 
-addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.5")
+addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.6")
 
 addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.7")
 


### PR DESCRIPTION
## Purpose

Add Java 9 to Travis build configuration.

## References

This PR is a follow up to #210. Since we are now using sbt 1.0, we can also start to test against Java 9.
