### PR TITLE
#215 Add followRedirects support to the Akka Http backend

### DIFF
--- a/integration-tests/src/test/scala/play/PendingSupport.scala
+++ b/integration-tests/src/test/scala/play/PendingSupport.scala
@@ -26,8 +26,8 @@ trait PendingSupport { self: Specification =>
   }
 
   def pendingFor(backend: Backend, reason: String)(test: => Result): Result = backend match {
-    case Ahc(true) => pending(s"!!! PENDING !!! because AHC backend $reason")
-    case AkkaHttp(true) => pending(s"!!! PENDING !!! because Akka Http backend $reason")
+    case Ahc(true) => pending(s"!!! PENDING !!! AHC backend $reason")
+    case AkkaHttp(true) => pending(s"!!! PENDING !!! Akka Http backend $reason")
     case _ => test
   }
 

--- a/integration-tests/src/test/scala/play/PendingSupport.scala
+++ b/integration-tests/src/test/scala/play/PendingSupport.scala
@@ -1,3 +1,7 @@
+/*
+ * Copyright (C) 2018 Lightbend Inc. <https://www.lightbend.com>
+ */
+
 package play
 
 import org.specs2.execute.Result

--- a/integration-tests/src/test/scala/play/PendingSupport.scala
+++ b/integration-tests/src/test/scala/play/PendingSupport.scala
@@ -1,0 +1,34 @@
+package play
+
+import org.specs2.execute.Result
+import org.specs2.mutable.Specification
+
+trait PendingSupport { self: Specification =>
+
+  trait Backend {
+    val matching: Boolean
+  }
+
+  case class Ahc private (matching: Boolean) extends Backend
+  object Ahc {
+    def apply(c: play.libs.ws.StandaloneWSClient): Ahc =
+      Ahc(c.isInstanceOf[play.libs.ws.ahc.StandaloneAhcWSClient])
+    def apply(c: play.api.libs.ws.StandaloneWSClient): Ahc =
+      Ahc(c.isInstanceOf[play.api.libs.ws.ahc.StandaloneAhcWSClient])
+  }
+
+  case class AkkaHttp private (matching: Boolean) extends Backend
+  object AkkaHttp {
+    def apply(c: play.libs.ws.StandaloneWSClient): AkkaHttp =
+      AkkaHttp(c.isInstanceOf[play.libs.ws.akkahttp.StandaloneAkkaHttpWSClient])
+    def apply(c: play.api.libs.ws.StandaloneWSClient): AkkaHttp =
+      AkkaHttp(c.isInstanceOf[play.api.libs.ws.akkahttp.StandaloneAkkaHttpWSClient])
+  }
+
+  def pendingFor(backend: Backend, reason: String)(test: => Result): Result = backend match {
+    case Ahc(true) => pending(s"!!! PENDING !!! because AHC backend $reason")
+    case AkkaHttp(true) => pending(s"!!! PENDING !!! because Akka Http backend $reason")
+    case _ => test
+  }
+
+}

--- a/integration-tests/src/test/scala/play/api/libs/ws/WSClientConfigSpec.scala
+++ b/integration-tests/src/test/scala/play/api/libs/ws/WSClientConfigSpec.scala
@@ -79,6 +79,16 @@ trait WSClientConfigSpec extends Specification
       }
     }
 
