### PR TITLE
Adding methods to retrieve current HTTP method+cookies in Java API

### DIFF
--- a/play-ahc-ws-standalone/src/main/java/play/libs/ws/ahc/StandaloneAhcWSRequest.java
+++ b/play-ahc-ws-standalone/src/main/java/play/libs/ws/ahc/StandaloneAhcWSRequest.java
@@ -271,6 +271,16 @@ public class StandaloneAhcWSRequest implements StandaloneWSRequest {
     }
 
     @Override
+    public String getMethod() {
+        return this.method;
+    }
+
+    @Override
+    public List<WSCookie> getCookies() {
+        return new ArrayList<>(cookies);
+    }
+
+    @Override
     public Map<String, List<String>> getHeaders() {
         return new HashMap<>(this.headers);
     }

--- a/play-ahc-ws-standalone/src/test/scala/play/libs/ws/ahc/AhcWSRequestSpec.scala
+++ b/play-ahc-ws-standalone/src/test/scala/play/libs/ws/ahc/AhcWSRequestSpec.scala
@@ -6,7 +6,6 @@ package play.libs.ws.ahc
 import java.time.Duration
 import java.util.Collections
 
-import akka.util.ByteString
 import org.specs2.mock.Mockito
 import org.specs2.mutable._
 import play.libs.oauth.OAuth
@@ -15,6 +14,7 @@ import play.shaded.ahc.io.netty.handler.codec.http.HttpHeaders
 import play.shaded.ahc.org.asynchttpclient.{ Request, RequestBuilderBase, SignatureCalculator }
 
 import scala.collection.JavaConverters._
+import scala.collection.mutable
 import scala.compat.java8.OptionConverters._
 
 class AhcWSRequestSpec extends Specification with Mockito with DefaultBodyReadables with DefaultBodyWritables {
@@ -24,6 +24,7 @@ class AhcWSRequestSpec extends Specification with Mockito with DefaultBodyReadab
     "Have GET method as the default" in {
       val client = mock[StandaloneAhcWSClient]
       val request = new StandaloneAhcWSRequest(client, "http://example.com", /*materializer*/ null)
+      request.getMethod must be_==("GET")
       request.buildRequest().getMethod must be_==("GET")
     }
 
@@ -36,6 +37,14 @@ class AhcWSRequestSpec extends Specification with Mockito with DefaultBodyReadab
     }
 
     "For POST requests" in {
+
+      "get method" in {
+        val client = mock[StandaloneAhcWSClient]
+        val req = new StandaloneAhcWSRequest(client, "http://playframework.com/", null)
+            .setMethod("POST")
+
+        req.getMethod must be_==("POST")
+      }
 
       "set text/plain content-types for text bodies" in {
         val client = mock[StandaloneAhcWSClient]
@@ -415,6 +424,18 @@ class AhcWSRequestSpec extends Specification with Mockito with DefaultBodyReadab
 
       def cookie(name: String, value: String): WSCookie = {
         new WSCookieBuilder().setName(name).setValue(value).build()
+      }
+
+      "get existing cookies" in {
+        val client = mock[StandaloneAhcWSClient]
+        val request = new StandaloneAhcWSRequest(client, "http://example.com", /*materializer*/ null)
+          .addCookie(cookie("cookie1", "value1"))
+
+        val cookiesInRequest: mutable.Buffer[WSCookie] = request.getCookies.asScala
+        cookiesInRequest.size must beEqualTo(1)
+        val cookieInRequest: WSCookie = cookiesInRequest.head
+        cookieInRequest.getName must beEqualTo("cookie1")
+        cookieInRequest.getValue must beEqualTo("value1")
       }
 
       "add a new cookie" in {

--- a/play-ws-standalone/src/main/java/play/libs/ws/StandaloneWSRequest.java
+++ b/play-ws-standalone/src/main/java/play/libs/ws/StandaloneWSRequest.java
@@ -335,6 +335,20 @@ public interface StandaloneWSRequest {
     String getUrl();
 
     /**
+     * @return the HTTP method of the request.
+     */
+    default String getMethod() {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * @return the cookies (a copy to prevent side-effects).
+     */
+    default List<WSCookie> getCookies() {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
      * @return the headers (a copy to prevent side-effects). This has not passed through an internal request builder and so will not be signed.
      */
     Map<String, List<String>> getHeaders();


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [x] Have you signed the [Typesafe CLA](https://www.typesafe.com/contribute/cla)?
* [x] Have you [squashed your commits](https://www.playframework.com/documentation/latest/WorkingWithGit#Squashing-commits)?
* [ ] Have you added copyright headers to new files?
* [x] Have you checked that both Scala and Java APIs are updated?
* [x] Have you updated the documentation for both Scala and Java sections?
* [x] Have you added tests for any changed functionality?

## Fixes

Fixes #231 and #232 

## Purpose

Adds new methods to the Java API for the StandaloneWSRequest to retrieve the request method and cookies
