### PR TITLE
Ensure logger factory uses name

### DIFF
--- a/play-ahc-ws-standalone/src/main/scala/play/api/libs/ws/ahc/AhcLoggerFactory.scala
+++ b/play-ahc-ws-standalone/src/main/scala/play/api/libs/ws/ahc/AhcLoggerFactory.scala
@@ -10,7 +10,7 @@ class AhcLoggerFactory(lf: ILoggerFactory = SLF4JLoggerFactory.getILoggerFactory
 
   private[ahc] def createLogger(name: String) = {
     new NoDepsLogger {
-      private[ahc] val logger = lf.getLogger(this.getClass.getName)
+      private[ahc] val logger = lf.getLogger(name)
 
       def warn(msg: String): Unit = logger.warn(msg)
       def isDebugEnabled: Boolean = logger.isDebugEnabled


### PR DESCRIPTION
## Fixes

Fixes https://github.com/playframework/play-ws/issues/291

## Purpose

Makes loggerfactory use passed in name.