+    "do not follow redirects" in {
+      withClient(_.copy(followRedirects = false)) {
+        _.url(s"http://localhost:$testServerPort/redirect")
+          .get()
+          .map(_.status)
+          .map(_ must beEqualTo(MovedPermanently.intValue))
+          .awaitFor(defaultTimeout)
+      }
+    }
+
     "eventually stop following perpetual redirecting" in {
       withClient(_.copy(followRedirects = true)) {
         _.url(s"http://localhost:$testServerPort/redirect-always")

--- a/integration-tests/src/test/scala/play/api/libs/ws/WSRequestFilterSpec.scala
+++ b/integration-tests/src/test/scala/play/api/libs/ws/WSRequestFilterSpec.scala
@@ -45,7 +45,7 @@ trait WSRequestFilterSpec extends Specification with AkkaServerProvider with Aft
 
   override val routes = WSRequestFilterSpec.routes
 
-  "with request filters" should {
+  "Scala Api WSClient with request filters" should {
 
     class CallbackRequestFilter(callList: mutable.Buffer[Int], value: Int) extends WSRequestFilter {
       override def apply(executor: WSRequestExecutor): WSRequestExecutor = {

--- a/integration-tests/src/test/scala/play/libs/ws/WSClientConfigSpec.scala
+++ b/integration-tests/src/test/scala/play/libs/ws/WSClientConfigSpec.scala
@@ -4,6 +4,7 @@
 
 package play.libs.ws
 
+import akka.http.scaladsl.model.StatusCodes
 import org.specs2.concurrent.ExecutionEnv
 import org.specs2.execute.Result
 import org.specs2.mutable.Specification
@@ -55,6 +56,17 @@ trait WSClientConfigSpec extends Specification
             .map(_ must beEqualTo("OK"))
             .awaitFor(defaultTimeout)
         }
+      }
+    }
+
+    "do not follow redirects" in {
+      withClient(_.copy(followRedirects = false)) {
+        _.url(s"http://localhost:$testServerPort/redirect")
+          .get()
+          .toScala
+          .map(_.getStatus)
+          .map(_ must beEqualTo(StatusCodes.MovedPermanently.intValue))
+          .awaitFor(defaultTimeout)
       }
     }
 

--- a/integration-tests/src/test/scala/play/libs/ws/WSClientConfigSpec.scala
+++ b/integration-tests/src/test/scala/play/libs/ws/WSClientConfigSpec.scala
@@ -57,6 +57,23 @@ trait WSClientConfigSpec extends Specification
         }
       }
     }
+
+    "eventually stop following perpetual redirecting" in {
+      withClient(_.copy(followRedirects = true)) { client =>
+        pendingFor(Ahc(client), "Java Api does not follow redirects") {
+          client.url(s"http://localhost:$testServerPort/redirect-always")
+            .get()
+            .toScala
+            .map(_ => failure)
+            .recover {
+              case ex =>
+                ex.getMessage must contain("Maximum redirect reached")
+                success
+            }
+            .awaitFor(defaultTimeout)
+        }
+      }
+    }
   }
 
 }

