### PR TITLE
Don't generate an empty form param when given an empty params map

### DIFF
--- a/play-ahc-ws-standalone/src/main/scala/play/api/libs/ws/ahc/FormUrlEncodedParser.scala
+++ b/play-ahc-ws-standalone/src/main/scala/play/api/libs/ws/ahc/FormUrlEncodedParser.scala
@@ -73,11 +73,15 @@ private[ahc] object FormUrlEncodedParser {
    * @return The sequence of key/value pairs
    */
   private def parseToPairs(data: String, encoding: String): Seq[(String, String)] = {
-    parameterDelimiter.split(data).map { param =>
-      val parts = param.split("=", -1)
-      val key = java.net.URLDecoder.decode(parts(0), encoding)
-      val value = java.net.URLDecoder.decode(parts.lift(1).getOrElse(""), encoding)
-      key -> value
+    if (data.isEmpty) {
+      Seq.empty
+    } else {
+      parameterDelimiter.split(data).map { param =>
+        val parts = param.split("=", -1)
+        val key = java.net.URLDecoder.decode(parts(0), encoding)
+        val value = java.net.URLDecoder.decode(parts.lift(1).getOrElse(""), encoding)
+        key -> value
+      }
     }
   }
 }

--- a/play-ahc-ws-standalone/src/test/scala/play/api/libs/ws/ahc/AhcWSRequestSpec.scala
+++ b/play-ahc-ws-standalone/src/test/scala/play/api/libs/ws/ahc/AhcWSRequestSpec.scala
@@ -354,6 +354,21 @@ class AhcWSRequestSpec extends Specification with Mockito with AfterAll with Def
       }
     }
 
+    "Parse no params for empty params map" in {
+      withClient { client =>
+        val consumerKey = ConsumerKey("key", "secret")
+        val requestToken = RequestToken("token", "secret")
+        val calc = OAuthCalculator(consumerKey, requestToken)
+        val reqEmptyParams: AHCRequest = client.url("http://playframework.com/")
+          .withBody(Map.empty[String, Seq[String]])
+          .sign(calc)
+          .asInstanceOf[StandaloneAhcWSRequest]
+          .buildRequest()
+
+        reqEmptyParams.getFormParams.asScala must beEmpty
+      }
+    }
+
     "Have form body for content type text/plain" in {
       withClient { client =>
         val formEncoding = java.net.URLEncoder.encode("param1=value1", "UTF-8")

--- a/play-ahc-ws-standalone/src/test/scala/play/libs/ws/ahc/AhcWSRequestSpec.scala
+++ b/play-ahc-ws-standalone/src/test/scala/play/libs/ws/ahc/AhcWSRequestSpec.scala
@@ -41,7 +41,7 @@ class AhcWSRequestSpec extends Specification with Mockito with DefaultBodyReadab
       "get method" in {
         val client = mock[StandaloneAhcWSClient]
         val req = new StandaloneAhcWSRequest(client, "http://playframework.com/", null)
-            .setMethod("POST")
+          .setMethod("POST")
 
         req.getMethod must be_==("POST")
       }


### PR DESCRIPTION
Currently we will generate an AHC `Param` object with an empty key and value when there is an empty set of urlencoded form params. This is because we take the raw string and split it to parse it, and splitting an empty string results in a single empty key-value pair. To fix it we need to special case the empty string.

This should fix #257, since having the extra empty param makes the OAuth signature different.