### PR TITLE
Optimize StandaloneAhcWSRequest.add* methods.

### DIFF
--- a/bench/src/main/scala/play/api/libs/ws/ahc/StandaloneAhcWSRequestBenchMapsBench.scala
+++ b/bench/src/main/scala/play/api/libs/ws/ahc/StandaloneAhcWSRequestBenchMapsBench.scala
@@ -1,0 +1,77 @@
+/*
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package play.api.libs.ws.ahc
+
+import java.util.concurrent.TimeUnit
+
+import akka.stream.Materializer
+import org.openjdk.jmh.annotations._
+import org.openjdk.jmh.infra.Blackhole
+import play.api.libs.ws.StandaloneWSRequest
+
+/**
+ * Tests Map-backed features of [[StandaloneAhcWSRequest]].
+ *
+ * ==Quick Run from sbt==
+ *
+ * > bench/jmh:run .*StandaloneAhcWSRequestBenchMapsBench
+ *
+ * ==Using Oracle Flight Recorder==
+ *
+ * To record a Flight Recorder file from a JMH run, run it using the jmh.extras.JFR profiler:
+ * > bench/jmh:run -prof jmh.extras.JFR .*StandaloneAhcWSRequestBenchMapsBench
+ *
+ * Compare your results before/after on your machine. Don't trust the ones in scaladoc.
+ *
+ * Sample benchmark results:
+ * {{{
+ * > bench/jmh:run .*StandaloneAhcWSRequestBenchMapsBench
+ * [info] Benchmark                                             (size)  Mode  Cnt    Score   Error  Units
+ * [info] StandaloneAhcWSRequestBenchMapsBench.addHeaders            1  avgt       162.673          ns/op
+ * [info] StandaloneAhcWSRequestBenchMapsBench.addHeaders           10  avgt       195.672          ns/op
+ * [info] StandaloneAhcWSRequestBenchMapsBench.addHeaders          100  avgt       278.829          ns/op
+ * [info] StandaloneAhcWSRequestBenchMapsBench.addHeaders         1000  avgt       356.446          ns/op
+ * [info] StandaloneAhcWSRequestBenchMapsBench.addHeaders        10000  avgt       308.384          ns/op
+ * [info] StandaloneAhcWSRequestBenchMapsBench.addQueryParams        1  avgt        42.123          ns/op
+ * [info] StandaloneAhcWSRequestBenchMapsBench.addQueryParams       10  avgt        82.650          ns/op
+ * [info] StandaloneAhcWSRequestBenchMapsBench.addQueryParams      100  avgt        90.095          ns/op
+ * [info] StandaloneAhcWSRequestBenchMapsBench.addQueryParams     1000  avgt       123.221          ns/op
+ * [info] StandaloneAhcWSRequestBenchMapsBench.addQueryParams    10000  avgt       141.556          ns/op
+ * }}}
+ *
+ * @see https://github.com/ktoso/sbt-jmh
+ */
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@BenchmarkMode(Array(Mode.AverageTime))
+@Fork(jvmArgsAppend = Array("-Xmx350m", "-XX:+HeapDumpOnOutOfMemoryError"), value = 1)
+@State(Scope.Benchmark)
+class StandaloneAhcWSRequestBenchMapsBench {
+
+  private implicit val materializer: Materializer = null // we're not actually going to execute anything.
+  private var exampleRequest: StandaloneWSRequest = _
+
+  @Param(Array("1", "10", "100", "1000", "10000"))
+  private var size: Int = _
+
+  @Setup def setup(): Unit = {
+    val params = (1 to size)
+      .map(_.toString)
+      .map(s => s -> s)
+
+    exampleRequest = StandaloneAhcWSRequest(new StandaloneAhcWSClient(null), "https://www.example.com")
+      .addQueryStringParameters(params: _*)
+      .addHttpHeaders(params: _*)
+  }
+
+  @Benchmark
+  def addQueryParams(bh: Blackhole): Unit = {
+    bh.consume(exampleRequest.addQueryStringParameters("nthParam" -> "nthParam"))
+  }
+
+  @Benchmark
+  def addHeaders(bh: Blackhole): Unit = {
+    bh.consume(exampleRequest.addHttpHeaders("nthHeader" -> "nthHeader"))
+  }
+}