--- a/integration-tests/src/test/scala/play/libs/ws/WSClientConfigSpec.scala
+++ b/integration-tests/src/test/scala/play/libs/ws/WSClientConfigSpec.scala
@@ -48,21 +48,23 @@ trait WSClientConfigSpec extends Specification
 
     "follow redirects by default" in {
       withClient(identity) { client =>
-        val request = client.url(s"http://localhost:$testServerPort/redirect")
-        request.getFollowRedirects must beTrue
+        pendingFor(Ahc(client), "does not set builder followRedirects from config") {
+          val request = client.url(s"http://localhost:$testServerPort/redirect")
+          request.getFollowRedirects must beTrue
 
-        request
-          .get()
-          .toScala
-          .map(_.getBody)
-          .map(_ must beEqualTo("OK"))
-          .awaitFor(defaultTimeout)
+          request
+            .get()
+            .toScala
+            .map(_.getBody)
+            .map(_ must beEqualTo("OK"))
+            .awaitFor(defaultTimeout)
+        }
       }
     }
 
     "follow redirects" in {
       withClient(_.copy(followRedirects = true)) { client =>
-        pendingFor(Ahc(client), "Java Api does not follow redirects") {
+        pendingFor(Ahc(client), "Java Api does not follow redirects by default") {
           client.url(s"http://localhost:$testServerPort/redirect")
             .get()
             .toScala

--- a/integration-tests/src/test/scala/play/libs/ws/WSRequestFilterSpec.scala
+++ b/integration-tests/src/test/scala/play/libs/ws/WSRequestFilterSpec.scala
@@ -23,7 +23,7 @@ trait WSRequestFilterSpec extends Specification
 
   override val routes = play.api.libs.ws.WSRequestFilterSpec.routes
 
-  "with request filters" should {
+  "Java Api WSClient with request filters" should {
 
     "execute with adhoc request filter" in {
       withClient() {

--- a/play-akka-http-ws-standalone/src/main/java/play/libs/ws/akkahttp/StandaloneAkkaHttpWSRequest.java
+++ b/play-akka-http-ws-standalone/src/main/java/play/libs/ws/akkahttp/StandaloneAkkaHttpWSRequest.java
@@ -42,6 +42,9 @@ public final class StandaloneAkkaHttpWSRequest implements StandaloneWSRequest {
   private final HttpsConnectionContext ctx;
   private final WSClientConfig config;
 
+  // FIXME make configurable
+  private final static Integer MAX_REDIRECTS = 5;
+
   StandaloneAkkaHttpWSRequest(String url, ActorSystem sys, Materializer mat, HttpsConnectionContext ctx, WSClientConfig config) {
     this(HttpRequest.create(url), new ArrayList<>(), Duration.ZERO, sys, mat, ctx, config);
   }
@@ -167,9 +170,10 @@ public final class StandaloneAkkaHttpWSRequest implements StandaloneWSRequest {
   @Override
   public CompletionStage<? extends StandaloneWSResponse> execute() {
     final WSRequestExecutor akkaExecutor = (request) -> {
+      final HttpRequest akkaRequest = ((StandaloneAkkaHttpWSRequest)request).request;
       final CompletableFuture<StandaloneAkkaHttpWSResponse> resultFuture =
-        Http.get(sys)
-          .singleRequest(((StandaloneAkkaHttpWSRequest)request).request, ctx)
+        requestToResponse(akkaRequest)
+          .thenComposeAsync((resp) -> handleRedirects(MAX_REDIRECTS, akkaRequest, resp))
           .thenApply(StandaloneAkkaHttpWSRequest::decodeResponse)
           .thenApply((r) -> new StandaloneAkkaHttpWSResponse(r, mat))
           .toCompletableFuture();
@@ -676,6 +680,34 @@ public final class StandaloneAkkaHttpWSRequest implements StandaloneWSRequest {
 
   private StandaloneWSRequest copy(Duration timeout) {
     return new StandaloneAkkaHttpWSRequest(this.request, this.filters, timeout, this.sys, this.mat, this.ctx, this.config);
+  }
+
+  private CompletionStage<HttpResponse> requestToResponse(HttpRequest request) {
+    return Http.get(sys).singleRequest(request, ctx);
+  }
+
+  private CompletableFuture<HttpResponse> handleRedirects(Integer redirectsLeft, HttpRequest request, HttpResponse response) {
+    if (redirectsLeft < 1) {
+      final CompletableFuture<HttpResponse> exception = new CompletableFuture<>();
+      exception.completeExceptionally(new TimeoutException("Maximum redirect reached: " + MAX_REDIRECTS));
+      return exception;
+    } else if (response.status().isRedirection()) {
+      final Uri location = response.getHeader(Location.class).get().getUri();
+      Uri redirectUri = location;
+      if (location.isRelative()) {
+        if (location.path().startsWith("/")) {
+          redirectUri = request.getUri().path(location.path());
+        }
+        else {
+          redirectUri = request.getUri().path(request.getUri().path() + location.path());
+        }
+      }
+      return requestToResponse(request.withUri(redirectUri))
+        .thenComposeAsync((resp) -> handleRedirects(redirectsLeft - 1, request, resp))
+        .toCompletableFuture();
+    } else {
+      return CompletableFuture.completedFuture(response);
+    }
   }
 
   private static HttpResponse decodeResponse(HttpResponse response) {

--- a/play-akka-http-ws-standalone/src/main/java/play/libs/ws/akkahttp/StandaloneAkkaHttpWSRequest.java
+++ b/play-akka-http-ws-standalone/src/main/java/play/libs/ws/akkahttp/StandaloneAkkaHttpWSRequest.java
@@ -691,7 +691,7 @@ public final class StandaloneAkkaHttpWSRequest implements StandaloneWSRequest {
       final CompletableFuture<HttpResponse> exception = new CompletableFuture<>();
       exception.completeExceptionally(new TimeoutException("Maximum redirect reached: " + MAX_REDIRECTS));
       return exception;
-    } else if (response.status().isRedirection()) {
+    } else if (response.status().isRedirection() && config.followRedirects()) {
       final Uri location = response.getHeader(Location.class).get().getUri();
       Uri redirectUri = location;
       if (location.isRelative()) {

--- a/play-akka-http-ws-standalone/src/main/java/play/libs/ws/akkahttp/StandaloneAkkaHttpWSRequest.java
+++ b/play-akka-http-ws-standalone/src/main/java/play/libs/ws/akkahttp/StandaloneAkkaHttpWSRequest.java
@@ -435,8 +435,16 @@ public final class StandaloneAkkaHttpWSRequest implements StandaloneWSRequest {
    */
   @Override
   public StandaloneWSRequest setFollowRedirects(boolean followRedirects) {
-    // FIXME https://github.com/playframework/play-ws/issues/207
-    throw new UnsupportedOperationException("Implementation is missing");
+    return copy(config.copy(
+      config.connectionTimeout(),
+      config.idleTimeout(),
+      config.requestTimeout(),
+      followRedirects,
+      config.useProxyProperties(),
+      config.userAgent(),
+      config.compressionEnabled(),
+      config.ssl()
+    ));
   }
 
   /**
@@ -632,8 +640,7 @@ public final class StandaloneAkkaHttpWSRequest implements StandaloneWSRequest {
    */
   @Override
   public boolean getFollowRedirects() {
-    // FIXME https://github.com/playframework/play-ws/issues/207
-    return false;
+    return config.followRedirects();
   }
 
   /**
@@ -680,6 +687,10 @@ public final class StandaloneAkkaHttpWSRequest implements StandaloneWSRequest {
 
   private StandaloneWSRequest copy(Duration timeout) {
     return new StandaloneAkkaHttpWSRequest(this.request, this.filters, timeout, this.sys, this.mat, this.ctx, this.config);
+  }
+
+  private StandaloneWSRequest copy(WSClientConfig config) {
+    return new StandaloneAkkaHttpWSRequest(this.request, this.filters, this.timeout, this.sys, this.mat, this.ctx, config);
   }
 
   private CompletionStage<HttpResponse> requestToResponse(HttpRequest request) {

--- a/play-akka-http-ws-standalone/src/main/java/play/libs/ws/akkahttp/StandaloneAkkaHttpWSResponse.java
+++ b/play-akka-http-ws-standalone/src/main/java/play/libs/ws/akkahttp/StandaloneAkkaHttpWSResponse.java
@@ -25,7 +25,7 @@ import java.util.stream.StreamSupport;
 public final class StandaloneAkkaHttpWSResponse implements StandaloneWSResponse {
 
   // FIXME make configurable
-  final Duration UNMARSHAL_TIMEOUT = Duration.ofSeconds(1);
+  private final static Duration UNMARSHAL_TIMEOUT = Duration.ofSeconds(1);
 
   private final HttpResponse response;
   private final Materializer mat;

--- a/play-akka-http-ws-standalone/src/main/scala/play/api/libs/ws/akkahttp/StandaloneAkkaHttpWSRequest.scala
+++ b/play-akka-http-ws-standalone/src/main/scala/play/api/libs/ws/akkahttp/StandaloneAkkaHttpWSRequest.scala
@@ -334,7 +334,7 @@ final class StandaloneAkkaHttpWSRequest private (
     def handleRedirects(redirectsLeft: Int, request: HttpRequest)(response: HttpResponse): Future[HttpResponse] = {
       if (redirectsLeft < 1) {
         Future.failed(new IllegalStateException("Maximum redirect reached: " + MaxRedirects))
-      } else if (response.status.isRedirection()) {
+      } else if (response.status.isRedirection() && config.followRedirects) {
         val location = response.header[Location].get.uri
         val redirectUri =
           if (location.isRelative)

--- a/play-akka-http-ws-standalone/src/main/scala/play/api/libs/ws/akkahttp/StandaloneAkkaHttpWSRequest.scala
+++ b/play-akka-http-ws-standalone/src/main/scala/play/api/libs/ws/akkahttp/StandaloneAkkaHttpWSRequest.scala
@@ -129,8 +129,7 @@ final class StandaloneAkkaHttpWSRequest private (
    * Whether this request should follow redirects
    */
   override def followRedirects: Option[Boolean] =
-    // FIXME https://github.com/playframework/play-ws/issues/207
-    Some(false)
+    Some(config.followRedirects)
 
   /**
    * The timeout for the request
@@ -207,8 +206,7 @@ final class StandaloneAkkaHttpWSRequest private (
    * Sets whether redirects (301, 302) should be followed automatically
    */
   override def withFollowRedirects(follow: Boolean): Self =
-    // FIXME https://github.com/playframework/play-ws/issues/207
-    ???
+    copy(config = config.copy(followRedirects = follow))
 
   /**
    * Sets the maximum time you expect the request to take.
@@ -391,6 +389,7 @@ final class StandaloneAkkaHttpWSRequest private (
   private def copy(
     request: HttpRequest = request,
     filters: Seq[WSRequestFilter] = filters,
-    timeout: Duration = timeout
-  ) = new StandaloneAkkaHttpWSRequest(request, filters, timeout)
+    timeout: Duration = timeout,
+    config: WSClientConfig = config
+  ) = new StandaloneAkkaHttpWSRequest(request, filters, timeout)(sys, mat, ctx, config)
 }


### PR DESCRIPTION
This adds followRedirects support to the Akka Http backend.

While adding tests for the followRedirects functionality I noticed some inconsistent behaviour of the Ahc backend. Therefore some of the tests are marked as pending for the Ahc backend.

This PR builds on top of #227 (which builds on top of #208 in itself) and therefore should be rebased and retargeted to master after #227 is merged.

Fixes #215