### PR TITLE
[1.1.x] Update cachecontrol to 1.1.3

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -39,7 +39,7 @@ object Dependencies {
   val signpostVersion = "1.2.1.2"
   val oauth = Seq("oauth.signpost" % "signpost-core" % signpostVersion)
 
-  val cachecontrolVersion = "1.1.2"
+  val cachecontrolVersion = "1.1.3"
   val cachecontrol = Seq("com.typesafe.play" %% "cachecontrol" % cachecontrolVersion)
 
   val asyncHttpClientVersion = "2.0.36"


### PR DESCRIPTION
This is a backported minor dependency update from `master`: 6120f7b60e3f461b0d15349a6337caea3e0b478d

Maybe we want some of those other patch updates on stable, but probably not the more significant updates... we can discuss here and I can update the pull request if needed.