### PR TITLE
 Skip JsValue Stringification in BodyWritables

### DIFF
--- a/play-ws-standalone-json/src/main/java/play/libs/ws/JsonBodyWritables.java
+++ b/play-ws-standalone-json/src/main/java/play/libs/ws/JsonBodyWritables.java
@@ -33,8 +33,8 @@ public interface JsonBodyWritables {
     default BodyWritable<ByteString> body(JsonNode node, ObjectMapper objectMapper) {
         try {
             Object json = objectMapper.readValue(node.toString(), Object.class);
-            String s = objectMapper.writerWithDefaultPrettyPrinter().writeValueAsString(json);
-            return new InMemoryBodyWritable(ByteString.fromString(s), "application/json");
+            byte[] bytes = objectMapper.writerWithDefaultPrettyPrinter().writeValueAsBytes(json);
+            return new InMemoryBodyWritable(ByteString.fromArrayUnsafe(bytes), "application/json");
         } catch (Exception e) {
             throw new IllegalStateException(e);
         }

--- a/play-ws-standalone-json/src/main/scala/play/api/libs/ws/JsonBodyWritables.scala
+++ b/play-ws-standalone-json/src/main/scala/play/api/libs/ws/JsonBodyWritables.scala
@@ -14,11 +14,11 @@ trait JsonBodyWritables {
    * Creates an InMemoryBody with "application/json" content type, using the static ObjectMapper.
    */
   implicit val writeableOf_JsValue: BodyWritable[JsValue] = {
-    BodyWritable(a => InMemoryBody(ByteString.fromString(Json.stringify(a))), "application/json")
+    BodyWritable(a => InMemoryBody(ByteString.fromArrayUnsafe(Json.toBytes(a))), "application/json")
   }
 
   def body(objectMapper: ObjectMapper): BodyWritable[JsonNode] = BodyWritable(json =>
-    InMemoryBody(ByteString.fromString(objectMapper.writer.writeValueAsString(json))), "application/json")
+    InMemoryBody(ByteString.fromArrayUnsafe(objectMapper.writer.writeValueAsBytes(json))), "application/json")
 }
 
 object JsonBodyWritables extends JsonBodyWritables


### PR DESCRIPTION
Skip Json.stringify() calls in JsValue BodyWritable instances and go straight to byte arrays instead, then use that byte array directly instead of copying it into the ByteString instances. See https://github.com/playframework/playframework/pull/8375 for similar change in Play controllers rendering json results.

# Pull Request Checklist

* [x] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [x] Have you signed the [Typesafe CLA](https://www.typesafe.com/contribute/cla)?
* [x] Have you [squashed your commits](https://www.playframework.com/documentation/latest/WorkingWithGit#Squashing-commits)?
* [x] Have you added copyright headers to new files?
* [x] Have you checked that both Scala and Java APIs are updated?
* [x] Have you updated the documentation for both Scala and Java sections?
* [x] Have you added tests for any changed functionality?