### PR TITLE
Update dependencies for stable version

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -14,7 +14,7 @@ import scalariform.formatter.preferences._
 //---------------------------------------------------------------
 
 val scala211 = "2.11.12"
-val scala212 = "2.12.4"
+val scala212 = "2.12.7"
 
 val previousVersion = None
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -23,7 +23,7 @@ object Dependencies {
 
   val scalaJava8Compat = Seq("org.scala-lang.modules" %% "scala-java8-compat" % "0.8.0")
 
-  val playJsonVersion = "2.6.0"
+  val playJsonVersion = "2.6.10"
   val playJson = Seq("com.typesafe.play" %% "play-json" % playJsonVersion)
 
   val slf4jApi = Seq("org.slf4j" % "slf4j-api" % "1.7.25")
@@ -39,17 +39,17 @@ object Dependencies {
   val signpostVersion = "1.2.1.2"
   val oauth = Seq("oauth.signpost" % "signpost-core" % signpostVersion)
 
-  val cachecontrolVersion = "1.1.3"
+  val cachecontrolVersion = "1.1.4"
   val cachecontrol = Seq("com.typesafe.play" %% "cachecontrol" % cachecontrolVersion)
 
-  val asyncHttpClientVersion = "2.0.36"
+  val asyncHttpClientVersion = "2.0.39"
   val asyncHttpClient = Seq("org.asynchttpclient" % "async-http-client" % asyncHttpClientVersion)
 
-  val akkaVersion = "2.5.9"
+  val akkaVersion = "2.5.17"
   val akkaStreams = Seq("com.typesafe.akka" %% "akka-stream" % akkaVersion)
-  val akkaHttp = Seq("com.typesafe.akka" %% "akka-http" % "10.0.11")
+  val akkaHttp = Seq("com.typesafe.akka" %% "akka-http" % "10.0.14")
 
-  val reactiveStreams = Seq("org.reactivestreams" % "reactive-streams" % "1.0.0")
+  val reactiveStreams = Seq("org.reactivestreams" % "reactive-streams" % "1.0.2")
 
   val testDependencies = (specsBuild ++ junitInterface ++ assertj ++ awaitility ++ slf4jtest ++ logback).map(_ % Test)
 


### PR DESCRIPTION
## Fixes

Fixes https://github.com/playframework/playframework/issues/8566.

## Purpose

Update dependencies, mainly async-http-client, to have better support in Java 9+.

## References

According to https://github.com/netty/netty/issues/7768 this was fixed in newer version of Netty and the (possible) fix is https://github.com/netty/netty/pull/7650. This is part of Netty 4.0.55.Final and [async-http-client is using 4.0.56](https://github.com/AsyncHttpClient/async-http-client/blob/async-http-client-project-2.0.39/pom.xml#L379). Since these dependencies are shaded, we need to update them here first, do a release and then update in Play.