### PR TITLE
Add withUrl(String)

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -49,6 +49,10 @@ lazy val mimaSettings = mimaDefaultSettings ++ Seq(
     ProblemFilters.exclude[ReversedMissingMethodProblem]("play.libs.ws.StandaloneWSRequest.getMethod"),
     ProblemFilters.exclude[ReversedMissingMethodProblem]("play.libs.ws.StandaloneWSRequest.setAuth"),
 
+    // Added in #268 for 2.0.0
+    ProblemFilters.exclude[ReversedMissingMethodProblem]("play.libs.ws.StandaloneWSRequest.setUrl"),
+    ProblemFilters.exclude[ReversedMissingMethodProblem]("play.api.libs.ws.StandaloneWSRequest.withUrl"),
+
     // Now have a default implementation at the interface
     ProblemFilters.exclude[DirectMissingMethodProblem]("play.libs.ws.ahc.StandaloneAhcWSRequest.getPassword"),
     ProblemFilters.exclude[DirectMissingMethodProblem]("play.libs.ws.ahc.StandaloneAhcWSRequest.getUsername"),

--- a/play-ahc-ws-standalone/src/main/java/play/libs/ws/ahc/StandaloneAhcWSRequest.java
+++ b/play-ahc-ws-standalone/src/main/java/play/libs/ws/ahc/StandaloneAhcWSRequest.java
@@ -42,7 +42,7 @@ public class StandaloneAhcWSRequest implements StandaloneWSRequest {
 
     private BodyWritable<?> bodyWritable;
 
-    private final String url;
+    private String url;
     private String method = "GET";
     private final Map<String, List<String>> headers = new HashMap<>();
     private final Map<String, List<String>> queryParameters = new LinkedHashMap<>();
@@ -223,6 +223,12 @@ public class StandaloneAhcWSRequest implements StandaloneWSRequest {
     @Override
     public Optional<String> getContentType() {
         return getHeader(CONTENT_TYPE);
+    }
+
+    @Override
+    public StandaloneAhcWSRequest setUrl(String url) {
+        this.url = url;
+        return this;
     }
 
     @Override

--- a/play-ahc-ws-standalone/src/main/scala/play/api/libs/ws/ahc/StandaloneAhcWSRequest.scala
+++ b/play-ahc-ws-standalone/src/main/scala/play/api/libs/ws/ahc/StandaloneAhcWSRequest.scala
@@ -183,6 +183,8 @@ case class StandaloneAhcWSRequest(
     withMethod(method).execute()
   }
 
+  override def withUrl(url: String): Self = copy(url = url)
+
   override def withMethod(method: String): Self = copy(method = method)
 
   override def execute(): Future[Response] = {

--- a/play-ahc-ws-standalone/src/test/scala/play/api/libs/ws/ahc/AhcWSRequestSpec.scala
+++ b/play-ahc-ws-standalone/src/test/scala/play/api/libs/ws/ahc/AhcWSRequestSpec.scala
@@ -458,6 +458,12 @@ class AhcWSRequestSpec extends Specification with Mockito with AfterAll with Def
 
   "StandaloneAhcWSRequest supports" in {
 
+    "replace url" in withClient { client =>
+      val req = client.url("http://playframework.com/")
+        .withUrl("http://www.example.com/")
+      req.url must_=== "http://www.example.com/"
+    }
+
     "a custom signature calculator" in {
       var called = false
       val calc = new play.shaded.ahc.org.asynchttpclient.SignatureCalculator with WSSignatureCalculator {

--- a/play-ahc-ws-standalone/src/test/scala/play/libs/ws/ahc/AhcWSRequestSpec.scala
+++ b/play-ahc-ws-standalone/src/test/scala/play/libs/ws/ahc/AhcWSRequestSpec.scala
@@ -36,6 +36,17 @@ class AhcWSRequestSpec extends Specification with Mockito with DefaultBodyReadab
       actual must beEqualTo("foo.com")
     }
 
+    "set the url" in {
+      val client = mock[StandaloneAhcWSClient]
+      val req = new StandaloneAhcWSRequest(client, "http://playframework.com/", null)
+      req.getUrl must be_===("http://playframework.com/") and {
+        val setReq = req.setUrl("http://example.com")
+        setReq.getUrl must be_===("http://example.com") and {
+          setReq must be_===(req)
+        }
+      }
+    }
+
     "For POST requests" in {
 
       "get method" in {
@@ -43,7 +54,7 @@ class AhcWSRequestSpec extends Specification with Mockito with DefaultBodyReadab
         val req = new StandaloneAhcWSRequest(client, "http://playframework.com/", null)
           .setMethod("POST")
 
-        req.getMethod must be_==("POST")
+        req.getMethod must be_===("POST")
       }
 
       "set text/plain content-types for text bodies" in {

--- a/play-ws-standalone/src/main/java/play/libs/ws/StandaloneWSRequest.java
+++ b/play-ws-standalone/src/main/java/play/libs/ws/StandaloneWSRequest.java
@@ -135,6 +135,14 @@ public interface StandaloneWSRequest {
     //-------------------------------------------------------------------------
 
     /**
+     * Sets the URL of the request.
+     *
+     * @param url the URL of the request
+     * @return the modified WSRequest.
+     */
+    StandaloneWSRequest setUrl(String url);
+
+    /**
      * Sets the HTTP method this request should use, where the no args execute() method is invoked.
      *
      * @param method the HTTP method.

--- a/play-ws-standalone/src/main/scala/play/api/libs/ws/StandaloneWSRequest.scala
+++ b/play-ws-standalone/src/main/scala/play/api/libs/ws/StandaloneWSRequest.scala
@@ -204,6 +204,11 @@ trait StandaloneWSRequest {
   def withProxyServer(proxyServer: WSProxyServer): Self
 
   /**
+   * Sets the url for this request.
+   */
+  def withUrl(url: String): Self
+
+  /**
    * Sets the method for this request
    */
   def withMethod(method: String): Self


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [x] Have you signed the [Typesafe CLA](https://www.typesafe.com/contribute/cla)?
* [x] Have you [squashed your commits](https://www.playframework.com/documentation/latest/WorkingWithGit#Squashing-commits)?
* [x] Have you added copyright headers to new files?
* [x] Have you checked that both Scala and Java APIs are updated? **(see below)**
* [x] Have you updated the documentation for both Scala and Java sections?
* [x] Have you added tests for any changed functionality?

## Fixes
Fixes #264

## Purpose

Adds support in the scala API for changing the `url` of the `WSRequest`.

## Background Context

Like @gmethvin, I've encountered a couple use cases where I'd like to modify the URL of an existing WSRequest.

1. Fixing URIs
In my `WSRequestFilter`s, I'd like to make use of `WSRequest.uri`, but it's unsafe (see #267). Today, I have a `WSRequestFilter` to sanitize the entire request prior to subsequent WSRequestFilters touching `WSRequest.uri`. In order to strip out query params and any other garbage from the URL, my `WSRequestFilter` has to rebuild the whole request from scratch. Additionally, it has to require a `WSClient` to do the job (`wsClient.url()`), which I hope is the same `WSClient` that originally used to build the request. Ugh!

2. Changing hostnames
We're cursed with https://github.com/mesosphere/marathon-lb, which sometimes fails to route requests. I'd love to be able to have a `WSRequestFilter` I can use to bypass that layer and rewrite https://pray-marathon-lb-works.example.com/foo to https://10.0.0.25/foo.