### PR TITLE
Upgrade async-http-client to 2.4.4 to expose client connection stats

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -32,7 +32,58 @@ lazy val mimaSettings = mimaDefaultSettings ++ Seq(
   mimaBinaryIssueFilters ++= Seq(
     ProblemFilters.exclude[DirectMissingMethodProblem]("play.libs.ws.ahc.StandaloneAhcWSResponse.getBodyAsSource"),
     ProblemFilters.exclude[MissingClassProblem]("play.api.libs.ws.package$"),
-    ProblemFilters.exclude[MissingClassProblem]("play.api.libs.ws.package")
+    ProblemFilters.exclude[MissingClassProblem]("play.api.libs.ws.package"),
+    ProblemFilters.exclude[DirectMissingMethodProblem]("play.libs.ws.ahc.StreamedResponse.this"),
+    ProblemFilters.exclude[IncompatibleMethTypeProblem]("play.libs.ws.ahc.StandaloneAhcWSResponse.asCookie"),
+    ProblemFilters.exclude[IncompatibleResultTypeProblem]("play.api.libs.ws.ahc.StandaloneAhcWSRequest.asCookie"),
+    ProblemFilters.exclude[IncompatibleMethTypeProblem]("play.api.libs.ws.ahc.StandaloneAhcWSRequest.asCookie"),
+    ProblemFilters.exclude[MissingTypesProblem]("play.api.libs.ws.ahc.AhcWSClientConfig$"),
+    ProblemFilters.exclude[DirectMissingMethodProblem]("play.api.libs.ws.ahc.AhcWSClientConfig.apply"),
+    ProblemFilters.exclude[DirectMissingMethodProblem]("play.api.libs.ws.ahc.AhcWSClientConfig.copy"),
+    ProblemFilters.exclude[DirectMissingMethodProblem]("play.api.libs.ws.ahc.AhcWSClientConfig.this"),
+    ProblemFilters.exclude[IncompatibleResultTypeProblem]("play.api.libs.ws.ahc.StreamedResponse.asCookie"),
+    ProblemFilters.exclude[IncompatibleMethTypeProblem]("play.api.libs.ws.ahc.StreamedResponse.asCookie"),
+    ProblemFilters.exclude[DirectMissingMethodProblem]("play.api.libs.ws.ahc.StreamedResponse.this"),
+    ProblemFilters.exclude[IncompatibleResultTypeProblem]("play.api.libs.ws.ahc.WSCookieConverter.asCookie"),
+    ProblemFilters.exclude[DirectMissingMethodProblem]("play.api.libs.ws.ahc.WSCookieConverter.asCookie"),
+    ProblemFilters.exclude[IncompatibleMethTypeProblem]("play.api.libs.ws.ahc.WSCookieConverter.asCookie"),
+    ProblemFilters.exclude[ReversedMissingMethodProblem]("play.api.libs.ws.ahc.WSCookieConverter.asCookie"),
+    ProblemFilters.exclude[IncompatibleMethTypeProblem]("play.api.libs.ws.ahc.DefaultStreamedAsyncHandler.onHeadersReceived"),
+    ProblemFilters.exclude[IncompatibleResultTypeProblem]("play.api.libs.ws.ahc.StandaloneAhcWSResponse.asCookie"),
+    ProblemFilters.exclude[IncompatibleMethTypeProblem]("play.api.libs.ws.ahc.StandaloneAhcWSResponse.asCookie"),
+    ProblemFilters.exclude[ReversedMissingMethodProblem]("play.api.libs.ws.ahc.CookieBuilder.useLaxCookieEncoder"),
+    ProblemFilters.exclude[IncompatibleMethTypeProblem]("play.api.libs.ws.ahc.cache.AsyncCacheableConnection.debug"),
+    ProblemFilters.exclude[IncompatibleMethTypeProblem]("play.api.libs.ws.ahc.cache.Debug.debug"),
+    ProblemFilters.exclude[DirectMissingMethodProblem]("play.api.libs.ws.ahc.cache.Debug.debug"),
+    ProblemFilters.exclude[ReversedMissingMethodProblem]("play.api.libs.ws.ahc.cache.Debug.debug"),
+    ProblemFilters.exclude[IncompatibleResultTypeProblem]("play.api.libs.ws.ahc.cache.CacheableResponse.copy$default$2"),
+    ProblemFilters.exclude[IncompatibleResultTypeProblem]("play.api.libs.ws.ahc.cache.CacheableResponse.ahcHeaders"),
+    ProblemFilters.exclude[DirectMissingMethodProblem]("play.api.libs.ws.ahc.cache.CacheableResponse.copy"),
+    ProblemFilters.exclude[IncompatibleMethTypeProblem]("play.api.libs.ws.ahc.cache.CacheableResponse.getHeaders"),
+    ProblemFilters.exclude[IncompatibleResultTypeProblem]("play.api.libs.ws.ahc.cache.CacheableResponse.headers"),
+    ProblemFilters.exclude[DirectMissingMethodProblem]("play.api.libs.ws.ahc.cache.CacheableResponse.this"),
+    ProblemFilters.exclude[IncompatibleMethTypeProblem]("play.api.libs.ws.ahc.cache.CacheableResponse.getHeader"),
+    ProblemFilters.exclude[IncompatibleMethTypeProblem]("play.api.libs.ws.ahc.cache.AhcHttpCache.calculateTimeToLive"),
+    ProblemFilters.exclude[IncompatibleMethTypeProblem]("play.api.libs.ws.ahc.cache.AhcHttpCache.debug"),
+    ProblemFilters.exclude[IncompatibleMethTypeProblem]("play.api.libs.ws.ahc.cache.AhcHttpCache.generateOriginResponse"),
+    ProblemFilters.exclude[IncompatibleMethTypeProblem]("play.api.libs.ws.ahc.cache.CacheableResponseBuilder.accumulate"),
+    ProblemFilters.exclude[DirectMissingMethodProblem]("play.api.libs.ws.ahc.cache.CacheableResponseBuilder.this"),
+    ProblemFilters.exclude[IncompatibleMethTypeProblem]("play.api.libs.ws.ahc.cache.AsyncCachingHandler.debug"),
+    ProblemFilters.exclude[DirectMissingMethodProblem]("play.api.libs.ws.ahc.cache.AsyncCachingHandler.generateTimeoutResponse"),
+    ProblemFilters.exclude[IncompatibleMethTypeProblem]("play.api.libs.ws.ahc.cache.AsyncCachingHandler.onHeadersReceived"),
+    ProblemFilters.exclude[DirectMissingMethodProblem]("play.api.libs.ws.ahc.cache.AsyncCachingHandler.this"),
+    ProblemFilters.exclude[DirectMissingMethodProblem]("play.api.libs.ws.ahc.cache.CacheableResponse.apply"),
+    ProblemFilters.exclude[IncompatibleMethTypeProblem]("play.api.libs.ws.ahc.cache.CacheableResponse.apply"),
+    ProblemFilters.exclude[IncompatibleMethTypeProblem]("play.api.libs.ws.ahc.cache.CacheableResponse.apply"),
+    ProblemFilters.exclude[DirectMissingMethodProblem]("play.api.libs.ws.ahc.cache.TimeoutResponse.generateTimeoutResponse"),
+    ProblemFilters.exclude[ReversedMissingMethodProblem]("play.api.libs.ws.ahc.cache.TimeoutResponse.generateTimeoutResponse"),
+    ProblemFilters.exclude[MissingClassProblem]("play.api.libs.ws.ahc.cache.CacheableHttpResponseHeaders"),
+    ProblemFilters.exclude[MissingClassProblem]("play.api.libs.ws.ahc.cache.CacheableHttpResponseHeaders$"),
+    ProblemFilters.exclude[IncompatibleMethTypeProblem]("play.api.libs.ws.ahc.cache.CachingAsyncHttpClient.debug"),
+    ProblemFilters.exclude[DirectMissingMethodProblem]("play.api.libs.ws.ahc.cache.CachingAsyncHttpClient.generateTimeoutResponse"),
+    ProblemFilters.exclude[IncompatibleMethTypeProblem]("play.api.libs.ws.ahc.cache.BackgroundAsyncHandler.debug"),
+    ProblemFilters.exclude[IncompatibleMethTypeProblem]("play.api.libs.ws.ahc.cache.BackgroundAsyncHandler.onHeadersReceived"),
+    ProblemFilters.exclude[DirectMissingMethodProblem]("play.api.libs.ws.ahc.cache.BackgroundAsyncHandler.this")
   )
 )
 
