### PR TITLE
Build fixes for release

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -181,9 +181,7 @@ lazy val `shaded-asynchttpclient` = project.in(file("shaded/asynchttpclient"))
   .settings(shadeAssemblySettings)
   .settings(
     libraryDependencies ++= asyncHttpClient,
-    name := "shaded-asynchttpclient"
-  )
-  .settings(
+    name := "shaded-asynchttpclient",
     logLevel in assembly := Level.Error,
     assemblyMergeStrategy in assembly := {
       val NettyPropertiesPath = "META-INF" + File.separator + "io.netty.versions.properties"
@@ -227,9 +225,7 @@ lazy val `shaded-oauth` = project.in(file("shaded/oauth"))
   .settings(shadeAssemblySettings)
   .settings(
     libraryDependencies ++= oauth,
-    name := "shaded-oauth"
-  )
-  .settings(
+    name := "shaded-oauth",
     //logLevel in assembly := Level.Debug,
     assemblyShadeRules in assembly := Seq(
       ShadeRule.rename("oauth.**" -> "play.shaded.oauth.@0").inAll,
@@ -309,9 +305,6 @@ lazy val `play-ahc-ws-standalone` = project
     fork in Test := true,
     testOptions in Test := Seq(Tests.Argument(TestFrameworks.JUnit, "-a", "-v"))
   )
-  .settings(
-     // The scaladoc generation
-  )
   .settings(libraryDependencies ++= standaloneAhcWSDependencies)
   .settings(shadedAhcSettings)
   .settings(shadedOAuthSettings)
@@ -352,9 +345,6 @@ lazy val `play-ws-standalone-json` = project
     fork in Test := true,
     testOptions in Test := Seq(Tests.Argument(TestFrameworks.JUnit, "-a", "-v"))
   )
-  .settings(
-    // The scaladoc generation
-  )
   .settings(libraryDependencies ++= standaloneAhcWSJsonDependencies)
   .dependsOn(
     `play-ws-standalone`
@@ -372,12 +362,9 @@ lazy val `play-ws-standalone-xml` = project
   .settings(mimaPreviousArtifacts := Set("com.typesafe.play" %% "play-ws-standalone-xml" % "1.0.0"))
   .settings(
     fork in Test := true,
-    testOptions in Test := Seq(Tests.Argument(TestFrameworks.JUnit, "-a", "-v"))
+    testOptions in Test := Seq(Tests.Argument(TestFrameworks.JUnit, "-a", "-v")),
+    libraryDependencies ++= standaloneAhcWSXMLDependencies
   )
-  .settings(
-    // The scaladoc generation
-  )
-  .settings(libraryDependencies ++= standaloneAhcWSXMLDependencies)
   .dependsOn(
     `play-ws-standalone`
   ).disablePlugins(sbtassembly.AssemblyPlugin)

--- a/build.sbt
+++ b/build.sbt
@@ -3,7 +3,7 @@ import com.typesafe.sbt.SbtScalariform.ScalariformKeys
 
 import com.typesafe.tools.mima.core._
 import com.typesafe.tools.mima.plugin.MimaPlugin.mimaDefaultSettings
-
+import java.io.File
 import sbtassembly.AssemblyPlugin.autoImport._
 import sbtassembly.MergeStrategy
 
@@ -178,13 +178,16 @@ lazy val `shaded-asynchttpclient` = project.in(file("shaded/asynchttpclient"))
   .settings(
     logLevel in assembly := Level.Error,
     assemblyMergeStrategy in assembly := {
-      case "META-INF/io.netty.versions.properties" =>
-        MergeStrategy.first
-      case "ahc-default.properties" =>
-        ahcMerge
-      case x =>
-        val oldStrategy = (assemblyMergeStrategy in assembly).value
-        oldStrategy(x)
+      val NettyPropertiesPath = "META-INF" + File.separator + "io.netty.versions.properties"
+      ({
+        case NettyPropertiesPath =>
+          MergeStrategy.first
+        case "ahc-default.properties" =>
+          ahcMerge
+        case x =>
+          val oldStrategy = (assemblyMergeStrategy in assembly).value
+          oldStrategy(x)
+      }: String => MergeStrategy)
     },
     //logLevel in assembly := Level.Debug,
     assemblyShadeRules in assembly := Seq(

--- a/build.sbt
+++ b/build.sbt
@@ -39,7 +39,6 @@ lazy val mimaSettings = mimaDefaultSettings ++ Seq(
 lazy val commonSettings = mimaSettings ++ Seq(
   organization := "com.typesafe.play",
   scalaVersion := scala212,
-  crossScalaVersions := Seq(scala212, scala211),
   scalacOptions in (Compile, doc) ++= Seq(
     "-target:jvm-1.8",
     "-deprecation",
@@ -86,6 +85,10 @@ lazy val commonSettings = mimaSettings ++ Seq(
   javacOptions in IntegrationTest ++= javacSettings
 )
 
+lazy val crossBuildSettings = Seq(
+  crossScalaVersions := Seq(scala212, scala211)
+)
+
 val formattingSettings = Seq(
   scalariformAutoformat := true,
   ScalariformKeys.preferences := ScalariformKeys.preferences.value
@@ -108,8 +111,7 @@ val disablePublishing = Seq[Setting[_]](
   publishLocal := {}
 )
 
-lazy val shadeAssemblySettings = commonSettings ++ Seq(
-  crossScalaVersions := Seq(scala212),
+lazy val shadeAssemblySettings = Seq(
   assemblyOption in assembly ~= (_.copy(includeScala = false)),
   test in assembly := {},
   assemblyOption in assembly ~= {
@@ -131,7 +133,13 @@ lazy val shadeAssemblySettings = commonSettings ++ Seq(
         sys.error("Cannot find valid scala version!")
     }
   },
-  crossPaths := false // only useful for Java
+  // Since these are Java libraries, disable some Scala and cross-building settings
+  // Note we can't add crossScalaPaths = None or Seq("2.12.4")  here due to
+  // https://github.com/sbt/sbt-release/issues/219. Instead we have to have it as
+  // a separate setting.
+  releaseCrossBuild := false,
+  crossPaths := false,
+  autoScalaLibrary := false
 )
 
 val ahcMerge: MergeStrategy = new MergeStrategy {
@@ -265,8 +273,11 @@ lazy val shaded = Project(id = "shaded", base = file("shaded") )
 lazy val `play-ws-standalone` = project
   .in(file("play-ws-standalone"))
   .settings(commonSettings)
-  .settings(mimaPreviousArtifacts := Set("com.typesafe.play" %% "play-ws-standalone" % "1.0.0"))
-  .settings(libraryDependencies ++= standaloneApiWSDependencies)
+  .settings(crossBuildSettings)
+  .settings(
+    mimaPreviousArtifacts := Set("com.typesafe.play" %% "play-ws-standalone" % "1.0.0"),
+    libraryDependencies ++= standaloneApiWSDependencies
+  )
   .disablePlugins(sbtassembly.AssemblyPlugin)
 
 //---------------------------------------------------------------
@@ -291,6 +302,7 @@ def addShadedDeps(deps: Seq[xml.Node], node: xml.Node): xml.Node = {
 lazy val `play-ahc-ws-standalone` = project
   .in(file("play-ahc-ws-standalone"))
   .settings(commonSettings)
+  .settings(crossBuildSettings)
   .settings(formattingSettings)
   .settings(mimaPreviousArtifacts := Set("com.typesafe.play" %% "play-ahc-ws-standalone" % "1.0.0"))
   .settings(
@@ -333,6 +345,7 @@ lazy val `play-ahc-ws-standalone` = project
 lazy val `play-ws-standalone-json` = project
   .in(file("play-ws-standalone-json"))
   .settings(commonSettings)
+  .settings(crossBuildSettings)
   .settings(formattingSettings)
   .settings(mimaPreviousArtifacts := Set("com.typesafe.play" %% "play-ws-standalone-json" % "1.0.0"))
   .settings(
@@ -354,6 +367,7 @@ lazy val `play-ws-standalone-json` = project
 lazy val `play-ws-standalone-xml` = project
   .in(file("play-ws-standalone-xml"))
   .settings(commonSettings)
+  .settings(crossBuildSettings)
   .settings(formattingSettings)
   .settings(mimaPreviousArtifacts := Set("com.typesafe.play" %% "play-ws-standalone-xml" % "1.0.0"))
   .settings(
@@ -374,6 +388,7 @@ lazy val `play-ws-standalone-xml` = project
 
 lazy val `integration-tests` = project.in(file("integration-tests"))
   .settings(commonSettings)
+  .settings(crossBuildSettings)
   .settings(formattingSettings)
   .settings(disableDocs)
   .settings(disablePublishing)
@@ -400,6 +415,7 @@ lazy val root = project
   .in(file("."))
   .settings(name := "play-ws-standalone-root")
   .settings(commonSettings)
+  .settings(crossBuildSettings)
   .settings(formattingSettings)
   .settings(disableDocs)
   .settings(disablePublishing)

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,4 +1,4 @@
 #
 # Copyright (C) 2009-2017 Lightbend Inc. <https://www.lightbend.com>
 #
-sbt.version=1.1.0
+sbt.version=1.1.1


### PR DESCRIPTION
Misc changes to the build. See the commit message for more info. The commit `
Avoid setting crossBuildScalaVersions for shaded projects` is the major issue that is fixed.