### PR TITLE
Fix release for Scala 2.13.0-M5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,8 @@ scala:
 
 script:
   - sbt ++$TRAVIS_SCALA_VERSION 'testOnly -- xonly timefactor 5' mimaReportBinaryIssues validateCode doc
+  # Check that we can actually build and package the library
+  - sbt ++$TRAVIS_SCALA_VERSION publishLocal
 
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,6 @@ matrix:
     # testing play-ws using it to better discover possible problems but we
     # can allow failures here too.
     - env: TRAVIS_JDK=adopt@1.11.0-1
-    - scala: 2.13.0-M5
 
 scala:
   - 2.12.7

--- a/build.sbt
+++ b/build.sbt
@@ -19,7 +19,7 @@ val scala213 = "2.13.0-M5"
 val previousVersion = "2.0.0"
 
 def binaryCompatibilitySettings(scalaBinVersion: String, org: String, moduleName: String): Set[ModuleID] = scalaBinVersion match {
-  case "2.13" => Set.empty
+  case version if version.equals(scala213) => Set.empty
   case _ => Set(org % s"${moduleName}_$scalaBinVersion" % previousVersion)
 }
 

--- a/build.sbt
+++ b/build.sbt
@@ -40,7 +40,7 @@ def scalacOptionsFor(scalaBinVersion: String): Seq[String] = scalaBinVersion mat
     "-feature",
     "-unchecked",
 
-    // This next two flags are not supported by 2.13
+    // The next two flags are not supported by 2.13
     "-Ywarn-unused-import",
     "-Ywarn-nullary-unit",
 

--- a/build.sbt
+++ b/build.sbt
@@ -18,9 +18,10 @@ val scala213 = "2.13.0-M5"
 // Binary compatibility is this version
 val previousVersion = "2.0.0"
 
-val binaryCompatibilitySettings = Seq(
-  mimaPreviousArtifacts := Set(organization.value % s"${moduleName.value}_${scalaBinaryVersion.value}" % previousVersion)
-)
+def binaryCompatibilitySettings(scalaBinVersion: String, org: String, moduleName: String): Set[ModuleID] = scalaBinVersion match {
+  case "2.13" => Set.empty
+  case _ => Set(org % s"${moduleName}_$scalaBinVersion" % previousVersion)
+}
 
 resolvers ++= DefaultOptions.resolvers(snapshot = true)
 resolvers in ThisBuild += Resolver.sonatypeRepo("public")
@@ -284,7 +285,7 @@ lazy val shaded = Project(id = "shaded", base = file("shaded") )
 lazy val `play-ws-standalone` = project
   .in(file("play-ws-standalone"))
   .settings(commonSettings)
-  .settings(binaryCompatibilitySettings)
+  .settings(mimaPreviousArtifacts := binaryCompatibilitySettings(scalaBinaryVersion.value, organization.value, name.value))
   .settings(libraryDependencies ++= standaloneApiWSDependencies)
   .disablePlugins(sbtassembly.AssemblyPlugin)
 
@@ -309,7 +310,7 @@ def addShadedDeps(deps: Seq[xml.Node], node: xml.Node): xml.Node = {
 // Standalone implementation using AsyncHttpClient
 lazy val `play-ahc-ws-standalone` = project
   .in(file("play-ahc-ws-standalone"))
-  .settings(binaryCompatibilitySettings: _*)
+  .settings(mimaPreviousArtifacts := binaryCompatibilitySettings(scalaBinaryVersion.value, organization.value, name.value))
   .settings(commonSettings ++ formattingSettings ++ shadedAhcSettings ++ shadedOAuthSettings ++ Seq(
     fork in Test := true,
     testOptions in Test := Seq(
@@ -343,7 +344,7 @@ lazy val `play-ws-standalone-json` = project
   .in(file("play-ws-standalone-json"))
   .settings(commonSettings)
   .settings(formattingSettings)
-  .settings(binaryCompatibilitySettings)
+  .settings(mimaPreviousArtifacts := binaryCompatibilitySettings(scalaBinaryVersion.value, organization.value, name.value))
   .settings(
     fork in Test := true,
     testOptions in Test := Seq(Tests.Argument(TestFrameworks.JUnit, "-a", "-v")),
@@ -361,7 +362,7 @@ lazy val `play-ws-standalone-xml` = project
   .in(file("play-ws-standalone-xml"))
   .settings(commonSettings)
   .settings(formattingSettings)
-  .settings(binaryCompatibilitySettings)
+  .settings(mimaPreviousArtifacts := binaryCompatibilitySettings(scalaBinaryVersion.value, organization.value, name.value))
   .settings(
     fork in Test := true,
     testOptions in Test := Seq(Tests.Argument(TestFrameworks.JUnit, "-a", "-v")),


### PR DESCRIPTION
## Purpose

~~The supported flags are different for Scala 2.11 and Scala 2.12/2.13.~~

The scope here is now to fix the release process for Scala 2.13.0-M5. See the commits history.