@@ -179,7 +230,7 @@ lazy val `shaded-asynchttpclient` = project.in(file("shaded/asynchttpclient"))
     assemblyMergeStrategy in assembly := {
       case "META-INF/io.netty.versions.properties" =>
         MergeStrategy.first
-      case "ahc-default.properties" =>
+      case ahcProperties if ahcProperties.endsWith("ahc-default.properties") =>
         ahcMerge
       case x =>
         val oldStrategy = (assemblyMergeStrategy in assembly).value

--- a/integration-tests/src/test/scala/play/api/libs/ws/ahc/XMLRequestSpec.scala
+++ b/integration-tests/src/test/scala/play/api/libs/ws/ahc/XMLRequestSpec.scala
@@ -40,7 +40,7 @@ class XMLRequestSpec extends Specification with Mockito with AfterAll {
       .asInstanceOf[StandaloneAhcWSRequest]
       .buildRequest()
 
-    req.getHeaders.get("Content-Type") must be_==("text/xml")
+    req.getHeaders.get("Content-Type") must be_==("text/xml; charset=UTF-8")
     ByteString.fromArray(req.getByteData).utf8String must be_==("<hello><test/></hello>")
   }
 

--- a/play-ahc-ws-standalone/src/main/java/play/libs/ws/ahc/CookieBuilder.java
+++ b/play-ahc-ws-standalone/src/main/java/play/libs/ws/ahc/CookieBuilder.java
@@ -6,15 +6,16 @@ package play.libs.ws.ahc;
 
 import play.libs.ws.WSCookie;
 import play.libs.ws.WSCookieBuilder;
-import play.shaded.ahc.org.asynchttpclient.cookie.CookieDecoder;
+import play.shaded.ahc.io.netty.handler.codec.http.cookie.ClientCookieDecoder;
+import play.shaded.ahc.io.netty.handler.codec.http.cookie.Cookie;
 
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
-import static play.shaded.ahc.io.netty.handler.codec.http.HttpHeaders.Names.SET_COOKIE;
-import static play.shaded.ahc.io.netty.handler.codec.http.HttpHeaders.Names.SET_COOKIE2;
+import static play.shaded.ahc.io.netty.handler.codec.http.HttpHeaderNames.SET_COOKIE;
+import static play.shaded.ahc.io.netty.handler.codec.http.HttpHeaderNames.SET_COOKIE2;
 import static play.shaded.ahc.org.asynchttpclient.util.MiscUtils.isNonEmpty;
 
 interface CookieBuilder {
@@ -29,14 +30,14 @@ interface CookieBuilder {
         if (isNonEmpty(setCookieHeaders)) {
             List<WSCookie> cookies = new ArrayList<>(setCookieHeaders.size());
             for (String value : setCookieHeaders) {
-                play.shaded.ahc.org.asynchttpclient.cookie.Cookie c = CookieDecoder.decode(value);
+                Cookie c = isUseLaxCookieEncoder() ? ClientCookieDecoder.LAX.decode(value) : ClientCookieDecoder.STRICT.decode(value);
                 if (c != null) {
                     WSCookie wsCookie = new WSCookieBuilder()
-                            .setName(c.getName())
-                            .setValue(c.getValue())
-                            .setDomain(c.getDomain())
-                            .setPath(c.getPath())
-                            .setMaxAge(c.getMaxAge())
+                            .setName(c.name())
+                            .setValue(c.value())
+                            .setDomain(c.domain())
+                            .setPath(c.path())
+                            .setMaxAge(c.maxAge())
                             .setSecure(c.isSecure())
                             .setHttpOnly(c.isHttpOnly())
                             .build();
@@ -49,4 +50,5 @@ interface CookieBuilder {
         return Collections.emptyList();
     }
 
+    boolean isUseLaxCookieEncoder();
 }

--- a/play-ahc-ws-standalone/src/main/java/play/libs/ws/ahc/StandaloneAhcWSClient.java
+++ b/play-ahc-ws-standalone/src/main/java/play/libs/ws/ahc/StandaloneAhcWSClient.java
@@ -100,7 +100,8 @@ public class StandaloneAhcWSClient implements StandaloneWSClient {
                         state.statusText(),
                         state.uriOption().get(),
                         state.responseHeaders(),
-                        state.publisher()),
+                        state.publisher(),
+                        asyncHttpClient.getConfig().isUseLaxCookieEncoder()),
                 scalaPromise));
         return FutureConverters.toJava(scalaPromise.future());
     }

--- a/play-ahc-ws-standalone/src/main/java/play/libs/ws/ahc/StandaloneAhcWSRequest.java
+++ b/play-ahc-ws-standalone/src/main/java/play/libs/ws/ahc/StandaloneAhcWSRequest.java
@@ -13,17 +13,20 @@ import org.reactivestreams.Publisher;
 import play.api.libs.ws.ahc.FormUrlEncodedParser;
 import play.libs.oauth.OAuth;
 import play.libs.ws.*;
+import play.shaded.ahc.io.netty.buffer.ByteBuf;
+import play.shaded.ahc.io.netty.buffer.Unpooled;
 import play.shaded.ahc.io.netty.handler.codec.http.DefaultHttpHeaders;
 import play.shaded.ahc.io.netty.handler.codec.http.HttpHeaders;
-import play.shaded.ahc.org.asynchttpclient.*;
-import play.shaded.ahc.org.asynchttpclient.cookie.Cookie;
+import play.shaded.ahc.io.netty.handler.codec.http.cookie.Cookie;
+import play.shaded.ahc.io.netty.handler.codec.http.cookie.DefaultCookie;
+import play.shaded.ahc.org.asynchttpclient.Realm;
+import play.shaded.ahc.org.asynchttpclient.Request;
+import play.shaded.ahc.org.asynchttpclient.RequestBuilder;
+import play.shaded.ahc.org.asynchttpclient.SignatureCalculator;
 import play.shaded.ahc.org.asynchttpclient.util.HttpUtils;
 
 import java.net.MalformedURLException;
-import java.net.URI;
-import java.net.URISyntaxException;
 import java.net.URL;
-import java.nio.ByteBuffer;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
@@ -424,7 +427,7 @@ public class StandaloneAhcWSRequest implements StandaloneWSRequest {
                     builder.setBody(byteString.toArray());
                 } else {
                     // Find a charset and try to pull a string out of it...
-                    Charset charset = HttpUtils.parseCharset(contentType);
+                    Charset charset = HttpUtils.extractContentTypeCharsetAttribute(contentType);
                     if (charset == null) {
                         charset = StandardCharsets.UTF_8;
                     }
@@ -454,7 +457,7 @@ public class StandaloneAhcWSRequest implements StandaloneWSRequest {
                 possiblyModifiedHeaders.remove(CONTENT_LENGTH);
 
                 @SuppressWarnings("unchecked") Source<ByteString, ?> sourceBody = ((SourceBodyWritable) bodyWritable).body().get();
-                Publisher<ByteBuffer> publisher = sourceBody.map(ByteString::toByteBuffer)
+                Publisher<ByteBuf> publisher = sourceBody.map(bs -> Unpooled.wrappedBuffer(bs.toByteBuffer()))
                         .runWith(Sink.asPublisher(AsPublisher.WITHOUT_FANOUT), materializer);
                 builder.setBody(publisher, contentLength);
             } else {
@@ -494,15 +497,13 @@ public class StandaloneAhcWSRequest implements StandaloneWSRequest {
 
         // add cookies
         this.cookies.forEach(cookie -> {
-            play.shaded.ahc.org.asynchttpclient.cookie.Cookie ahcCookie = Cookie.newValidCookie(
-                    cookie.getName(),
-                    cookie.getValue(),
-                    false,
-                    cookie.getDomain().orElse(null),
-                    cookie.getPath().orElse(null),
-                    cookie.getMaxAge().orElse(-1L),
-                    cookie.isSecure(),
-                    cookie.isHttpOnly());
+            Cookie ahcCookie = new DefaultCookie(cookie.getName(), cookie.getValue());
+            ahcCookie.setWrap(false);
+            ahcCookie.setDomain(cookie.getDomain().orElse(null));
+            ahcCookie.setPath(cookie.getPath().orElse(null));
+            ahcCookie.setMaxAge(cookie.getMaxAge().orElse(-1L));
+            ahcCookie.setSecure(cookie.isSecure());
+            ahcCookie.setHttpOnly(cookie.isHttpOnly());
             builder.addCookie(ahcCookie);
         });
 

--- a/play-ahc-ws-standalone/src/main/java/play/libs/ws/ahc/StandaloneAhcWSResponse.java
+++ b/play-ahc-ws-standalone/src/main/java/play/libs/ws/ahc/StandaloneAhcWSResponse.java
@@ -11,7 +11,7 @@ import play.libs.ws.StandaloneWSResponse;
 import play.libs.ws.WSCookie;
 import play.libs.ws.WSCookieBuilder;
 import play.shaded.ahc.io.netty.handler.codec.http.HttpHeaders;
-import play.shaded.ahc.org.asynchttpclient.cookie.Cookie;
+import play.shaded.ahc.io.netty.handler.codec.http.cookie.Cookie;
 
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -78,11 +78,11 @@ public class StandaloneAhcWSResponse implements StandaloneWSResponse {
 
     public WSCookie asCookie(Cookie c) {
        return new WSCookieBuilder()
-                .setName(c.getName())
-                .setValue(c.getValue())
-                .setDomain(c.getDomain())
-                .setPath(c.getPath())
-                .setMaxAge(c.getMaxAge())
+                .setName(c.name())
+                .setValue(c.value())
+                .setDomain(c.domain())
+                .setPath(c.path())
+                .setMaxAge(c.maxAge())
                 .setSecure(c.isSecure())
                 .setHttpOnly(c.isHttpOnly()).build();
     }
@@ -92,9 +92,9 @@ public class StandaloneAhcWSResponse implements StandaloneWSResponse {
      */
     @Override
     public Optional<WSCookie> getCookie(String name) {
-        for (play.shaded.ahc.org.asynchttpclient.cookie.Cookie ahcCookie : ahcResponse.getCookies()) {
+        for (Cookie ahcCookie : ahcResponse.getCookies()) {
             // safe -- cookie.getName() will never return null
-            if (ahcCookie.getName().equals(name)) {
+            if (ahcCookie.name().equals(name)) {
                 return Optional.of(asCookie(ahcCookie));
             }
         }

--- a/play-ahc-ws-standalone/src/main/java/play/libs/ws/ahc/StreamedResponse.java
+++ b/play-ahc-ws-standalone/src/main/java/play/libs/ws/ahc/StreamedResponse.java
@@ -32,6 +32,7 @@ public class StreamedResponse implements StandaloneWSResponse, CookieBuilder {
     private final URI uri;
     private final Publisher<HttpResponseBodyPart> publisher;
     private final StandaloneAhcWSClient client;
+    private final boolean useLaxCookieEncoder;
 
     private List<WSCookie> cookies;
 
@@ -39,13 +40,15 @@ public class StreamedResponse implements StandaloneWSResponse, CookieBuilder {
                             int status,
                             String statusText, URI uri,
                             scala.collection.Map<String, Seq<String>> headers,
-                            Publisher<HttpResponseBodyPart> publisher) {
+                            Publisher<HttpResponseBodyPart> publisher,
+                            boolean useLaxCookieEncoder) {
         this.client = client;
         this.status = status;
         this.statusText = statusText;
         this.uri = uri;
         this.headers = asJava(headers);
         this.publisher = publisher;
+        this.useLaxCookieEncoder = useLaxCookieEncoder;
     }
 
     @Override
@@ -105,6 +108,11 @@ public class StreamedResponse implements StandaloneWSResponse, CookieBuilder {
     @Override
     public Source<ByteString, ?> getBodyAsSource() {
         return Source.fromPublisher(publisher).map(bodyPart -> ByteString.fromArray(bodyPart.getBodyPartBytes()));
+    }
+
+    @Override
+    public boolean isUseLaxCookieEncoder() {
+        return useLaxCookieEncoder;
     }
 
     private java.util.Map<String, List<String>> asJava(scala.collection.Map<String, Seq<String>> scalaMap) {

--- a/play-ahc-ws-standalone/src/main/resources/reference.conf
+++ b/play-ahc-ws-standalone/src/main/resources/reference.conf
@@ -26,6 +26,8 @@ play {
       # Whether the raw URL should be used.
       disableUrlEncoding = false
 
+      # Whether to use LAX(no cookie name/value verification) or STRICT (verifies cookie name/value) cookie decoder
+      useLaxCookieEncoder = false
     }
   }
 }

--- a/play-ahc-ws-standalone/src/main/scala/play/api/libs/ws/ahc/AhcCurlRequestLogger.scala
+++ b/play-ahc-ws-standalone/src/main/scala/play/api/libs/ws/ahc/AhcCurlRequestLogger.scala
@@ -99,10 +99,10 @@ trait CurlFormat {
 
   protected def findCharset(request: StandaloneAhcWSRequest): String = {
     request.contentType.map { ct =>
-      Option(HttpUtils.parseCharset(ct)).getOrElse {
+      Option(HttpUtils.extractContentTypeCharsetAttribute(ct)).getOrElse {
         StandardCharsets.UTF_8
       }.name()
-    }.getOrElse(HttpUtils.parseCharset("UTF-8").name())
+    }.getOrElse(HttpUtils.extractContentTypeCharsetAttribute("UTF-8").name())
   }
 
   def quote(unsafe: String): String = unsafe.replace("'", "'\\''")

--- a/play-ahc-ws-standalone/src/main/scala/play/api/libs/ws/ahc/AhcWSUtils.scala
+++ b/play-ahc-ws-standalone/src/main/scala/play/api/libs/ws/ahc/AhcWSUtils.scala
@@ -14,7 +14,7 @@ private[ws] object AhcWSUtils {
   }
 
   def getCharset(contentType: String): Charset = {
-    Option(HttpUtils.parseCharset(contentType)).getOrElse {
+    Option(HttpUtils.extractContentTypeCharsetAttribute(contentType)).getOrElse {
       if (contentType.startsWith("text/"))
         StandardCharsets.ISO_8859_1
       else

--- a/play-ahc-ws-standalone/src/main/scala/play/api/libs/ws/ahc/StandaloneAhcWSClient.scala
+++ b/play-ahc-ws-standalone/src/main/scala/play/api/libs/ws/ahc/StandaloneAhcWSClient.scala
@@ -97,7 +97,8 @@ class StandaloneAhcWSClient @Inject() (asyncHttpClient: AsyncHttpClient)(implici
         state.statusText,
         state.uriOption.get,
         state.responseHeaders,
-        state.publisher)
+        state.publisher,
+        asyncHttpClient.getConfig.isUseLaxCookieEncoder)
     )
     asyncHttpClient.executeRequest(request, new DefaultStreamedAsyncHandler[StreamedResponse](function, promise))
     promise.future

--- a/play-ahc-ws-standalone/src/main/scala/play/api/libs/ws/ahc/StandaloneAhcWSRequest.scala
+++ b/play-ahc-ws-standalone/src/main/scala/play/api/libs/ws/ahc/StandaloneAhcWSRequest.scala
@@ -10,6 +10,7 @@ import java.nio.charset.{ Charset, StandardCharsets }
 import akka.stream.Materializer
 import akka.stream.scaladsl.Sink
 import play.api.libs.ws.{ StandaloneWSRequest, _ }
+import play.shaded.ahc.io.netty.buffer.Unpooled
 import play.shaded.ahc.io.netty.handler.codec.http.HttpHeaders
 import play.shaded.ahc.org.asynchttpclient.Realm.AuthScheme
 import play.shaded.ahc.org.asynchttpclient._
@@ -277,7 +278,7 @@ case class StandaloneAhcWSRequest(
             val filteredHeaders = this.headers.filterNot { case (k, v) => k.equalsIgnoreCase(HttpHeaders.Names.CONTENT_LENGTH) }
 
             // extract the content type and the charset
-            val charsetOption = Option(HttpUtils.parseCharset(ct))
+            val charsetOption = Option(HttpUtils.extractContentTypeCharsetAttribute(ct))
             val charset = charsetOption.getOrElse {
               StandardCharsets.UTF_8
             }.name()
@@ -311,7 +312,7 @@ case class StandaloneAhcWSRequest(
         val filteredHeaders = this.headers.filterNot { case (k, v) => k.equalsIgnoreCase(HttpHeaders.Names.CONTENT_LENGTH) }
         val contentLength = this.headers.find { case (k, _) => k.equalsIgnoreCase(HttpHeaders.Names.CONTENT_LENGTH) }.map(_._2.head.toLong)
 
-        (builder.setBody(source.map(_.toByteBuffer).runWith(Sink.asPublisher(false)), contentLength.getOrElse(-1L)), filteredHeaders)
+        (builder.setBody(source.map(bs => Unpooled.wrappedBuffer(bs.toByteBuffer)).runWith(Sink.asPublisher(false)), contentLength.getOrElse(-1L)), filteredHeaders)
     }
 
     // headers

--- a/play-ahc-ws-standalone/src/main/scala/play/api/libs/ws/ahc/Streamed.scala
+++ b/play-ahc-ws-standalone/src/main/scala/play/api/libs/ws/ahc/Streamed.scala
@@ -6,6 +6,7 @@ package play.api.libs.ws.ahc
 import java.net.URI
 
 import org.reactivestreams.{ Publisher, Subscriber, Subscription }
+import play.shaded.ahc.io.netty.handler.codec.http.HttpHeaders
 import play.shaded.ahc.org.asynchttpclient.AsyncHandler.State
 import play.shaded.ahc.org.asynchttpclient._
 import play.shaded.ahc.org.asynchttpclient.handler.StreamedAsyncHandler
@@ -44,10 +45,10 @@ class DefaultStreamedAsyncHandler[T](f: java.util.function.Function[StreamedStat
     }
   }
 
-  override def onHeadersReceived(h: HttpResponseHeaders): State = {
+  override def onHeadersReceived(h: HttpHeaders): State = {
     if (this.state.publisher != EmptyPublisher) State.ABORT
     else {
-      state = state.copy(responseHeaders = headersToMap(h.getHeaders))
+      state = state.copy(responseHeaders = headersToMap(h))
       State.CONTINUE
     }
   }

--- a/play-ahc-ws-standalone/src/main/scala/play/api/libs/ws/ahc/StreamedResponse.scala
+++ b/play-ahc-ws-standalone/src/main/scala/play/api/libs/ws/ahc/StreamedResponse.scala
@@ -29,7 +29,8 @@ class StreamedResponse(
     val statusText: String,
     val uri: java.net.URI,
     val headers: Map[String, Seq[String]],
-    publisher: Publisher[HttpResponseBodyPart]) extends StandaloneWSResponse with CookieBuilder {
+    publisher: Publisher[HttpResponseBodyPart],
+    val useLaxCookieEncoder: Boolean) extends StandaloneWSResponse with CookieBuilder {
 
   /**
    * Get the underlying response object.

--- a/play-ahc-ws-standalone/src/main/scala/play/api/libs/ws/ahc/cache/AsyncCachingHandler.scala
+++ b/play-ahc-ws-standalone/src/main/scala/play/api/libs/ws/ahc/cache/AsyncCachingHandler.scala
@@ -9,6 +9,7 @@ import play.shaded.ahc.org.asynchttpclient._
 import com.typesafe.play.cachecontrol.ResponseServeAction
 import org.joda.time.DateTime
 import org.slf4j.{ Logger, LoggerFactory }
+import play.shaded.ahc.io.netty.handler.codec.http.HttpHeaders
 
 import scala.concurrent.Await
 import scala.concurrent.duration.Duration
@@ -20,7 +21,8 @@ class AsyncCachingHandler[T](
     request: Request,
     handler: AsyncCompletionHandler[T],
     cache: AhcHttpCache,
-    maybeAction: Option[ResponseServeAction])
+    maybeAction: Option[ResponseServeAction],
+    ahcConfig: AsyncHttpClientConfig)
   extends AsyncHandler[T]
   with TimeoutResponse
   with Debug {
@@ -30,7 +32,7 @@ class AsyncCachingHandler[T](
   import com.typesafe.play.cachecontrol.HttpDate
   import AsyncCachingHandler._
 
-  protected val builder = new CacheableResponseBuilder()
+  protected val builder = new CacheableResponseBuilder(ahcConfig)
 
   protected val requestTime: DateTime = HttpDate.now
 
@@ -38,7 +40,7 @@ class AsyncCachingHandler[T](
 
   protected val timeout: Duration = scala.concurrent.duration.Duration(1, "second")
 
-  protected lazy val timeoutResponse: CacheableResponse = generateTimeoutResponse(request)
+  protected lazy val timeoutResponse: CacheableResponse = generateTimeoutResponse(request, ahcConfig)
 
   /**
    * Invoked if something wrong happened inside the previous methods or when an I/O exception occurs.
@@ -77,8 +79,8 @@ class AsyncCachingHandler[T](
   /**
    * Called when all response’s headers has been processed.
    */
-  override def onHeadersReceived(responseHeaders: HttpResponseHeaders): AsyncHandler.State = {
-    if (!responseHeaders.getHeaders.contains(DATE)) {
+  override def onHeadersReceived(responseHeaders: HttpHeaders): AsyncHandler.State = {
+    if (!responseHeaders.contains(DATE)) {
       /*
        A recipient with a clock that receives a response message without a
        Date header field MUST record the time it was received and append a
@@ -88,7 +90,7 @@ class AsyncCachingHandler[T](
        https://tools.ietf.org/html/rfc7231#section-7.1.1.2
       */
       val currentDate = HttpDate.format(HttpDate.now)
-      responseHeaders.getHeaders.add(DATE, currentDate)
+      responseHeaders.add(DATE, currentDate)
     }
     builder.accumulate(responseHeaders)
     handler.onHeadersReceived(responseHeaders)

--- a/play-ahc-ws-standalone/src/main/scala/play/api/libs/ws/ahc/cache/BackgroundAsyncHandler.scala
+++ b/play-ahc-ws-standalone/src/main/scala/play/api/libs/ws/ahc/cache/BackgroundAsyncHandler.scala
@@ -7,14 +7,15 @@ package play.api.libs.ws.ahc.cache
 
 import play.shaded.ahc.org.asynchttpclient._
 import com.typesafe.play.cachecontrol.ResponseCachingActions.{ DoCacheResponse, DoNotCacheResponse }
-import org.slf4j.{ LoggerFactory, Logger }
+import org.slf4j.{ Logger, LoggerFactory }
+import play.shaded.ahc.io.netty.handler.codec.http.HttpHeaders
 
 import scala.concurrent.Await
 
 /**
  * An async handler that accumulates a response and stores it to cache in the background.
  */
-class BackgroundAsyncHandler[T](request: Request, cache: AhcHttpCache)
+class BackgroundAsyncHandler[T](request: Request, cache: AhcHttpCache, ahcConfig: AsyncHttpClientConfig)
   extends AsyncHandler[T]
   with Debug {
 
@@ -22,7 +23,7 @@ class BackgroundAsyncHandler[T](request: Request, cache: AhcHttpCache)
 
   private val timeout = scala.concurrent.duration.Duration(1, "second")
 
-  private val builder = new CacheableResponseBuilder
+  private val builder = new CacheableResponseBuilder(ahcConfig)
 
   private val key = EffectiveURIKey(request)
 
@@ -40,7 +41,7 @@ class BackgroundAsyncHandler[T](request: Request, cache: AhcHttpCache)
   }
 
   @throws(classOf[Exception])
-  def onHeadersReceived(headers: HttpResponseHeaders): AsyncHandler.State = {
+  def onHeadersReceived(headers: HttpHeaders): AsyncHandler.State = {
     builder.accumulate(headers)
     AsyncHandler.State.CONTINUE
   }

--- a/play-ahc-ws-standalone/src/main/scala/play/api/libs/ws/ahc/cache/CacheableResponse.scala
+++ b/play-ahc-ws-standalone/src/main/scala/play/api/libs/ws/ahc/cache/CacheableResponse.scala
@@ -8,22 +8,22 @@ package play.api.libs.ws.ahc.cache
 import java.io.{ ByteArrayInputStream, IOException, InputStream }
 import java.net.{ MalformedURLException, SocketAddress }
 import java.nio.ByteBuffer
-import java.nio.charset.Charset
+import java.nio.charset.{ Charset, StandardCharsets }
 import java.util
 
 import org.slf4j.LoggerFactory
 import play.shaded.ahc.io.netty.handler.codec.http.HttpHeaders.Names._
+import play.shaded.ahc.io.netty.handler.codec.http.cookie.Cookie
 import play.shaded.ahc.io.netty.handler.codec.http.{ DefaultHttpHeaders, HttpHeaders }
 import play.shaded.ahc.org.asynchttpclient._
-import play.shaded.ahc.org.asynchttpclient.cookie.Cookie
 import play.shaded.ahc.org.asynchttpclient.uri.Uri
 import play.shaded.ahc.org.asynchttpclient.util.HttpUtils._
 
-class CacheableResponseBuilder {
+class CacheableResponseBuilder(ahcConfig: AsyncHttpClientConfig) {
 
   private var bodyParts: List[CacheableHttpResponseBodyPart] = Nil
   private var status: Option[CacheableHttpResponseStatus] = None
-  private var headers: Option[CacheableHttpResponseHeaders] = None
+  private var headers: Option[HttpHeaders] = None
 
   def accumulate(responseStatus: HttpResponseStatus): CacheableResponseBuilder = {
     // https://github.com/AsyncHttpClient/async-http-client/blob/2.0/client/src/main/java/org/asynchttpclient/HttpResponseStatus.java
@@ -37,9 +37,8 @@ class CacheableResponseBuilder {
     this
   }
 
-  def accumulate(responseHeaders: HttpResponseHeaders): CacheableResponseBuilder = {
-    val cacheableHeaders = CacheableHttpResponseHeaders(responseHeaders.isTrailling, responseHeaders.getHeaders)
-    headers = Some(cacheableHeaders)
+  def accumulate(responseHeaders: HttpHeaders): CacheableResponseBuilder = {
+    headers = Some(responseHeaders)
     this
   }
 
@@ -57,15 +56,16 @@ class CacheableResponseBuilder {
 
   def build: CacheableResponse = {
     import scala.collection.JavaConverters._
-    new CacheableResponse(status.get, headers.get, bodyParts.asJava)
+    new CacheableResponse(status.get, headers.get, bodyParts.asJava, ahcConfig)
   }
 }
 
 // https://github.com/AsyncHttpClient/async-http-client/blob/2.0/client/src/main/java/org/asynchttpclient/netty/NettyResponse.java
 case class CacheableResponse(
     status: CacheableHttpResponseStatus,
-    headers: CacheableHttpResponseHeaders,
-    bodyParts: util.List[CacheableHttpResponseBodyPart]) extends Response {
+    headers: HttpHeaders,
+    bodyParts: util.List[CacheableHttpResponseBodyPart],
+    ahcConfig: AsyncHttpClientConfig) extends Response {
 
   private var cookies: util.List[Cookie] = _
 
@@ -75,18 +75,17 @@ case class CacheableResponse(
 
   def ahcStatus: HttpResponseStatus = status.asInstanceOf[HttpResponseStatus]
 
-  def ahcHeaders: HttpResponseHeaders = headers.asInstanceOf[HttpResponseHeaders]
+  def ahcHeaders: HttpHeaders = headers.asInstanceOf[HttpHeaders]
 
   def ahcbodyParts: util.List[HttpResponseBodyPart] = bodyParts.asInstanceOf[util.List[HttpResponseBodyPart]]
 
   def withHeaders(tuple: (String, String)*): CacheableResponse = {
-    val headerMap = new DefaultHttpHeaders().add(this.headers.headers)
+    val headerMap = new DefaultHttpHeaders().add(this.headers)
     tuple.foreach {
       case (k, v) =>
         headerMap.add(k, v)
     }
-    val newHeaders = CacheableHttpResponseHeaders(this.headers.trailingHeaders, headerMap)
-    this.copy(headers = newHeaders)
+    this.copy(headers = headerMap)
   }
 
   override def getStatusCode: Int = {
@@ -112,13 +111,11 @@ case class CacheableResponse(
     target
   }
 
-  private def computeCharset(charset: Charset): Charset = {
-    Option(charset)
-      .orElse(
-        Option(getContentType)
-          .flatMap(ct => Option(parseCharset(ct)))
-      ).getOrElse(DEFAULT_CHARSET)
-  }
+  private def computeCharset(charset: Charset): Charset = Option(charset)
+    .orElse(
+      Option(getContentType)
+        .flatMap(ct => Option(extractContentTypeCharsetAttribute(ct)))
+    ).getOrElse(StandardCharsets.UTF_8)
 
   @throws(classOf[IOException])
   override def getResponseBody: String = {
@@ -153,16 +150,16 @@ case class CacheableResponse(
     getHeader(CONTENT_TYPE)
   }
 
-  override def getHeader(name: String): String = {
-    headers.getHeaders.get(name)
+  override def getHeader(name: CharSequence): String = {
+    headers.get(name)
   }
 
-  override def getHeaders(name: String): util.List[String] = {
-    headers.getHeaders.getAll(name)
+  override def getHeaders(name: CharSequence): util.List[String] = {
+    headers.getAll(name)
   }
 
   override def getHeaders: HttpHeaders = {
-    headers.getHeaders
+    headers
   }
 
   override def isRedirected: Boolean = {
@@ -201,16 +198,16 @@ case class CacheableResponse(
 
   private def buildCookies: util.List[Cookie] = {
     import play.shaded.ahc.org.asynchttpclient.util.MiscUtils.isNonEmpty
-    import play.shaded.ahc.org.asynchttpclient.cookie.CookieDecoder
+    import play.shaded.ahc.io.netty.handler.codec.http.cookie.ClientCookieDecoder
     import java.util.Collections
 
-    var setCookieHeaders = headers.getHeaders.getAll(SET_COOKIE2)
-    if (!isNonEmpty(setCookieHeaders)) setCookieHeaders = headers.getHeaders.getAll(SET_COOKIE)
+    var setCookieHeaders = headers.getAll(SET_COOKIE2)
+    if (!isNonEmpty(setCookieHeaders)) setCookieHeaders = headers.getAll(SET_COOKIE)
     if (isNonEmpty(setCookieHeaders)) {
       val cookies = new util.ArrayList[Cookie](1)
       import scala.collection.JavaConversions._
       for (value <- setCookieHeaders) {
-        val c = CookieDecoder.decode(value)
+        val c = if (ahcConfig.isUseLaxCookieEncoder) ClientCookieDecoder.LAX.decode(value) else ClientCookieDecoder.STRICT.decode(value)
         if (c != null) cookies.add(c)
       }
       return Collections.unmodifiableList(cookies)
@@ -227,35 +224,25 @@ case class CacheableResponse(
   override def getRemoteAddress: SocketAddress = status.getRemoteAddress
 }
 
-case class CacheableHttpResponseHeaders(trailingHeaders: Boolean, headers: HttpHeaders)
-  extends HttpResponseHeaders(headers, trailingHeaders) {
-
-  override def toString: String = {
-    s"CacheableHttpResponseHeaders(trailingHeaders = $trailingHeaders, headers = $headers)"
-  }
-}
-
 object CacheableResponse {
   private val logger = LoggerFactory.getLogger("play.api.libs.ws.ahc.cache.CacheableResponse")
 
-  def apply(code: Int, urlString: String): CacheableResponse = {
+  def apply(code: Int, urlString: String, ahcConfig: AsyncHttpClientConfig): CacheableResponse = {
     val uri: Uri = Uri.create(urlString)
     val status = new CacheableHttpResponseStatus(uri, code, "", "")
-    val headers = new DefaultHttpHeaders()
-    val responseHeaders = CacheableHttpResponseHeaders(trailingHeaders = false, headers = headers)
+    val responseHeaders = new DefaultHttpHeaders()
     val bodyParts = util.Collections.emptyList[CacheableHttpResponseBodyPart]
 
-    CacheableResponse(status = status, headers = responseHeaders, bodyParts = bodyParts)
+    CacheableResponse(status = status, headers = responseHeaders, bodyParts = bodyParts, ahcConfig)
   }
 
-  def apply(code: Int, urlString: String, body: String): CacheableResponse = {
+  def apply(code: Int, urlString: String, body: String, ahcConfig: AsyncHttpClientConfig): CacheableResponse = {
     val uri: Uri = Uri.create(urlString)
     val status = new CacheableHttpResponseStatus(uri, code, "", "")
-    val headers = new DefaultHttpHeaders()
-    val responseHeaders = CacheableHttpResponseHeaders(trailingHeaders = false, headers = headers)
+    val responseHeaders = new DefaultHttpHeaders()
     val bodyParts = util.Collections.singletonList(new CacheableHttpResponseBodyPart(body.getBytes, true))
 
-    CacheableResponse(status = status, headers = responseHeaders, bodyParts = bodyParts)
+    CacheableResponse(status = status, headers = responseHeaders, bodyParts = bodyParts, ahcConfig)
   }
 }
 
@@ -265,7 +252,7 @@ class CacheableHttpResponseStatus(
     statusCode: Int,
     statusText: String,
     protocolText: String)
-  extends HttpResponseStatus(uri, null) {
+  extends HttpResponseStatus(uri) {
   override def getStatusCode: Int = statusCode
 
   override def getProtocolText: String = protocolText

--- a/play-ahc-ws-standalone/src/main/scala/play/api/libs/ws/ahc/cache/Debug.scala
+++ b/play-ahc-ws-standalone/src/main/scala/play/api/libs/ws/ahc/cache/Debug.scala
@@ -6,6 +6,7 @@
 package play.api.libs.ws.ahc.cache
 
 import play.api.libs.ws.ahc.AhcUtilities
+import play.shaded.ahc.io.netty.handler.codec.http.HttpHeaders
 import play.shaded.ahc.org.asynchttpclient._
 
 /**
@@ -41,12 +42,9 @@ private[ahc] trait Debug extends AhcUtilities {
     }.getOrElse("null")
   }
 
-  def debug(responseHeaders: HttpResponseHeaders): String = {
-    Option(responseHeaders).map {
-      case crh: CacheableHttpResponseHeaders =>
-        crh.toString
-      case rh =>
-        s"HttpResponseHeaders(${headersToMap(rh.getHeaders)})"
+  def debug(responseHeaders: HttpHeaders): String = {
+    Option(responseHeaders).map { rh =>
+      s"HttpResponseHeaders(${headersToMap(rh)})"
     }.getOrElse("null")
   }
 

--- a/play-ahc-ws-standalone/src/test/scala/play/api/libs/ws/ahc/AhcConfigBuilderSpec.scala
+++ b/play-ahc-ws-standalone/src/test/scala/play/api/libs/ws/ahc/AhcConfigBuilderSpec.scala
@@ -230,7 +230,7 @@ class AhcConfigBuilderSpec extends Specification with Mockito {
           val builder = new AhcConfigBuilder(config)
 
           val asyncConfig = builder.build()
-          asyncConfig.isAcceptAnyCertificate must beFalse
+          asyncConfig.isUseInsecureTrustManager must beFalse
         }
 
         "should disable the hostname verifier if loose.acceptAnyCertificate is enabled" in {
@@ -241,7 +241,7 @@ class AhcConfigBuilderSpec extends Specification with Mockito {
           val builder = new AhcConfigBuilder(config)
 
           val asyncConfig = builder.build()
-          asyncConfig.isAcceptAnyCertificate must beTrue
+          asyncConfig.isUseInsecureTrustManager must beTrue
         }
       }
 

--- a/play-ahc-ws-standalone/src/test/scala/play/api/libs/ws/ahc/AhcWSRequestSpec.scala
+++ b/play-ahc-ws-standalone/src/test/scala/play/api/libs/ws/ahc/AhcWSRequestSpec.scala
@@ -14,8 +14,8 @@ import play.api.libs.oauth.{ ConsumerKey, OAuthCalculator, RequestToken }
 import play.api.libs.ws._
 import play.shaded.ahc.io.netty.handler.codec.http.HttpHeaders
 import play.shaded.ahc.org.asynchttpclient.Realm.AuthScheme
-import play.shaded.ahc.org.asynchttpclient.cookie.{ Cookie => AHCCookie }
-import play.shaded.ahc.org.asynchttpclient.{ Param, Request => AHCRequest }
+import play.shaded.ahc.io.netty.handler.codec.http.cookie.{ Cookie => AHCCookie }
+import play.shaded.ahc.org.asynchttpclient.{ Param, RequestBuilderBase, SignatureCalculator, Request => AHCRequest }
 
 import scala.collection.JavaConverters._
 import scala.concurrent.duration._
@@ -123,8 +123,8 @@ class AhcWSRequestSpec extends Specification with Mockito with AfterAll with Def
           .buildRequest()
 
         req.getCookies.asScala must size(1)
-        req.getCookies.asScala.head.getName must beEqualTo("cookie1")
-        req.getCookies.asScala.head.getValue must beEqualTo("value1")
+        req.getCookies.asScala.head.name must beEqualTo("cookie1")
+        req.getCookies.asScala.head.value must beEqualTo("value1")
       }
     }
 
@@ -137,11 +137,11 @@ class AhcWSRequestSpec extends Specification with Mockito with AfterAll with Def
           .buildRequest()
 
         req.getCookies.asScala must size(2)
-        req.getCookies.asScala.head.getName must beEqualTo("cookie1")
-        req.getCookies.asScala.head.getValue must beEqualTo("value1")
+        req.getCookies.asScala.head.name must beEqualTo("cookie1")
+        req.getCookies.asScala.head.value must beEqualTo("value1")
 
-        req.getCookies.asScala(1).getName must beEqualTo("cookie2")
-        req.getCookies.asScala(1).getValue must beEqualTo("value2")
+        req.getCookies.asScala(1).name must beEqualTo("cookie2")
+        req.getCookies.asScala(1).value must beEqualTo("value2")
       }
     }
 
@@ -155,11 +155,11 @@ class AhcWSRequestSpec extends Specification with Mockito with AfterAll with Def
           .buildRequest()
 
         req.getCookies.asScala must size(2)
-        req.getCookies.asScala.head.getName must beEqualTo("cookie1")
-        req.getCookies.asScala.head.getValue must beEqualTo("value1")
+        req.getCookies.asScala.head.name must beEqualTo("cookie1")
+        req.getCookies.asScala.head.value must beEqualTo("value1")
 
-        req.getCookies.asScala(1).getName must beEqualTo("cookie2")
-        req.getCookies.asScala(1).getValue must beEqualTo("value2")
+        req.getCookies.asScala(1).name must beEqualTo("cookie2")
+        req.getCookies.asScala(1).value must beEqualTo("value2")
       }
     }
 
@@ -173,11 +173,11 @@ class AhcWSRequestSpec extends Specification with Mockito with AfterAll with Def
           .buildRequest()
 
         req.getCookies.asScala must size(2)
-        req.getCookies.asScala.head.getName must beEqualTo("cookie3")
-        req.getCookies.asScala.head.getValue must beEqualTo("value3")
+        req.getCookies.asScala.head.name must beEqualTo("cookie3")
+        req.getCookies.asScala.head.value must beEqualTo("value3")
 
-        req.getCookies.asScala(1).getName must beEqualTo("cookie4")
-        req.getCookies.asScala(1).getValue must beEqualTo("value4")
+        req.getCookies.asScala(1).name must beEqualTo("cookie4")
+        req.getCookies.asScala(1).value must beEqualTo("value4")
       }
     }
 
@@ -445,7 +445,7 @@ class AhcWSRequestSpec extends Specification with Mockito with AfterAll with Def
 
     "a custom signature calculator" in {
       var called = false
-      val calc = new play.shaded.ahc.org.asynchttpclient.SignatureCalculator with WSSignatureCalculator {
+      val calc = new SignatureCalculator with WSSignatureCalculator {
         override def calculateAndAddSignature(
           request: play.shaded.ahc.org.asynchttpclient.Request,
           requestBuilder: play.shaded.ahc.org.asynchttpclient.RequestBuilderBase[_]): Unit = {

--- a/play-ahc-ws-standalone/src/test/scala/play/api/libs/ws/ahc/AhcWSResponseSpec.scala
+++ b/play-ahc-ws-standalone/src/test/scala/play/api/libs/ws/ahc/AhcWSResponseSpec.scala
@@ -11,7 +11,7 @@ import org.specs2.mock.Mockito
 import org.specs2.mutable.Specification
 import play.api.libs.ws._
 import play.shaded.ahc.io.netty.handler.codec.http.DefaultHttpHeaders
-import play.shaded.ahc.org.asynchttpclient.cookie.{ Cookie => AHCCookie }
+import play.shaded.ahc.io.netty.handler.codec.http.cookie.{ DefaultCookie, Cookie => AHCCookie }
 import play.shaded.ahc.org.asynchttpclient.{ Response => AHCResponse }
 
 class AhcWSResponseSpec extends Specification with Mockito with DefaultBodyReadables with DefaultBodyWritables {
@@ -23,7 +23,7 @@ class AhcWSResponseSpec extends Specification with Mockito with DefaultBodyReada
       val (name, value, wrap, domain, path, maxAge, secure, httpOnly) =
         ("someName", "someValue", true, "example.com", "/", 1000L, false, false)
 
-      val ahcCookie: AHCCookie = new AHCCookie(name, value, wrap, domain, path, maxAge, secure, httpOnly)
+      val ahcCookie: AHCCookie = asCookie(name, value, wrap, domain, path, maxAge, secure, httpOnly)
       ahcResponse.getCookies returns util.Arrays.asList(ahcCookie)
 
       val response = StandaloneAhcWSResponse(ahcResponse)
@@ -45,7 +45,7 @@ class AhcWSResponseSpec extends Specification with Mockito with DefaultBodyReada
       val (name, value, wrap, domain, path, maxAge, secure, httpOnly) =
         ("someName", "someValue", true, "example.com", "/", 1000L, false, false)
 
-      val ahcCookie: AHCCookie = new AHCCookie(name, value, wrap, domain, path, maxAge, secure, httpOnly)
+      val ahcCookie: AHCCookie = asCookie(name, value, wrap, domain, path, maxAge, secure, httpOnly)
       ahcResponse.getCookies returns util.Arrays.asList(ahcCookie)
 
       val response = StandaloneAhcWSResponse(ahcResponse)
@@ -66,7 +66,7 @@ class AhcWSResponseSpec extends Specification with Mockito with DefaultBodyReada
     "return -1 values of expires and maxAge as None" in {
       val ahcResponse: AHCResponse = mock[AHCResponse]
 
-      val ahcCookie: AHCCookie = new AHCCookie("someName", "value", true, "domain", "path", -1L, false, false)
+      val ahcCookie: AHCCookie = asCookie("someName", "value", true, "domain", "path", -1L, false, false)
       ahcResponse.getCookies returns util.Arrays.asList(ahcCookie)
 
       val response = StandaloneAhcWSResponse(ahcResponse)
@@ -157,6 +157,17 @@ class AhcWSResponseSpec extends Specification with Mockito with DefaultBodyReada
 
       response.headerValues("Foo") must beEqualTo(Seq("bar", "baz"))
     }
+  }
+
+  def asCookie(name: String, value: String, wrap: Boolean, domain: String, path: String, maxAge: Long, secure: Boolean, httpOnly: Boolean): AHCCookie = {
+    val c = new DefaultCookie(name, value)
+    c.setWrap(wrap)
+    c.setDomain(domain)
+    c.setPath(path)
+    c.setMaxAge(maxAge)
+    c.setSecure(secure)
+    c.setHttpOnly(httpOnly)
+    c
   }
 
 }

--- a/play-ahc-ws-standalone/src/test/scala/play/api/libs/ws/ahc/cache/AhcWSCacheSpec.scala
+++ b/play-ahc-ws-standalone/src/test/scala/play/api/libs/ws/ahc/cache/AhcWSCacheSpec.scala
@@ -12,7 +12,7 @@ import com.typesafe.play.cachecontrol._
 import org.joda.time.Seconds
 import org.specs2.mutable.Specification
 import play.shaded.ahc.io.netty.handler.codec.http.{ DefaultHttpHeaders, HttpHeaders }
-import play.shaded.ahc.org.asynchttpclient.{ Request, RequestBuilder }
+import play.shaded.ahc.org.asynchttpclient.{ DefaultAsyncHttpClientConfig, Request, RequestBuilder }
 
 class AhcWSCacheSpec extends Specification {
 
@@ -60,11 +60,12 @@ class AhcWSCacheSpec extends Specification {
       import scala.concurrent.ExecutionContext.Implicits.global
 
       implicit val cache = new AhcHttpCache(new StubHttpCache(), false)
+      val achConfig = new DefaultAsyncHttpClientConfig.Builder().build()
 
       val url = "http://localhost:9000"
 
       val request = generateRequest(url)(headers => headers.add("Accept-Encoding", "gzip"))
-      val response = CacheableResponse(200, url).withHeaders("Vary" -> "Accept-Encoding")
+      val response = CacheableResponse(200, url, achConfig).withHeaders("Vary" -> "Accept-Encoding")
 
       val actual = cache.calculateSecondaryKeys(request, response)
 

--- a/play-ahc-ws-standalone/src/test/scala/play/api/libs/ws/ahc/cache/CacheableResponseSpec.scala
+++ b/play-ahc-ws-standalone/src/test/scala/play/api/libs/ws/ahc/cache/CacheableResponseSpec.scala
@@ -5,27 +5,29 @@ package play.api.libs.ws.ahc.cache
 
 import org.specs2.mutable.Specification
 import play.shaded.ahc.io.netty.handler.codec.http.HttpHeaders.Names._
+import play.shaded.ahc.org.asynchttpclient.DefaultAsyncHttpClientConfig
 
 class CacheableResponseSpec extends Specification {
+  val achConfig = new DefaultAsyncHttpClientConfig.Builder().build()
 
   "CacheableResponse" should {
 
     "get body" in {
 
       "when it is text/plain" in {
-        val response = CacheableResponse(200, "https://playframework.com/", "PlayFramework Homepage").withHeaders(CONTENT_TYPE -> "text/plain")
+        val response = CacheableResponse(200, "https://playframework.com/", "PlayFramework Homepage", achConfig).withHeaders(CONTENT_TYPE -> "text/plain")
         response.getResponseBody must beEqualTo("PlayFramework Homepage")
         response.getContentType must beEqualTo("text/plain")
       }
 
       "when it is application/json" in {
-        val response = CacheableResponse(200, "https://playframework.com/", """{ "a": "b" }""").withHeaders("Content-Type" -> "application/json")
+        val response = CacheableResponse(200, "https://playframework.com/", """{ "a": "b" }""", achConfig).withHeaders("Content-Type" -> "application/json")
         response.getResponseBody must beEqualTo("""{ "a": "b" }""")
         response.getContentType must beEqualTo("application/json")
       }
 
       "when it is application/json; charset=utf-8" in {
-        val response = CacheableResponse(200, "https://playframework.com/", """{ "a": "b" }""").withHeaders("Content-Type" -> "application/json; charset=utf-8")
+        val response = CacheableResponse(200, "https://playframework.com/", """{ "a": "b" }""", achConfig).withHeaders("Content-Type" -> "application/json; charset=utf-8")
         response.getResponseBody must beEqualTo("""{ "a": "b" }""")
         response.getContentType must beEqualTo("application/json; charset=utf-8")
       }

--- a/play-ahc-ws-standalone/src/test/scala/play/libs/ws/ahc/AhcWSRequestSpec.scala
+++ b/play-ahc-ws-standalone/src/test/scala/play/libs/ws/ahc/AhcWSRequestSpec.scala
@@ -11,7 +11,7 @@ import org.specs2.mock.Mockito
 import org.specs2.mutable._
 import play.libs.oauth.OAuth
 import play.libs.ws._
-import play.shaded.ahc.io.netty.handler.codec.http.HttpHeaders
+import play.shaded.ahc.io.netty.handler.codec.http.{ HttpHeaderNames, HttpHeaders }
 import play.shaded.ahc.org.asynchttpclient.{ Request, RequestBuilderBase, SignatureCalculator }
 
 import scala.collection.JavaConverters._
@@ -55,7 +55,7 @@ class AhcWSRequestSpec extends Specification with Mockito with DefaultBodyReadab
           .asInstanceOf[StandaloneAhcWSRequest]
           .buildRequest()
 
-        req.getHeaders.get(HttpHeaders.Names.CONTENT_TYPE) must be_==("text/plain")
+        req.getHeaders.get(HttpHeaderNames.CONTENT_TYPE) must be_==("text/plain; charset=UTF-8")
         req.getStringData must be_==("HELLO WORLD")
       }
 
@@ -67,7 +67,7 @@ class AhcWSRequestSpec extends Specification with Mockito with DefaultBodyReadab
           .asInstanceOf[StandaloneAhcWSRequest]
           .buildRequest()
 
-        req.getHeaders.get(HttpHeaders.Names.CONTENT_TYPE) must be_==("text/plain+hello") // preserve the content type
+        req.getHeaders.get(HttpHeaderNames.CONTENT_TYPE) must be_==("text/plain+hello; charset=UTF-8") // preserve the content type
         req.getStringData must be_==("HELLO WORLD") // should result in byte data.
       }
 
@@ -178,7 +178,7 @@ class AhcWSRequestSpec extends Specification with Mockito with DefaultBodyReadab
       request.setBody(body("HELLO WORLD"))
       request.addHeader("Content-Type", "application/json") // will be ignored since body already sets content type
       val req = request.buildRequest()
-      req.getHeaders.get("Content-Type") must be_==("text/plain")
+      req.getHeaders.get("Content-Type") must be_==("text/plain; charset=UTF-8")
     }
 
     "only send first Content-Type header and keep the charset when setting the Content-Type multiple times" in {
@@ -455,7 +455,7 @@ class AhcWSRequestSpec extends Specification with Mockito with DefaultBodyReadab
           .addCookie(cookie("cookie1", "value1"))
           .buildRequest()
 
-        request.getCookies.asScala.head.getName must beEqualTo("cookie1")
+        request.getCookies.asScala.head.name must beEqualTo("cookie1")
       }
 
       "add more than one cookie" in {
@@ -465,8 +465,8 @@ class AhcWSRequestSpec extends Specification with Mockito with DefaultBodyReadab
           .buildRequest()
 
         request.getCookies.asScala must size(2)
-        request.getCookies.asScala.head.getName must beEqualTo("cookie1")
-        request.getCookies.asScala(1).getName must beEqualTo("cookie2")
+        request.getCookies.asScala.head.name must beEqualTo("cookie1")
+        request.getCookies.asScala(1).name must beEqualTo("cookie2")
       }
 
       "keep existing cookies when adding a new one" in {
@@ -477,8 +477,8 @@ class AhcWSRequestSpec extends Specification with Mockito with DefaultBodyReadab
           .buildRequest()
 
         request.getCookies.asScala must size(2)
-        request.getCookies.asScala.head.getName must beEqualTo("cookie1")
-        request.getCookies.asScala(1).getName must beEqualTo("cookie2")
+        request.getCookies.asScala.head.name must beEqualTo("cookie1")
+        request.getCookies.asScala(1).name must beEqualTo("cookie2")
       }
 
       "set all cookies" in {
@@ -488,8 +488,8 @@ class AhcWSRequestSpec extends Specification with Mockito with DefaultBodyReadab
           .buildRequest()
 
         request.getCookies.asScala must size(2)
-        request.getCookies.asScala.head.getName must beEqualTo("cookie1")
-        request.getCookies.asScala(1).getName must beEqualTo("cookie2")
+        request.getCookies.asScala.head.name must beEqualTo("cookie1")
+        request.getCookies.asScala(1).name must beEqualTo("cookie2")
       }
 
       "discard old cookies when setting" in {
@@ -500,8 +500,8 @@ class AhcWSRequestSpec extends Specification with Mockito with DefaultBodyReadab
           .buildRequest()
 
         request.getCookies.asScala must size(2)
-        request.getCookies.asScala.head.getName must beEqualTo("cookie3")
-        request.getCookies.asScala(1).getName must beEqualTo("cookie4")
+        request.getCookies.asScala.head.name must beEqualTo("cookie3")
+        request.getCookies.asScala(1).name must beEqualTo("cookie4")
       }
     }
   }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -42,7 +42,7 @@ object Dependencies {
   val cachecontrolVersion = "1.1.3"
   val cachecontrol = Seq("com.typesafe.play" %% "cachecontrol" % cachecontrolVersion)
 
-  val asyncHttpClientVersion = "2.0.36"
+  val asyncHttpClientVersion = "2.5.2"
   val asyncHttpClient = Seq("org.asynchttpclient" % "async-http-client" % asyncHttpClientVersion)
 
   val akkaVersion = "2.5.9"


### PR DESCRIPTION
Couldn't find a way to update branch name in the other PR, so had to create a new PR

# Pull Request Checklist

* [Y] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [Y] Have you signed the [Typesafe CLA](https://www.typesafe.com/contribute/cla)?
* [Y] Have you [squashed your commits](https://www.playframework.com/documentation/latest/WorkingWithGit#Squashing-commits)?
* [N/A] Have you added copyright headers to new files?
* [Y] Have you checked that both Scala and Java APIs are updated?
* [Y] Have you updated the documentation for both Scala and Java sections?
* [Y] Have you added tests for any changed functionality?

## Fixes
Upgrade Async-Http-Client to 2.4.4

## Purpose

Have access to connection stats through new class exposed from AsyncHttpClient

## Background Context

One major change around Cookie specific codes from Async-Http-Client is moved to Netty and there are now 2 different decoders (STRICT and LAX) so that we had to make that configurable.

## References
* https://discuss.lightbend.com/t/upgrade-async-http-client/752
* CHANGES in the Async-Http-Client : https://github.com/AsyncHttpClient/async-http-client/blob/master/CHANGES.md

Please refer to https://github.com/playframework/play-ws/pull/252 for previous comments