--- a/build.sbt
+++ b/build.sbt
@@ -208,8 +208,7 @@ val disableDocs = Seq[Setting[_]](
 
 val disablePublishing = Seq[Setting[_]](
   publishArtifact := false,
-  skip in publish := true,
-  crossScalaVersions := Seq(scala212)
+  skip in publish := true
 )
 
 lazy val shadeAssemblySettings = commonSettings ++ Seq(
@@ -465,7 +464,6 @@ lazy val `integration-tests` = project.in(file("integration-tests"))
   .settings(disableDocs)
   .settings(disablePublishing)
   .settings(
-    crossScalaVersions := Seq(scala213, scala212, scala211),
     fork in Test := true,
     concurrentRestrictions += Tags.limitAll(1), // only one integration test at a time
     testOptions in Test := Seq(Tests.Argument(TestFrameworks.JUnit, "-a", "-v")),
@@ -479,6 +477,24 @@ lazy val `integration-tests` = project.in(file("integration-tests"))
     `play-ws-standalone-xml`
   )
   .disablePlugins(sbtassembly.AssemblyPlugin)
+
+//---------------------------------------------------------------
+// Benchmarks (run manually)
+//---------------------------------------------------------------
+
+lazy val bench = project
+  .in(file("bench"))
+  .enablePlugins(JmhPlugin)
+  .dependsOn(
+    `play-ws-standalone`,
+    `play-ws-standalone-json`,
+    `play-ws-standalone-xml`,
+    `play-ahc-ws-standalone`
+  )
+  .settings(commonSettings)
+  .settings(formattingSettings)
+  .settings(disableDocs)
+  .settings(disablePublishing)
 
 //---------------------------------------------------------------
 // Root Project
@@ -496,13 +512,15 @@ lazy val root = project
   .settings(formattingSettings)
   .settings(disableDocs)
   .settings(disablePublishing)
+  .settings(crossScalaVersions := Seq(scala212))
   .aggregate(
     `shaded`,
     `play-ws-standalone`,
     `play-ws-standalone-json`,
     `play-ws-standalone-xml`,
     `play-ahc-ws-standalone`,
-    `integration-tests`
+    `integration-tests`,
+    bench
   )
   .disablePlugins(sbtassembly.AssemblyPlugin)
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -17,3 +17,5 @@ addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "0.1.18")
 addSbtPlugin("com.gilt" % "sbt-dependency-graph-sugar" % "0.9.0")
 
 addSbtPlugin("de.heikoseeberger" % "sbt-header" % "5.0.0")
+
+addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.3.4")


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [x] Have you signed the [Typesafe CLA](https://www.typesafe.com/contribute/cla)?
* [x] Have you [squashed your commits](https://www.playframework.com/documentation/latest/WorkingWithGit#Squashing-commits)?
* [x] Have you added copyright headers to new files?
* [x] Have you checked that both Scala and Java APIs are updated?
* [x] Have you updated the documentation for both Scala and Java sections?
* [x] Have you added tests for any changed functionality?

## Purpose

Optimizes `StandaloneAhcWSRequest.add*` methods from O(n) down to O(eC) by avoiding reconstructing maps from scratch.

## Background Context
I spotted this while benching https://github.com/playframework/play-ws/pull/288.

`StandaloneAhcWSRequest` uses immutable maps that support structural sharing, yet the implementations of `addQueryStringParameters((String, String)*)` and `addHttpHeaders(hdrs: (String, String)*)` rebuild the entire map on each call. For a request with *n* elements, appending a new one is an O(*n*) operation over an O(eC) data structure. Inserting *n* elements is O(*n²*).

Play 2.5 `WSRequest` has an O(eC) implementation, so this seems like new behavior in the pre-release of play-ahc-ws-standalone v2.

## Benchmarks
`AddQueryParamsBench` measures adding a single query param to a request that already has *size* query params.

Before
```
[info] Benchmark                      (size)  Mode  Cnt        Score       Error  Units
[info] AddQueryParamsBench.addParams       1  avgt   10      417.620 ±    17.237  ns/op
[info] AddQueryParamsBench.addParams      10  avgt   10     2257.053 ±    76.440  ns/op
[info] AddQueryParamsBench.addParams     100  avgt   10    18839.600 ±   801.003  ns/op
[info] AddQueryParamsBench.addParams    1000  avgt   10   224491.116 ± 12133.870  ns/op
[info] AddQueryParamsBench.addParams   10000  avgt   10  3065837.189 ± 82797.559  ns/op
```

We cross the 1s/call threshold somewhere between the 1,000 and 10,000th param. At 10k query params, constructing the whole request takes 16 seconds.

Admittedly 10k query params is on the high end of what we're likely to see in real apps, but we can also bring it down to nanoseconds pretty trivially.

After
```
[info] Benchmark                      (size)  Mode  Cnt    Score   Error  Units
[info] AddQueryParamsBench.addParams       1  avgt   10   47.978 ± 0.388  ns/op
[info] AddQueryParamsBench.addParams      10  avgt   10   76.495 ± 0.663  ns/op
[info] AddQueryParamsBench.addParams     100  avgt   10  118.205 ± 1.072  ns/op
[info] AddQueryParamsBench.addParams    1000  avgt   10  141.506 ± 1.681  ns/op
[info] AddQueryParamsBench.addParams   10000  avgt   10  151.452 ± 2.560  ns/op
```

## Caveats
There is a default implementation of these methods in the `trait StandaloneWSRequest`. I don't see any harm in leaving them there.

## References

No other issues or PRs that I'm aware of.