### PR TITLE
Fix double publishing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ cache:
   - "$HOME/.ivy2/cache"
   - "$HOME/.sbt/boot/"
 script:
-- sbt ++$TRAVIS_SCALA_VERSION 'test-only -- xonly timefactor 5' mimaReportBinaryIssues doc 
+- sbt ++$TRAVIS_SCALA_VERSION 'testOnly -- xonly timefactor 5' mimaReportBinaryIssues doc 
 before_cache:
 - find $HOME/.ivy2/cache -name "ivydata-*.properties" | xargs rm
 notifications:

--- a/build.sbt
+++ b/build.sbt
@@ -13,6 +13,9 @@ import scalariform.formatter.preferences._
 // Shading and Project Settings
 //---------------------------------------------------------------
 
+val scala211 = "2.11.12"
+val scala212 = "2.12.4"
+
 val previousVersion = None
 
 resolvers ++= DefaultOptions.resolvers(snapshot = true)
@@ -35,8 +38,8 @@ lazy val mimaSettings = mimaDefaultSettings ++ Seq(
 
 lazy val commonSettings = mimaSettings ++ Seq(
   organization := "com.typesafe.play",
-  scalaVersion := "2.12.4",
-  crossScalaVersions := Seq("2.12.4", "2.11.12"),
+  scalaVersion := scala212,
+  crossScalaVersions := Seq(scala212, scala211),
   scalacOptions in (Compile, doc) ++= Seq(
     "-target:jvm-1.8",
     "-deprecation",
@@ -106,6 +109,7 @@ val disablePublishing = Seq[Setting[_]](
 )
 
 lazy val shadeAssemblySettings = commonSettings ++ Seq(
+  crossScalaVersions := Seq(scala212),
   assemblyOption in assembly ~= (_.copy(includeScala = false)),
   test in assembly := {},
   assemblyOption in assembly ~= {

--- a/build.sbt
+++ b/build.sbt
@@ -103,9 +103,8 @@ val disableDocs = Seq[Setting[_]](
 
 val disablePublishing = Seq[Setting[_]](
   publishArtifact := false,
-  // The above is enough for Maven repos but it doesn't prevent publishing of ivy.xml files
-  publish := {},
-  publishLocal := {}
+  skip in publish := true,
+  crossScalaVersions := Seq(scala212)
 )
 
 lazy val shadeAssemblySettings = commonSettings ++ Seq(
@@ -247,12 +246,14 @@ val shadedOAuthSettings = Seq(
 //---------------------------------------------------------------
 
 lazy val shaded = Project(id = "shaded", base = file("shaded") )
-  .settings(disableDocs)
-  .settings(disablePublishing)
   .aggregate(
     `shaded-asynchttpclient`,
     `shaded-oauth`
   ).disablePlugins(sbtassembly.AssemblyPlugin)
+  .settings(
+    disableDocs,
+    disablePublishing,
+  )
 
 //---------------------------------------------------------------
 // WS API
@@ -319,8 +320,6 @@ lazy val `play-ahc-ws-standalone` = project
   )
   .dependsOn(
     `play-ws-standalone`
-  ).aggregate(
-    `shaded`
   ).disablePlugins(sbtassembly.AssemblyPlugin)
 
 //---------------------------------------------------------------
@@ -375,6 +374,7 @@ lazy val `integration-tests` = project.in(file("integration-tests"))
   .settings(disableDocs)
   .settings(disablePublishing)
   .settings(
+    crossScalaVersions := Seq(scala212, scala211),
     fork in Test := true,
     concurrentRestrictions += Tags.limitAll(1), // only one integration test at a time
     testOptions in Test := Seq(Tests.Argument(TestFrameworks.JUnit, "-a", "-v")),

--- a/build.sbt
+++ b/build.sbt
@@ -84,12 +84,13 @@ lazy val commonSettings = mimaSettings ++ Seq(
 )
 
 val formattingSettings = Seq(
+  scalariformAutoformat := true,
   ScalariformKeys.preferences := ScalariformKeys.preferences.value
     .setPreference(SpacesAroundMultiImports, true)
     .setPreference(SpaceInsideParentheses, false)
     .setPreference(DanglingCloseParenthesis, Preserve)
     .setPreference(PreserveSpaceBeforeArguments, true)
-    .setPreference(DoubleIndentClassDeclaration, true)
+    .setPreference(DoubleIndentConstructorArguments, true)
 )
 
 val disableDocs = Seq[Setting[_]](
@@ -193,7 +194,7 @@ lazy val `shaded-asynchttpclient` = project.in(file("shaded/asynchttpclient"))
 
     // https://stackoverflow.com/questions/24807875/how-to-remove-projectdependencies-from-pom
     // Remove dependencies from the POM because we have a FAT jar here.
-    makePomConfiguration := makePomConfiguration.value.copy(process = dependenciesFilter),
+    makePomConfiguration := makePomConfiguration.value.withProcess(process = dependenciesFilter),
     //ivyXML := <dependencies></dependencies>,
     //ivyLoggingLevel := UpdateLogging.Full,
     //logLevel := Level.Debug,
@@ -222,7 +223,7 @@ lazy val `shaded-oauth` = project.in(file("shaded/oauth"))
 
     // https://stackoverflow.com/questions/24807875/how-to-remove-projectdependencies-from-pom
     // Remove dependencies from the POM because we have a FAT jar here.
-    makePomConfiguration := makePomConfiguration.value.copy(process = dependenciesFilter),
+    makePomConfiguration := makePomConfiguration.value.withProcess(process = dependenciesFilter),
 
     assemblyOption in assembly := (assemblyOption in assembly).value.copy(includeBin = false, includeScala = false),
     packageBin in Compile := assembly.value
@@ -285,7 +286,6 @@ lazy val `play-ahc-ws-standalone` = project
   .settings(commonSettings)
   .settings(formattingSettings)
   .settings(mimaPreviousArtifacts := Set("com.typesafe.play" %% "play-ahc-ws-standalone" % "1.0.0"))
-  .settings(SbtScalariform.scalariformSettings)
   .settings(
     fork in Test := true,
     testOptions in Test := Seq(Tests.Argument(TestFrameworks.JUnit, "-a", "-v"))
@@ -328,7 +328,6 @@ lazy val `play-ws-standalone-json` = project
   .settings(commonSettings)
   .settings(formattingSettings)
   .settings(mimaPreviousArtifacts := Set("com.typesafe.play" %% "play-ws-standalone-json" % "1.0.0"))
-  .settings(SbtScalariform.scalariformSettings)
   .settings(
     fork in Test := true,
     testOptions in Test := Seq(Tests.Argument(TestFrameworks.JUnit, "-a", "-v"))
@@ -350,7 +349,6 @@ lazy val `play-ws-standalone-xml` = project
   .settings(commonSettings)
   .settings(formattingSettings)
   .settings(mimaPreviousArtifacts := Set("com.typesafe.play" %% "play-ws-standalone-xml" % "1.0.0"))
-  .settings(SbtScalariform.scalariformSettings)
   .settings(
     fork in Test := true,
     testOptions in Test := Seq(Tests.Argument(TestFrameworks.JUnit, "-a", "-v"))
@@ -372,7 +370,6 @@ lazy val `integration-tests` = project.in(file("integration-tests"))
   .settings(formattingSettings)
   .settings(disableDocs)
   .settings(disablePublishing)
-  .settings(SbtScalariform.scalariformSettings)
   .settings(
     fork in Test := true,
     concurrentRestrictions += Tags.limitAll(1), // only one integration test at a time
@@ -417,6 +414,14 @@ import sbtrelease.ReleasePlugin.autoImport.ReleaseTransformations._
 // otherwise same as orgname, and "sonatypeList" says "No staging profile is found for com.typesafe.play"
 sonatypeProfileName := "com.typesafe"
 
+val publishSignedCommand: State => State =
+    (state: State) =>
+      state.copy(remainingCommands = Exec("publishSigned", None) +: state.remainingCommands)
+
+val sonatypeReleaseAllCommand: State => State =
+    (state: State) =>
+      state.copy(remainingCommands = Exec("sonatypeReleaseAll", None) +: state.remainingCommands)
+
 releaseProcess := Seq[ReleaseStep](
   checkSnapshotDependencies,
   inquireVersions,
@@ -425,9 +430,9 @@ releaseProcess := Seq[ReleaseStep](
   setReleaseVersion,
   commitReleaseVersion,
   tagRelease,
-  ReleaseStep(action = Command.process("publishSigned", _), enableCrossBuild = true),
+  ReleaseStep(action = publishSignedCommand, enableCrossBuild = true),
   setNextVersion,
   commitNextVersion,
-  ReleaseStep(action = Command.process("sonatypeReleaseAll", _), enableCrossBuild = true),
+  ReleaseStep(action = sonatypeReleaseAllCommand, enableCrossBuild = true),
   pushChanges
 )

--- a/build.sbt
+++ b/build.sbt
@@ -412,15 +412,11 @@ lazy val root = project
 import sbtrelease.ReleasePlugin.autoImport.ReleaseTransformations._
 
 // otherwise same as orgname, and "sonatypeList" says "No staging profile is found for com.typesafe.play"
-sonatypeProfileName := "com.typesafe"
+sonatypeProfileName in ThisBuild := "com.typesafe"
 
-val publishSignedCommand: State => State =
-    (state: State) =>
-      state.copy(remainingCommands = Exec("publishSigned", None) +: state.remainingCommands)
-
-val sonatypeReleaseAllCommand: State => State =
-    (state: State) =>
-      state.copy(remainingCommands = Exec("sonatypeReleaseAll", None) +: state.remainingCommands)
+// This automatically selects the snapshots or staging repository
+// according to the version value.
+publishTo in ThisBuild := Some(sonatypeDefaultResolver.value)
 
 releaseProcess := Seq[ReleaseStep](
   checkSnapshotDependencies,
@@ -430,9 +426,9 @@ releaseProcess := Seq[ReleaseStep](
   setReleaseVersion,
   commitReleaseVersion,
   tagRelease,
-  ReleaseStep(action = publishSignedCommand, enableCrossBuild = true),
+  releaseStepCommandAndRemaining("+publishSigned"),
   setNextVersion,
   commitNextVersion,
-  ReleaseStep(action = sonatypeReleaseAllCommand, enableCrossBuild = true),
+  releaseStepCommand("+sonatypeReleaseAll"),
   pushChanges
 )

--- a/integration-tests/src/test/scala/play/api/libs/ws/ahc/AhcWSClientSpec.scala
+++ b/integration-tests/src/test/scala/play/api/libs/ws/ahc/AhcWSClientSpec.scala
@@ -15,10 +15,10 @@ import play.api.libs.ws.{ BodyReadable, DefaultBodyReadables }
 import scala.concurrent._
 
 class AhcWSClientSpec(implicit val executionEnv: ExecutionEnv) extends Specification
-    with AkkaServerProvider
-    with FutureMatchers
-    with FutureAwait
-    with DefaultBodyReadables {
+  with AkkaServerProvider
+  with FutureMatchers
+  with FutureAwait
+  with DefaultBodyReadables {
 
   def withClient(config: AhcWSClientConfig = AhcWSClientConfigFactory.forConfig())(block: StandaloneAhcWSClient => Result): Result = {
     val client = StandaloneAhcWSClient(config)

--- a/play-ahc-ws-standalone/src/main/scala/play/api/libs/ws/ahc/AhcConfig.scala
+++ b/play-ahc-ws-standalone/src/main/scala/play/api/libs/ws/ahc/AhcConfig.scala
@@ -35,15 +35,15 @@ import scala.concurrent.duration._
  * @param keepAlive keeps thread pool active, replaces allowPoolingConnection and allowSslConnectionPool
  */
 case class AhcWSClientConfig(
-  wsClientConfig: WSClientConfig = WSClientConfig(),
-  maxConnectionsPerHost: Int = -1,
-  maxConnectionsTotal: Int = -1,
-  maxConnectionLifetime: Duration = Duration.Inf,
-  idleConnectionInPoolTimeout: Duration = 1.minute,
-  maxNumberOfRedirects: Int = 5,
-  maxRequestRetry: Int = 5,
-  disableUrlEncoding: Boolean = false,
-  keepAlive: Boolean = true)
+    wsClientConfig: WSClientConfig = WSClientConfig(),
+    maxConnectionsPerHost: Int = -1,
+    maxConnectionsTotal: Int = -1,
+    maxConnectionLifetime: Duration = Duration.Inf,
+    idleConnectionInPoolTimeout: Duration = 1.minute,
+    maxNumberOfRedirects: Int = 5,
+    maxRequestRetry: Int = 5,
+    disableUrlEncoding: Boolean = false,
+    keepAlive: Boolean = true)
 
 /**
  * Factory for creating AhcWSClientConfig, for use from Java.

--- a/play-ahc-ws-standalone/src/main/scala/play/api/libs/ws/ahc/StandaloneAhcWSResponse.scala
+++ b/play-ahc-ws-standalone/src/main/scala/play/api/libs/ws/ahc/StandaloneAhcWSResponse.scala
@@ -14,9 +14,9 @@ import scala.collection.JavaConverters._
  * A WS HTTP response backed by org.asynchttpclient.Response.
  */
 class StandaloneAhcWSResponse(ahcResponse: AHCResponse) extends StandaloneWSResponse
-    with DefaultBodyReadables
-    with WSCookieConverter
-    with AhcUtilities {
+  with DefaultBodyReadables
+  with WSCookieConverter
+  with AhcUtilities {
 
   override lazy val headers: Map[String, Seq[String]] = headersToMap(ahcResponse.getHeaders)
 

--- a/play-ahc-ws-standalone/src/main/scala/play/api/libs/ws/ahc/Streamed.scala
+++ b/play-ahc-ws-standalone/src/main/scala/play/api/libs/ws/ahc/Streamed.scala
@@ -13,11 +13,11 @@ import play.shaded.ahc.org.asynchttpclient.handler.StreamedAsyncHandler
 import scala.concurrent.Promise
 
 case class StreamedState(
-  statusCode: Int = -1,
-  statusText: String = "",
-  uriOption: Option[URI] = None,
-  responseHeaders: Map[String, Seq[String]] = Map.empty,
-  publisher: Publisher[HttpResponseBodyPart] = EmptyPublisher
+    statusCode: Int = -1,
+    statusText: String = "",
+    uriOption: Option[URI] = None,
+    responseHeaders: Map[String, Seq[String]] = Map.empty,
+    publisher: Publisher[HttpResponseBodyPart] = EmptyPublisher
 )
 
 class DefaultStreamedAsyncHandler[T](f: java.util.function.Function[StreamedState, T], promise: Promise[T]) extends StreamedAsyncHandler[Unit] with AhcUtilities {

--- a/play-ahc-ws-standalone/src/main/scala/play/api/libs/ws/ahc/cache/AsyncCachingHandler.scala
+++ b/play-ahc-ws-standalone/src/main/scala/play/api/libs/ws/ahc/cache/AsyncCachingHandler.scala
@@ -17,13 +17,13 @@ import scala.concurrent.duration.Duration
  * An async handler that accumulates response data to place in cache with the given key.
  */
 class AsyncCachingHandler[T](
-  request: Request,
-  handler: AsyncCompletionHandler[T],
-  cache: AhcHttpCache,
-  maybeAction: Option[ResponseServeAction])
-    extends AsyncHandler[T]
-    with TimeoutResponse
-    with Debug {
+    request: Request,
+    handler: AsyncCompletionHandler[T],
+    cache: AhcHttpCache,
+    maybeAction: Option[ResponseServeAction])
+  extends AsyncHandler[T]
+  with TimeoutResponse
+  with Debug {
 
   private val DATE = "Date"
 

--- a/play-ahc-ws-standalone/src/main/scala/play/api/libs/ws/ahc/cache/BackgroundAsyncHandler.scala
+++ b/play-ahc-ws-standalone/src/main/scala/play/api/libs/ws/ahc/cache/BackgroundAsyncHandler.scala
@@ -15,8 +15,8 @@ import scala.concurrent.Await
  * An async handler that accumulates a response and stores it to cache in the background.
  */
 class BackgroundAsyncHandler[T](request: Request, cache: AhcHttpCache)
-    extends AsyncHandler[T]
-    with Debug {
+  extends AsyncHandler[T]
+  with Debug {
 
   import BackgroundAsyncHandler.logger
 

--- a/play-ahc-ws-standalone/src/main/scala/play/api/libs/ws/ahc/cache/CacheAsyncConnection.scala
+++ b/play-ahc-ws-standalone/src/main/scala/play/api/libs/ws/ahc/cache/CacheAsyncConnection.scala
@@ -16,11 +16,11 @@ import play.shaded.ahc.org.asynchttpclient.handler.ProgressAsyncHandler
  * Calls the relevant methods on the async handler, providing it with the cached response.
  */
 class AsyncCacheableConnection[T](
-  asyncHandler: AsyncHandler[T],
-  request: Request,
-  response: CacheableResponse,
-  future: ListenableFuture[T])
-    extends Callable[T] with Debug {
+    asyncHandler: AsyncHandler[T],
+    request: Request,
+    response: CacheableResponse,
+    future: ListenableFuture[T])
+  extends Callable[T] with Debug {
 
   import AsyncCacheableConnection._
 

--- a/play-ahc-ws-standalone/src/main/scala/play/api/libs/ws/ahc/cache/CacheableResponse.scala
+++ b/play-ahc-ws-standalone/src/main/scala/play/api/libs/ws/ahc/cache/CacheableResponse.scala
@@ -228,7 +228,7 @@ case class CacheableResponse(
 }
 
 case class CacheableHttpResponseHeaders(trailingHeaders: Boolean, headers: HttpHeaders)
-    extends HttpResponseHeaders(headers, trailingHeaders) {
+  extends HttpResponseHeaders(headers, trailingHeaders) {
 
   override def toString: String = {
     s"CacheableHttpResponseHeaders(trailingHeaders = $trailingHeaders, headers = $headers)"
@@ -261,11 +261,11 @@ object CacheableResponse {
 
 // https://github.com/AsyncHttpClient/async-http-client/blob/2.0/client/src/main/java/org/asynchttpclient/netty/NettyResponseStatus.java
 class CacheableHttpResponseStatus(
-  uri: Uri,
-  statusCode: Int,
-  statusText: String,
-  protocolText: String)
-    extends HttpResponseStatus(uri, null) {
+    uri: Uri,
+    statusCode: Int,
+    statusText: String,
+    protocolText: String)
+  extends HttpResponseStatus(uri, null) {
   override def getStatusCode: Int = statusCode
 
   override def getProtocolText: String = protocolText

--- a/play-ahc-ws-standalone/src/main/scala/play/api/libs/ws/ahc/cache/CachingAsyncHttpClient.scala
+++ b/play-ahc-ws-standalone/src/main/scala/play/api/libs/ws/ahc/cache/CachingAsyncHttpClient.scala
@@ -29,11 +29,11 @@ trait TimeoutResponse {
  * A provider that pulls a response from the cache.
  */
 class CachingAsyncHttpClient(
-  underlying: AsyncHttpClient,
-  ahcHttpCache: AhcHttpCache)
-    extends AsyncHttpClient
-    with TimeoutResponse
-    with Debug {
+    underlying: AsyncHttpClient,
+    ahcHttpCache: AhcHttpCache)
+  extends AsyncHttpClient
+  with TimeoutResponse
+  with Debug {
 
   import com.typesafe.play.cachecontrol.ResponseSelectionActions._
   import com.typesafe.play.cachecontrol.ResponseServeActions._

--- a/play-ws-standalone/src/main/scala/play/api/libs/ws/Body.scala
+++ b/play-ws-standalone/src/main/scala/play/api/libs/ws/Body.scala
@@ -31,8 +31,7 @@ case class InMemoryBody(bytes: ByteString) extends WSBody
 case class SourceBody(source: Source[ByteString, _]) extends WSBody
 
 @implicitNotFound(
-  "Cannot find an instance of StandaloneWSResponse to ${R}. Define a BodyReadable[${R}] or extend play.api.libs.ws.ahc.DefaultBodyReadables"
-)
+  "Cannot find an instance of StandaloneWSResponse to ${R}. Define a BodyReadable[${R}] or extend play.api.libs.ws.ahc.DefaultBodyReadables")
 class BodyReadable[+R](val transform: StandaloneWSResponse => R)
 
 object BodyReadable {
@@ -43,8 +42,7 @@ object BodyReadable {
  * This is a type class pattern for writing different types of bodies to a WS request.
  */
 @implicitNotFound(
-  "Cannot find an instance of ${A} to WSBody. Define a BodyWritable[${A}] or extend play.api.libs.ws.ahc.DefaultBodyWritables"
-)
+  "Cannot find an instance of ${A} to WSBody. Define a BodyWritable[${A}] or extend play.api.libs.ws.ahc.DefaultBodyWritables")
 class BodyWritable[-A](val transform: A => WSBody, val contentType: String) {
   def map[B](f: B => A): BodyWritable[B] = new BodyWritable(b => transform(f(b)), contentType)
 }

--- a/play-ws-standalone/src/main/scala/play/api/libs/ws/DefaultBodyWritables.scala
+++ b/play-ws-standalone/src/main/scala/play/api/libs/ws/DefaultBodyWritables.scala
@@ -100,8 +100,7 @@ trait DefaultBodyWritables {
     BodyWritable(
       formData =>
         InMemoryBody(ByteString.fromString(formData.flatMap(item => item._2.map(c => s"${item._1}=${URLEncoder.encode(c, "UTF-8")}")).mkString("&"))),
-      "application/x-www-form-urlencoded"
-    )
+      "application/x-www-form-urlencoded")
   }
 
   implicit val writeableOf_urlEncodedSimpleForm: BodyWritable[Map[String, String]] = {

--- a/play-ws-standalone/src/main/scala/play/api/libs/ws/WS.scala
+++ b/play-ws-standalone/src/main/scala/play/api/libs/ws/WS.scala
@@ -73,8 +73,7 @@ case class DefaultWSCookie(
   path: Option[String] = None,
   maxAge: Option[Long] = None,
   secure: Boolean = false,
-  httpOnly: Boolean = false
-) extends WSCookie
+  httpOnly: Boolean = false) extends WSCookie
 
 /**
  * A WS proxy.
@@ -127,8 +126,7 @@ case class DefaultWSProxyServer(
   /* The realm's charset. */
   encoding: Option[String] = None,
 
-  nonProxyHosts: Option[Seq[String]] = None
-) extends WSProxyServer
+  nonProxyHosts: Option[Seq[String]] = None) extends WSProxyServer
 
 /**
  * Sign a WS call with OAuth.

--- a/play-ws-standalone/src/main/scala/play/api/libs/ws/WSClientConfig.scala
+++ b/play-ws-standalone/src/main/scala/play/api/libs/ws/WSClientConfig.scala
@@ -27,6 +27,5 @@ case class WSClientConfig(
   useProxyProperties: Boolean = true,
   userAgent: Option[String] = None,
   compressionEnabled: Boolean = false,
-  ssl: SSLConfigSettings = SSLConfigSettings()
-)
+  ssl: SSLConfigSettings = SSLConfigSettings())
 

--- a/play-ws-standalone/src/main/scala/play/api/libs/ws/WSConfigParser.scala
+++ b/play-ws-standalone/src/main/scala/play/api/libs/ws/WSConfigParser.scala
@@ -56,8 +56,7 @@ class WSConfigParser @Inject() (config: Config, classLoader: ClassLoader) extend
       useProxyProperties = useProxyProperties,
       userAgent = userAgent,
       compressionEnabled = compressionEnabled,
-      ssl = sslConfig
-    )
+      ssl = sslConfig)
   }
 
   override lazy val get: WSClientConfig = parse()

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,4 +1,4 @@
 #
 # Copyright (C) 2009-2017 Lightbend Inc. <https://www.lightbend.com>
 #
-sbt.version=1.0.4
+sbt.version=1.1.0

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,4 +1,4 @@
 #
 # Copyright (C) 2009-2017 Lightbend Inc. <https://www.lightbend.com>
 #
-sbt.version=0.13.15
+sbt.version=1.0.4

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,4 +1,4 @@
 #
 # Copyright (C) 2009-2017 Lightbend Inc. <https://www.lightbend.com>
 #
-sbt.version=1.1.0
+sbt.version=1.1.1

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -2,15 +2,15 @@
 resolvers ++= DefaultOptions.resolvers(snapshot = true)
 resolvers += Resolver.typesafeRepo("releases")
 
-addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "1.1")
-addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.0.0")
+addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "2.0")
+addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.1.0")
 
 addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.6")
 
-addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.3")
+addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.7")
 
-addSbtPlugin("org.scalariform" % "sbt-scalariform" % "1.6.0")
+addSbtPlugin("org.scalariform" % "sbt-scalariform" % "1.8.2")
 
-addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "0.1.14")
+addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "0.1.18")
 
-addSbtPlugin("com.gilt" % "sbt-dependency-graph-sugar" % "0.8.2")
+addSbtPlugin("com.gilt" % "sbt-dependency-graph-sugar" % "0.9.0")


### PR DESCRIPTION
Ref sbt/sbt-release#219

I don't think double publishing is the problem of sbt-release.

Part of the reason double publishing is happening is due to `crossScalaVersions := Seq(scala212, scala211)` set in artificial subprojects like `root` and `shaded`, and that these subprojects aggregate shaded Java subprojects. This means that when `+` traversal is on 2.11.x, it will propagate `publishSigned` to them, resulting in double publishing.

This adds `crossScalaVersions := Seq(scala212)` to `disablePublishing` so `root` and `shaded` do not cross build.

In addition, to avoid command propagation `aggregate(shaded)` was removed from `play-ahc-ws-standalone`.

See https://gist.github.com/eed3si9n/9a9e164072970a6daa4d318a28be7d73