### PR TITLE
fix: make query param order deterministic when adding params

### DIFF
--- a/play-ahc-ws-standalone/src/main/java/play/libs/ws/ahc/StandaloneAhcWSRequest.java
+++ b/play-ahc-ws-standalone/src/main/java/play/libs/ws/ahc/StandaloneAhcWSRequest.java
@@ -47,7 +47,7 @@ public class StandaloneAhcWSRequest implements StandaloneWSRequest {
     private final String url;
     private String method = "GET";
     private final Map<String, List<String>> headers = new HashMap<>();
-    private final Map<String, List<String>> queryParameters = new HashMap<>();
+    private final Map<String, List<String>> queryParameters = new LinkedHashMap<>();
 
     private final List<WSCookie> cookies = new ArrayList<>();
 
@@ -287,7 +287,7 @@ public class StandaloneAhcWSRequest implements StandaloneWSRequest {
 
     @Override
     public Map<String, List<String>> getQueryParameters() {
-        return new HashMap<>(this.queryParameters);
+        return new LinkedHashMap<>(this.queryParameters);
     }
 
     @Override

--- a/play-ahc-ws-standalone/src/test/scala/play/libs/ws/ahc/AhcWSRequestSpec.scala
+++ b/play-ahc-ws-standalone/src/test/scala/play/libs/ws/ahc/AhcWSRequestSpec.scala
@@ -333,6 +333,38 @@ class AhcWSRequestSpec extends Specification with Mockito with DefaultBodyReadab
         request.getUrl must contain("p1=v1")
       }
 
+      "deterministic query param order a" in {
+        val client = mock[StandaloneAhcWSClient]
+        val request = new StandaloneAhcWSRequest(client, "http://example.com", /*materializer*/ null)
+          .addQueryParameter("p1", "v1")
+          .addQueryParameter("p2", "v2")
+          .buildRequest()
+
+        request.getUrl must contain("p1=v1&p2=v2")
+      }
+
+      "deterministic query param order b" in {
+        val client = mock[StandaloneAhcWSClient]
+        val request = new StandaloneAhcWSRequest(client, "http://example.com", /*materializer*/ null)
+          .addQueryParameter("p2", "v2")
+          .addQueryParameter("p1", "v1")
+          .buildRequest()
+
+        request.getUrl must contain("p2=v2&p1=v1")
+      }
+
+      "deterministic query param order for duplicate keys" in {
+        val client = mock[StandaloneAhcWSClient]
+        val request = new StandaloneAhcWSRequest(client, "http://example.com", /*materializer*/ null)
+          .addQueryParameter("p1", "v1")
+          .addQueryParameter("p2", "v2")
+          .addQueryParameter("p1", "v3")
+          .addQueryParameter("p1", "v4")
+          .buildRequest()
+
+        request.getUrl must contain("p1=v1&p1=v3&p1=v4&p2=v2")
+      }
+
       "add new value for existing parameter" in {
         val client = mock[StandaloneAhcWSClient]
         val request = new StandaloneAhcWSRequest(client, "http://example.com", /*materializer*/ null)


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [x] Have you signed the [Typesafe CLA](https://www.typesafe.com/contribute/cla)?
* [x] Have you [squashed your commits](https://www.playframework.com/documentation/latest/WorkingWithGit#Squashing-commits)?
* [ ] Have you added copyright headers to new files?
* [ ] Have you checked that both Scala and Java APIs are updated?
* [ ] Have you updated the documentation for both Scala and Java sections?
* [x] Have you added tests for any changed functionality?

## Fixes

Fixes #48 

## Purpose

Ensure deterministic query param order when adding params through the WSRequest interface.
This does not address order when adding to a query param that already contains a value.
for example
```
req.addQueryParam("p1", "v1")
req.addQueryParam("p2", "v2")
req.addQueryParam("p1, "v3")
```
will yield `p1=v1&p1=v3&p2=v2` which is still not perfect but is at least deterministic


## Background Context

I wanted to make the minimal code change to achieve deterministic behaviour.
When generating digital signatures of urls (for example of an Authorization header) it's important to have a deterministic order to be able to correctly compute the digest.

## References

https://github.com/playframework/playframework/pull/6884
https://github.com/playframework/play-ws/pull/102