### PR TITLE
No need to run cross run sonatypeRelease command

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -433,6 +433,6 @@ releaseProcess := Seq[ReleaseStep](
   releaseStepCommandAndRemaining("+publishSigned"),
   setNextVersion,
   commitNextVersion,
-  releaseStepCommand("+sonatypeReleaseAll"),
+  releaseStepCommand("sonatypeRelease"),
   pushChanges
 )


### PR DESCRIPTION
## Purpose

It is also better to use `sonatypeRelease` because `sonatypeReleaseAll`
will promote all staged repositories for that organization profile. When
using `sonatypeRelease`, the release fails if there is more than one stage
repository. While this is annoying, it is better than have multiple releases
affecting each other.

## References

https://github.com/xerial/sbt-sonatype
