### PR TITLE
[2.7.x]: Update play json 2.7.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,7 @@ matrix:
     # testing play-ws using it to better discover possible problems but we
     # can allow failures here too.
     - env: TRAVIS_JDK=adopt@1.11.0-1
+    - scala: 2.13.0-M3
 
 scala:
   - 2.12.7

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -45,9 +45,9 @@ object Dependencies {
   val asyncHttpClientVersion = "2.6.0"
   val asyncHttpClient = Seq("org.asynchttpclient" % "async-http-client" % asyncHttpClientVersion)
 
-  val akkaVersion = "2.5.17"
+  val akkaVersion = "2.5.19"
   val akkaStreams = Seq("com.typesafe.akka" %% "akka-stream" % akkaVersion)
-  val akkaHttp = Seq("com.typesafe.akka" %% "akka-http" % "10.1.0")
+  val akkaHttp = Seq("com.typesafe.akka" %% "akka-http" % "10.1.5")
 
   val reactiveStreams = Seq("org.reactivestreams" % "reactive-streams" % "1.0.2")
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -23,7 +23,7 @@ object Dependencies {
 
   val scalaJava8Compat = Seq("org.scala-lang.modules" %% "scala-java8-compat" % "0.8.0")
 
-  val playJsonVersion = "2.6.13"
+  val playJsonVersion = "2.7.0"
   val playJson = Seq("com.typesafe.play" %% "play-json" % playJsonVersion)
 
   val slf4jApi = Seq("org.slf4j" % "slf4j-api" % "1.7.25")


### PR DESCRIPTION
## Purpose

Play-WS 2.0.0 should be using Play JSON 2.7.0, but I made the release in the inversed order.

This updates Play JSON here and also harmonizes some dependencies with what we have in Play itself.