### PR TITLE
[1.x.x]: Skip JsValue Stringification in BodyWritables

### DIFF
--- a/play-ws-standalone-json/src/main/java/play/libs/ws/JsonBodyWritables.java
+++ b/play-ws-standalone-json/src/main/java/play/libs/ws/JsonBodyWritables.java
@@ -33,8 +33,8 @@ public interface JsonBodyWritables {
     default BodyWritable<ByteString> body(JsonNode node, ObjectMapper objectMapper) {
         try {
             Object json = objectMapper.readValue(node.toString(), Object.class);
-            String s = objectMapper.writerWithDefaultPrettyPrinter().writeValueAsString(json);
-            return new InMemoryBodyWritable(ByteString.fromString(s), "application/json");
+            byte[] bytes = objectMapper.writerWithDefaultPrettyPrinter().writeValueAsBytes(json);
+            return new InMemoryBodyWritable(ByteString.fromArrayUnsafe(bytes), "application/json");
         } catch (Exception e) {
             throw new IllegalStateException(e);
         }

--- a/play-ws-standalone-json/src/main/scala/play/api/libs/ws/JsonBodyWritables.scala
+++ b/play-ws-standalone-json/src/main/scala/play/api/libs/ws/JsonBodyWritables.scala
@@ -14,11 +14,11 @@ trait JsonBodyWritables {
    * Creates an InMemoryBody with "application/json" content type, using the static ObjectMapper.
    */
   implicit val writeableOf_JsValue: BodyWritable[JsValue] = {
-    BodyWritable(a => InMemoryBody(ByteString.fromString(Json.stringify(a))), "application/json")
+    BodyWritable(a => InMemoryBody(ByteString.fromArrayUnsafe(Json.toBytes(a))), "application/json")
   }
 
   def body(objectMapper: ObjectMapper): BodyWritable[JsonNode] = BodyWritable(json =>
-    InMemoryBody(ByteString.fromString(objectMapper.writer.writeValueAsString(json))), "application/json")
+    InMemoryBody(ByteString.fromArrayUnsafe(objectMapper.writer.writeValueAsBytes(json))), "application/json")
 }
 
 object JsonBodyWritables extends JsonBodyWritables


### PR DESCRIPTION
Backports #251.