### PR TITLE
Add @throws, scaladoc: clarify uri params

### DIFF
--- a/play-ws-standalone/src/main/java/play/libs/ws/StandaloneWSClient.java
+++ b/play-ws-standalone/src/main/java/play/libs/ws/StandaloneWSClient.java
@@ -22,6 +22,8 @@ public interface StandaloneWSClient extends java.io.Closeable {
      * properties on the StandaloneWSRequest by chaining calls, and execute the request to
      * return an asynchronous {@code CompletionStage<StandaloneWSResponse>}.
      *
+     * SHOULD NOT include the query string. Use {@link StandaloneWSRequest#addQueryParameter(String, String)} instead.
+     *
      * @param url the URL to request
      * @return the request
      */

--- a/play-ws-standalone/src/main/java/play/libs/ws/StandaloneWSRequest.java
+++ b/play-ws-standalone/src/main/java/play/libs/ws/StandaloneWSRequest.java
@@ -136,6 +136,7 @@ public interface StandaloneWSRequest {
 
     /**
      * Sets the URL of the request.
+     * SHOULD NOT include the query string. Use {@link StandaloneWSRequest#addQueryParameter(String, String)} instead.
      *
      * @param url the URL of the request
      * @return the modified WSRequest.

--- a/play-ws-standalone/src/main/scala/play/api/libs/ws/StandaloneWSClient.scala
+++ b/play-ws-standalone/src/main/scala/play/api/libs/ws/StandaloneWSClient.scala
@@ -22,6 +22,7 @@ trait StandaloneWSClient extends Closeable {
    * Generates a request.  Throws IllegalArgumentException if the URL is invalid.
    *
    * @param url The base URL to make HTTP requests to.
+   *            SHOULD NOT include the query string. Use [[StandaloneWSRequest.withQueryStringParameters]] instead.
    * @return a request
    */
   @throws[IllegalArgumentException]

--- a/play-ws-standalone/src/main/scala/play/api/libs/ws/StandaloneWSRequest.scala
+++ b/play-ws-standalone/src/main/scala/play/api/libs/ws/StandaloneWSRequest.scala
@@ -30,6 +30,7 @@ trait StandaloneWSRequest {
   /**
    * The URI for this request
    */
+  @throws[java.net.URISyntaxException]("if the url is invalid, e.g. /path?foo=|")
   def uri: URI
 
   /**
@@ -205,6 +206,7 @@ trait StandaloneWSRequest {
 
   /**
    * Sets the url for this request.
+   * SHOULD NOT include the query string. Use [[withQueryStringParameters]] instead.
    */
   def withUrl(url: String): Self
 


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [x] Have you signed the [Typesafe CLA](https://www.typesafe.com/contribute/cla)?
* [x] Have you [squashed your commits](https://www.playframework.com/documentation/latest/WorkingWithGit#Squashing-commits)?
* [x] Have you added copyright headers to new files?
* [x] Have you checked that both Scala and Java APIs are updated?
* [x] Have you updated the documentation for both Scala and Java sections?
* [x] Have you added tests for any changed functionality?

## Fixes

#267 (sorta?)

## Purpose

Adds scaladoc for acceptable values of `url: String`, specifically the presence of query params.

## Background Context
This PR documents the expectations and consequences of query param values in `url: String`.

AHC is actually capable of executing these requests properly in most cases. So far the only impact I've seen is that this can cause `java.net.URI` to throw `URISyntaxException` which I've documented with `@throws` as well.

## References

* https://discuss.lightbend.com/t/correct-usage-of-wsclient-url-string-parameter/1783
* https://github.com/playframework/play-ws/issues/267