### PR TITLE
#213 Add WSClientConfig support to the Akka Http backend

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,9 +1,6 @@
 import Dependencies._
 import com.typesafe.sbt.SbtScalariform.ScalariformKeys
 
-import com.typesafe.tools.mima.core._
-import com.typesafe.tools.mima.plugin.MimaPlugin.mimaDefaultSettings
-
 import sbtassembly.AssemblyPlugin.autoImport._
 import sbtassembly.MergeStrategy
 
@@ -25,15 +22,7 @@ val javacSettings = Seq(
   "-Xlint:unchecked"
 )
 
-lazy val mimaSettings = mimaDefaultSettings ++ Seq(
-  mimaBinaryIssueFilters ++= Seq(
-    ProblemFilters.exclude[DirectMissingMethodProblem]("play.libs.ws.ahc.StandaloneAhcWSResponse.getBodyAsSource"),
-    ProblemFilters.exclude[MissingClassProblem]("play.api.libs.ws.package$"),
-    ProblemFilters.exclude[MissingClassProblem]("play.api.libs.ws.package")
-  )
-)
-
-lazy val commonSettings = mimaSettings ++ Seq(
+lazy val commonSettings = Seq(
   organization := "com.typesafe.play",
   scalaVersion := "2.12.4",
   crossScalaVersions := Seq("2.12.4", "2.11.11"),

--- a/integration-tests/src/test/scala/play/AkkaServerProvider.scala
+++ b/integration-tests/src/test/scala/play/AkkaServerProvider.scala
@@ -14,6 +14,7 @@ import akka.http.scaladsl.{ Http, HttpsConnectionContext }
 import akka.http.scaladsl.server.Route
 import akka.stream.ActorMaterializer
 import com.typesafe.config.ConfigFactory
+import com.typesafe.sslconfig.akka.AkkaSSLConfig
 import org.specs2.concurrent.ExecutionEnv
 import org.specs2.specification.BeforeAfterAll
 
@@ -83,7 +84,7 @@ trait AkkaServerProvider extends BeforeAfterAll {
     new HttpsConnectionContext(context)
   }
 
-  def clientHttpsContext() = {
+  def clientHttpsContext(akkaSslConfig: Option[AkkaSSLConfig] = None): HttpsConnectionContext = {
     val certStore = KeyStore.getInstance(KeyStore.getDefaultType)
     certStore.load(null, null)
     // only do this if you want to accept a custom root CA. Understand what you are doing!
@@ -97,7 +98,10 @@ trait AkkaServerProvider extends BeforeAfterAll {
 
     val params = new SSLParameters()
     params.setEndpointIdentificationAlgorithm("https")
-    new HttpsConnectionContext(context, sslParameters = Some(params))
+    new HttpsConnectionContext(
+      context,
+      sslConfig = akkaSslConfig,
+      sslParameters = Some(params))
   }
 
   private def resourceStream(resourceName: String): InputStream = {

--- a/integration-tests/src/test/scala/play/api/libs/ws/WSClientConfigSpec.scala
+++ b/integration-tests/src/test/scala/play/api/libs/ws/WSClientConfigSpec.scala
@@ -30,7 +30,7 @@ object WSClientConfigSpec {
 }
 
 trait WSClientConfigSpec extends Specification
-    with AkkaServerProvider {
+  with AkkaServerProvider {
 
   implicit def executionEnv: ExecutionEnv
 

--- a/integration-tests/src/test/scala/play/api/libs/ws/WSClientConfigSpec.scala
+++ b/integration-tests/src/test/scala/play/api/libs/ws/WSClientConfigSpec.scala
@@ -1,3 +1,7 @@
+/*
+ * Copyright (C) 2018 Lightbend Inc. <https://www.lightbend.com>
+ */
+
 package play.api.libs.ws
 
 import akka.http.scaladsl.coding.{ Deflate, Gzip }

--- a/integration-tests/src/test/scala/play/api/libs/ws/WSClientConfigSpec.scala
+++ b/integration-tests/src/test/scala/play/api/libs/ws/WSClientConfigSpec.scala
@@ -1,0 +1,41 @@
+package play.api.libs.ws
+
+import akka.http.scaladsl.model.headers.`User-Agent`
+import org.specs2.concurrent.ExecutionEnv
+import org.specs2.execute.Result
+import org.specs2.mutable.Specification
+import play.AkkaServerProvider
+
+object WSClientConfigSpec {
+  val routes = {
+    import akka.http.scaladsl.server.Directives._
+    path("user-agent") {
+      headerValueByType[`User-Agent`]() { ua =>
+        complete(ua.products.head.toString())
+      }
+    }
+  }
+}
+
+trait WSClientConfigSpec extends Specification
+    with AkkaServerProvider {
+
+  implicit def executionEnv: ExecutionEnv
+
+  def withClient(configTransform: WSClientConfig => WSClientConfig)(block: StandaloneWSClient => Result): Result
+
+  override val routes = WSClientConfigSpec.routes
+
+  "WSClient" should {
+    "use user agent from config" in {
+      withClient(_.copy(userAgent = Some("custom-user-agent"))) {
+        _.url(s"http://localhost:$testServerPort/user-agent")
+          .get()
+          .map(_.body)
+          .map(_ must beEqualTo("custom-user-agent"))
+          .awaitFor(defaultTimeout)
+      }
+    }
+  }
+
+}

--- a/integration-tests/src/test/scala/play/api/libs/ws/ahc/AhcWSClientConfigSpec.scala
+++ b/integration-tests/src/test/scala/play/api/libs/ws/ahc/AhcWSClientConfigSpec.scala
@@ -1,0 +1,17 @@
+package play.api.libs.ws.ahc
+
+import org.specs2.concurrent.ExecutionEnv
+import org.specs2.execute.Result
+import play.api.libs.ws.{ StandaloneWSClient, WSClientConfig, WSClientConfigSpec }
+
+class AhcWSClientConfigSpec(implicit override val executionEnv: ExecutionEnv) extends WSClientConfigSpec {
+  def withClient(configTransform: WSClientConfig => WSClientConfig)(block: StandaloneWSClient => Result): Result = {
+    val config = AhcWSClientConfigFactory.forClientConfig(configTransform(WSClientConfig()))
+    val client = StandaloneAhcWSClient(config)
+    try {
+      block(client)
+    } finally {
+      client.close()
+    }
+  }
+}

--- a/integration-tests/src/test/scala/play/api/libs/ws/ahc/AhcWSClientConfigSpec.scala
+++ b/integration-tests/src/test/scala/play/api/libs/ws/ahc/AhcWSClientConfigSpec.scala
@@ -1,3 +1,7 @@
+/*
+ * Copyright (C) 2018 Lightbend Inc. <https://www.lightbend.com>
+ */
+
 package play.api.libs.ws.ahc
 
 import org.specs2.concurrent.ExecutionEnv

--- a/integration-tests/src/test/scala/play/api/libs/ws/akkahttp/AkkaHttpWSClientConfigSpec.scala
+++ b/integration-tests/src/test/scala/play/api/libs/ws/akkahttp/AkkaHttpWSClientConfigSpec.scala
@@ -1,3 +1,7 @@
+/*
+ * Copyright (C) 2018 Lightbend Inc. <https://www.lightbend.com>
+ */
+
 package play.api.libs.ws.akkahttp
 
 import com.typesafe.sslconfig.akka.AkkaSSLConfig

--- a/integration-tests/src/test/scala/play/api/libs/ws/akkahttp/AkkaHttpWSClientConfigSpec.scala
+++ b/integration-tests/src/test/scala/play/api/libs/ws/akkahttp/AkkaHttpWSClientConfigSpec.scala
@@ -1,0 +1,19 @@
+package play.api.libs.ws.akkahttp
+
+import com.typesafe.sslconfig.akka.AkkaSSLConfig
+import org.specs2.concurrent.ExecutionEnv
+import org.specs2.execute.Result
+import play.api.libs.ws.{ StandaloneWSClient, WSClientConfig, WSClientConfigSpec }
+
+class AkkaHttpWSClientConfigSpec(implicit override val executionEnv: ExecutionEnv) extends WSClientConfigSpec {
+  def withClient(configTransform: WSClientConfig => WSClientConfig)(block: StandaloneWSClient => Result): Result = {
+    val config = configTransform(WSClientConfig.forConfig())
+    val httpsContext = clientHttpsContext(Some(AkkaSSLConfig().withSettings(config.ssl)))
+    val client = StandaloneAkkaHttpWSClient(httpsContext, config)(system, materializer)
+    try {
+      block(client)
+    } finally {
+      client.close()
+    }
+  }
+}

--- a/integration-tests/src/test/scala/play/libs/ws/WSClientConfigSpec.scala
+++ b/integration-tests/src/test/scala/play/libs/ws/WSClientConfigSpec.scala
@@ -1,0 +1,33 @@
+package play.libs.ws
+
+import org.specs2.concurrent.ExecutionEnv
+import org.specs2.execute.Result
+import org.specs2.mutable.Specification
+import play.AkkaServerProvider
+import play.api.libs.ws.WSClientConfig
+
+import scala.compat.java8.FutureConverters._
+
+trait WSClientConfigSpec extends Specification
+    with AkkaServerProvider {
+
+  implicit def executionEnv: ExecutionEnv
+
+  def withClient(configTransform: WSClientConfig => WSClientConfig)(block: StandaloneWSClient => Result): Result
+
+  override val routes = play.api.libs.ws.WSClientConfigSpec.routes
+
+  "WSClient" should {
+    "use user agent from config" in {
+      withClient(_.copy(userAgent = Some("custom-user-agent"))) {
+        _.url(s"http://localhost:$testServerPort/user-agent")
+          .get()
+          .toScala
+          .map(_.getBody)
+          .map(_ must beEqualTo("custom-user-agent"))
+          .awaitFor(defaultTimeout)
+      }
+    }
+  }
+
+}

--- a/integration-tests/src/test/scala/play/libs/ws/WSClientConfigSpec.scala
+++ b/integration-tests/src/test/scala/play/libs/ws/WSClientConfigSpec.scala
@@ -28,6 +28,17 @@ trait WSClientConfigSpec extends Specification
           .awaitFor(defaultTimeout)
       }
     }
+
+    "uncompress when compression enabled" in {
+      withClient(_.copy(compressionEnabled = true)) {
+        _.url(s"http://localhost:$testServerPort/compression")
+          .get()
+          .toScala
+          .map(_.getBody)
+          .map(_ must beEqualTo("gzip,deflate"))
+          .awaitFor(defaultTimeout)
+      }
+    }
   }
 
 }

--- a/integration-tests/src/test/scala/play/libs/ws/WSClientConfigSpec.scala
+++ b/integration-tests/src/test/scala/play/libs/ws/WSClientConfigSpec.scala
@@ -1,3 +1,7 @@
+/*
+ * Copyright (C) 2018 Lightbend Inc. <https://www.lightbend.com>
+ */
+
 package play.libs.ws
 
 import org.specs2.concurrent.ExecutionEnv

--- a/integration-tests/src/test/scala/play/libs/ws/WSClientConfigSpec.scala
+++ b/integration-tests/src/test/scala/play/libs/ws/WSClientConfigSpec.scala
@@ -13,7 +13,7 @@ import play.api.libs.ws.WSClientConfig
 import scala.compat.java8.FutureConverters._
 
 trait WSClientConfigSpec extends Specification
-    with AkkaServerProvider {
+  with AkkaServerProvider {
 
   implicit def executionEnv: ExecutionEnv
 

--- a/integration-tests/src/test/scala/play/libs/ws/ahc/AhcWSClientConfigSpec.scala
+++ b/integration-tests/src/test/scala/play/libs/ws/ahc/AhcWSClientConfigSpec.scala
@@ -1,3 +1,7 @@
+/*
+ * Copyright (C) 2018 Lightbend Inc. <https://www.lightbend.com>
+ */
+
 package play.libs.ws.ahc
 
 import org.specs2.concurrent.ExecutionEnv

--- a/integration-tests/src/test/scala/play/libs/ws/ahc/AhcWSClientConfigSpec.scala
+++ b/integration-tests/src/test/scala/play/libs/ws/ahc/AhcWSClientConfigSpec.scala
@@ -1,0 +1,18 @@
+package play.libs.ws.ahc
+
+import org.specs2.concurrent.ExecutionEnv
+import org.specs2.execute.Result
+import play.api.libs.ws.WSClientConfig
+import play.libs.ws.{ StandaloneWSClient, WSClientConfigSpec }
+
+class AhcWSClientConfigSpec(implicit override val executionEnv: ExecutionEnv) extends WSClientConfigSpec {
+  def withClient(configTransform: WSClientConfig => WSClientConfig)(block: StandaloneWSClient => Result): Result = {
+    val config = AhcWSClientConfigFactory.forClientConfig(configTransform(WSClientConfig()))
+    val client = StandaloneAhcWSClient.create(config, materializer)
+    try {
+      block(client)
+    } finally {
+      client.close()
+    }
+  }
+}

--- a/integration-tests/src/test/scala/play/libs/ws/akkahttp/AkkaHttpWSClientConfigSpec.scala
+++ b/integration-tests/src/test/scala/play/libs/ws/akkahttp/AkkaHttpWSClientConfigSpec.scala
@@ -1,0 +1,20 @@
+package play.libs.ws.akkahttp
+
+import com.typesafe.sslconfig.akka.AkkaSSLConfig
+import org.specs2.concurrent.ExecutionEnv
+import org.specs2.execute.Result
+import play.api.libs.ws.WSClientConfig
+import play.libs.ws.{ StandaloneWSClient, WSClientConfigSpec }
+
+class AkkaHttpWSClientConfigSpec(implicit override val executionEnv: ExecutionEnv) extends WSClientConfigSpec {
+  def withClient(configTransform: WSClientConfig => WSClientConfig)(block: StandaloneWSClient => Result): Result = {
+    val config = configTransform(WSClientConfig.forConfig())
+    val httpsContext = clientHttpsContext(Some(AkkaSSLConfig().withSettings(config.ssl)))
+    val client = new StandaloneAkkaHttpWSClient(system, materializer, httpsContext, config)
+    try {
+      block(client)
+    } finally {
+      client.close()
+    }
+  }
+}

--- a/integration-tests/src/test/scala/play/libs/ws/akkahttp/AkkaHttpWSClientConfigSpec.scala
+++ b/integration-tests/src/test/scala/play/libs/ws/akkahttp/AkkaHttpWSClientConfigSpec.scala
@@ -1,3 +1,7 @@
+/*
+ * Copyright (C) 2018 Lightbend Inc. <https://www.lightbend.com>
+ */
+
 package play.libs.ws.akkahttp
 
 import com.typesafe.sslconfig.akka.AkkaSSLConfig

--- a/play-ahc-ws-standalone/src/main/mima-filters/1.0.0.backwards.excludes
+++ b/play-ahc-ws-standalone/src/main/mima-filters/1.0.0.backwards.excludes
@@ -1,0 +1,1 @@
+ProblemFilters.exclude[DirectMissingMethodProblem]("play.libs.ws.ahc.StandaloneAhcWSResponse.getBodyAsSource")

--- a/play-akka-http-ws-standalone/src/main/java/play/libs/ws/akkahttp/StandaloneAkkaHttpWSClient.java
+++ b/play-akka-http-ws-standalone/src/main/java/play/libs/ws/akkahttp/StandaloneAkkaHttpWSClient.java
@@ -7,6 +7,7 @@ import akka.actor.ActorSystem;
 import akka.http.javadsl.Http;
 import akka.http.javadsl.HttpsConnectionContext;
 import akka.stream.Materializer;
+import play.api.libs.ws.WSClientConfig;
 import play.libs.ws.StandaloneWSClient;
 import play.libs.ws.StandaloneWSRequest;
 
@@ -18,15 +19,21 @@ public final class StandaloneAkkaHttpWSClient implements StandaloneWSClient {
   private final ActorSystem sys;
   private final Materializer mat;
   private final HttpsConnectionContext ctx;
+  private final WSClientConfig config;
 
   public StandaloneAkkaHttpWSClient(ActorSystem sys, Materializer mat) {
-    this(sys, mat, Http.get(sys).defaultClientHttpsContext());
+    this(sys, mat, Http.get(sys).defaultClientHttpsContext(), WSClientConfig.forConfig());
   }
 
   public StandaloneAkkaHttpWSClient(ActorSystem sys, Materializer mat, HttpsConnectionContext ctx) {
+    this(sys, mat, ctx, WSClientConfig.forConfig());
+  }
+
+  public StandaloneAkkaHttpWSClient(ActorSystem sys, Materializer mat, HttpsConnectionContext ctx, WSClientConfig config) {
     this.sys = sys;
     this.mat = mat;
     this.ctx = ctx;
+    this.config = config;
   }
 
     /**
@@ -50,7 +57,7 @@ public final class StandaloneAkkaHttpWSClient implements StandaloneWSClient {
   @Override
   public StandaloneWSRequest url(String url) {
     try {
-      return new StandaloneAkkaHttpWSRequest(url, sys, mat, ctx);
+      return new StandaloneAkkaHttpWSRequest(url, sys, mat, ctx, config);
     }
     catch (IllegalArgumentException ex) {
       throw new RuntimeException(new MalformedURLException(ex.getMessage()));

--- a/play-akka-http-ws-standalone/src/main/java/play/libs/ws/akkahttp/StandaloneAkkaHttpWSRequest.java
+++ b/play-akka-http-ws-standalone/src/main/java/play/libs/ws/akkahttp/StandaloneAkkaHttpWSRequest.java
@@ -7,11 +7,10 @@ import akka.actor.ActorSystem;
 import akka.http.impl.model.parser.HeaderParser$;
 import akka.http.javadsl.Http;
 import akka.http.javadsl.HttpsConnectionContext;
+import akka.http.javadsl.coding.Coder;
 import akka.http.javadsl.model.*;
-import akka.http.javadsl.model.headers.Authorization;
-import akka.http.javadsl.model.headers.BasicHttpCredentials;
-import akka.http.javadsl.model.headers.Cookie;
-import akka.http.javadsl.model.headers.UserAgent;
+import akka.http.javadsl.model.ContentType;
+import akka.http.javadsl.model.headers.*;
 import akka.http.scaladsl.model.headers.ProductVersion;
 import akka.japi.Pair;
 import akka.parboiled2.ParserInput$;
@@ -29,6 +28,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 
 public final class StandaloneAkkaHttpWSRequest implements StandaloneWSRequest {
@@ -47,19 +47,31 @@ public final class StandaloneAkkaHttpWSRequest implements StandaloneWSRequest {
   }
 
   private StandaloneAkkaHttpWSRequest(HttpRequest request, List<WSRequestFilter> filters, Duration timeout, ActorSystem sys, Materializer mat, HttpsConnectionContext ctx, WSClientConfig config) {
-    this.request = config.userAgent().fold(
-      () -> request,
-      (ua) -> request.addHeader(UserAgent.create(
-        // FIXME JAVA API expose ProductVersion.parseMultiple in Java API
-        scala.collection.JavaConverters.seqAsJavaList(ProductVersion.parseMultiple(ua)).toArray(new ProductVersion[0])
-      ))
+
+    final List<Function<HttpRequest, HttpRequest>> requestTransformations = Arrays.asList(
+      (req) -> config.userAgent().fold(
+        () -> req,
+        (ua) -> req.addHeader(UserAgent.create(
+          // FIXME JAVA API expose ProductVersion.parseMultiple in Java API
+          scala.collection.JavaConverters.seqAsJavaList(ProductVersion.parseMultiple(ua)).toArray(new ProductVersion[0])
+        ))
+      ),
+      (req) -> {
+        if (!config.compressionEnabled()) return req;
+        else return req.addHeader(AcceptEncoding.create(
+          HttpEncodingRange.create(HttpEncodings.GZIP), HttpEncodingRange.create(HttpEncodings.DEFLATE))
+        );
+      }
     );
+
+    this.request = requestTransformations.stream().reduce(request, (req, f) -> f.apply(req), (r1, r2) -> r2);
     this.filters = filters;
     this.timeout = timeout;
     this.sys = sys;
     this.mat = mat;
     this.ctx = ctx;
     this.config = config;
+
   }
 
   /**
@@ -157,6 +169,7 @@ public final class StandaloneAkkaHttpWSRequest implements StandaloneWSRequest {
       final CompletableFuture<StandaloneAkkaHttpWSResponse> resultFuture =
         Http.get(sys)
           .singleRequest(((StandaloneAkkaHttpWSRequest)request).request, ctx)
+          .thenApply(StandaloneAkkaHttpWSRequest::decodeResponse)
           .thenApply((r) -> new StandaloneAkkaHttpWSResponse(r, mat))
           .toCompletableFuture();
 
@@ -664,4 +677,13 @@ public final class StandaloneAkkaHttpWSRequest implements StandaloneWSRequest {
     return new StandaloneAkkaHttpWSRequest(this.request, this.filters, timeout, this.sys, this.mat, this.ctx, this.config);
   }
 
+  private static HttpResponse decodeResponse(HttpResponse response) {
+    Coder coder = Coder.NoCoding;
+    if (response.encoding().equals(HttpEncodings.GZIP)) {
+      coder = Coder.Gzip;
+    } else if (response.encoding().equals(HttpEncodings.DEFLATE)) {
+      coder = Coder.Deflate;
+    }
+    return coder.decodeMessage(response);
+  }
 }

--- a/play-akka-http-ws-standalone/src/main/scala/play/api/libs/ws/akkahttp/StandaloneAkkaHttpWSClient.scala
+++ b/play-akka-http-ws-standalone/src/main/scala/play/api/libs/ws/akkahttp/StandaloneAkkaHttpWSClient.scala
@@ -7,21 +7,24 @@ import akka.actor.ActorSystem
 import akka.http.scaladsl.{ Http, HttpsConnectionContext }
 import akka.http.scaladsl.model.IllegalUriException
 import akka.stream.Materializer
-import play.api.libs.ws.{ StandaloneWSClient, StandaloneWSRequest }
+import play.api.libs.ws.{ StandaloneWSClient, StandaloneWSRequest, WSClientConfig }
 
 import scala.util.control.NonFatal
 
 object StandaloneAkkaHttpWSClient {
   def apply()(implicit sys: ActorSystem, mat: Materializer): StandaloneWSClient =
-    apply(Http().defaultClientHttpsContext)(sys, mat)
+    apply(Http().defaultClientHttpsContext, WSClientConfig.forConfig())(sys, mat)
 
   def apply(ctx: HttpsConnectionContext)(implicit sys: ActorSystem, mat: Materializer): StandaloneWSClient =
-    new StandaloneAkkaHttpWSClient()(sys, mat, ctx)
+    apply(ctx, WSClientConfig.forConfig())(sys, mat)
+
+  def apply(ctx: HttpsConnectionContext, config: WSClientConfig)(implicit sys: ActorSystem, mat: Materializer): StandaloneWSClient =
+    new StandaloneAkkaHttpWSClient()(sys, mat, ctx, config)
 }
 
 final class StandaloneAkkaHttpWSClient private ()(
     implicit
-    val sys: ActorSystem, val mat: Materializer, val ctx: HttpsConnectionContext
+    val sys: ActorSystem, val mat: Materializer, val ctx: HttpsConnectionContext, val config: WSClientConfig
 ) extends StandaloneWSClient {
   /**
    * The underlying implementation of the client, if any.  You must cast explicitly to the type you want.

--- a/play-akka-http-ws-standalone/src/main/scala/play/api/libs/ws/akkahttp/StandaloneAkkaHttpWSRequest.scala
+++ b/play-akka-http-ws-standalone/src/main/scala/play/api/libs/ws/akkahttp/StandaloneAkkaHttpWSRequest.scala
@@ -40,7 +40,7 @@ final class StandaloneAkkaHttpWSRequest private (
     val filters: Seq[WSRequestFilter],
     val timeout: Duration
 )(implicit
-  val sys: ActorSystem,
+    val sys: ActorSystem,
     val mat: Materializer,
     val ctx: HttpsConnectionContext,
     val config: WSClientConfig) extends StandaloneWSRequest {

--- a/play-akka-http-ws-standalone/src/main/scala/play/api/libs/ws/akkahttp/StandaloneAkkaHttpWSRequest.scala
+++ b/play-akka-http-ws-standalone/src/main/scala/play/api/libs/ws/akkahttp/StandaloneAkkaHttpWSRequest.scala
@@ -6,6 +6,7 @@ package play.api.libs.ws.akkahttp
 import java.net.URI
 
 import akka.actor.ActorSystem
+import akka.http.scaladsl.coding.{ Deflate, Gzip, NoCoding }
 import akka.http.scaladsl.{ Http, HttpsConnectionContext }
 import akka.http.scaladsl.model.HttpHeader.ParsingResult
 import akka.http.scaladsl.model.Uri.Authority
@@ -21,9 +22,14 @@ import scala.concurrent.duration.{ Duration, FiniteDuration }
 
 object StandaloneAkkaHttpWSRequest {
   def apply(url: String)(implicit sys: ActorSystem, mat: Materializer, ctx: HttpsConnectionContext, config: WSClientConfig): StandaloneAkkaHttpWSRequest = {
-    val request = HttpRequest().withUri(Uri.parseAbsolute(url))
+
+    val requestTransformations = Seq(
+      (req: HttpRequest) => config.userAgent.fold(req)(ua => req.withHeaders(`User-Agent`(ua))),
+      (req: HttpRequest) => if (!config.compressionEnabled) req else req.withHeaders(`Accept-Encoding`(HttpEncodings.gzip, HttpEncodings.deflate))
+    )
+
     new StandaloneAkkaHttpWSRequest(
-      config.userAgent.fold(request)(ua => request.withHeaders(`User-Agent`(ua))),
+      requestTransformations.foldLeft(HttpRequest().withUri(Uri.parseAbsolute(url)))((req, f) => f(req)),
       Seq.empty, Duration.Inf
     )
   }
@@ -319,6 +325,18 @@ final class StandaloneAkkaHttpWSRequest private (
    * Execute this request
    */
   override def execute(): Future[Response] = {
+    def decodeResponse(response: HttpResponse): HttpResponse = {
+      val decoder = response.encoding match {
+        case HttpEncodings.gzip ⇒
+          Gzip
+        case HttpEncodings.deflate ⇒
+          Deflate
+        case _ ⇒
+          NoCoding
+      }
+      decoder.decodeMessage(response)
+    }
+
     val akkaExecutor = WSRequestExecutor { request =>
       import sys.dispatcher
       val akkaRequest = request.asInstanceOf[StandaloneAkkaHttpWSRequest].request
@@ -329,7 +347,9 @@ final class StandaloneAkkaHttpWSRequest private (
       }
       Future.firstCompletedOf(
         timeoutFuture :+
-          Http().singleRequest(akkaRequest, connectionContext = ctx).map(StandaloneAkkaHttpWSResponse.apply)(sys.dispatcher)
+          Http().singleRequest(akkaRequest, connectionContext = ctx)
+          .map(decodeResponse)
+          .map(StandaloneAkkaHttpWSResponse.apply)(sys.dispatcher)
       )
     }
 

--- a/play-akka-http-ws-standalone/src/main/scala/play/api/libs/ws/akkahttp/StandaloneAkkaHttpWSRequest.scala
+++ b/play-akka-http-ws-standalone/src/main/scala/play/api/libs/ws/akkahttp/StandaloneAkkaHttpWSRequest.scala
@@ -20,14 +20,24 @@ import scala.concurrent.{ Future, TimeoutException }
 import scala.concurrent.duration.{ Duration, FiniteDuration }
 
 object StandaloneAkkaHttpWSRequest {
-  def apply(url: String)(implicit sys: ActorSystem, mat: Materializer, ctx: HttpsConnectionContext): StandaloneAkkaHttpWSRequest = new StandaloneAkkaHttpWSRequest(HttpRequest().withUri(Uri.parseAbsolute(url)), Seq.empty, Duration.Inf)
+  def apply(url: String)(implicit sys: ActorSystem, mat: Materializer, ctx: HttpsConnectionContext, config: WSClientConfig): StandaloneAkkaHttpWSRequest = {
+    val request = HttpRequest().withUri(Uri.parseAbsolute(url))
+    new StandaloneAkkaHttpWSRequest(
+      config.userAgent.fold(request)(ua => request.withHeaders(`User-Agent`(ua))),
+      Seq.empty, Duration.Inf
+    )
+  }
 }
 
 final class StandaloneAkkaHttpWSRequest private (
     val request: HttpRequest,
     val filters: Seq[WSRequestFilter],
     val timeout: Duration
-)(implicit val sys: ActorSystem, val mat: Materializer, val ctx: HttpsConnectionContext) extends StandaloneWSRequest {
+)(implicit
+  val sys: ActorSystem,
+    val mat: Materializer,
+    val ctx: HttpsConnectionContext,
+    val config: WSClientConfig) extends StandaloneWSRequest {
 
   override type Self = StandaloneWSRequest
   override type Response = StandaloneWSResponse

--- a/play-ws-standalone/src/main/mima-filters/1.0.0.backwards.excludes
+++ b/play-ws-standalone/src/main/mima-filters/1.0.0.backwards.excludes
@@ -1,0 +1,2 @@
+ProblemFilters.exclude[MissingClassProblem]("play.api.libs.ws.package$")
+ProblemFilters.exclude[MissingClassProblem]("play.api.libs.ws.package")

--- a/play-ws-standalone/src/main/mima-filters/1.1.3.backwards.excludes
+++ b/play-ws-standalone/src/main/mima-filters/1.1.3.backwards.excludes
@@ -1,0 +1,2 @@
+#213 Add WSClientConfig support to the Akka Http backend
+ProblemFilters.exclude[MissingTypesProblem]("play.api.libs.ws.WSClientConfig$")

--- a/play-ws-standalone/src/main/scala/play/api/libs/ws/WSClientConfig.scala
+++ b/play-ws-standalone/src/main/scala/play/api/libs/ws/WSClientConfig.scala
@@ -3,6 +3,7 @@
  */
 package play.api.libs.ws
 
+import com.typesafe.config.{ Config, ConfigFactory }
 import com.typesafe.sslconfig.ssl.SSLConfigSettings
 
 import scala.concurrent.duration._
@@ -28,4 +29,25 @@ case class WSClientConfig(
   userAgent: Option[String] = None,
   compressionEnabled: Boolean = false,
   ssl: SSLConfigSettings = SSLConfigSettings())
+
+object WSClientConfig {
+
+  /**
+   * Creates WSClientConfig from the default application configuration.
+   *
+   * @return a WSClientConfig configuration object.
+   */
+  def forConfig(): WSClientConfig =
+    forConfig(ConfigFactory.load(), this.getClass.getClassLoader)
+
+  /**
+   * Creates a WSClientConfig from a Typesafe Config object.
+   *
+   * @param config the config file containing settings for WSConfigParser
+   * @param classLoader the classloader
+   * @return a WSClientConfig configuration object.
+   */
+  def forConfig(config: Config, classLoader: ClassLoader): WSClientConfig =
+    new WSConfigParser(config, classLoader).parse()
+}
 


### PR DESCRIPTION
This adds WSClientConfig support for the Akka Http backend. The only two supported config parameters are `userAgent` and `compressionEnabled`. New tests are added that tests these parameters in AHC and Akka Http backends for both Java and Scala APIs.

Other config parameters need corresponding features from #207.

This PR builds on top of #208 and therefore should be rebased and retargeted to master after #208 is merged. 

Fixes #213