### PR TITLE
[fix] don't use AHC cookie store

### DIFF
--- a/play-ahc-ws-standalone/src/main/scala/play/api/libs/ws/ahc/AhcConfig.scala
+++ b/play-ahc-ws-standalone/src/main/scala/play/api/libs/ws/ahc/AhcConfig.scala
@@ -208,6 +208,13 @@ class AhcConfigBuilder(ahcConfig: AhcWSClientConfig = AhcWSClientConfig()) {
     builder.setShutdownQuietPeriod(0)
     builder.setShutdownTimeout(0)
     builder.setUseLaxCookieEncoder(ahcConfig.useLaxCookieEncoder)
+
+    // The WSRequest withCookies method suggests all cookies will be
+    // discarded. This is not the case if the underlying http client
+    // has a cookie store. Play ws also does not know about those
+    // cookies so for example the AhcCurlRequestLogger does not log
+    // these cookies.
+    builder.setCookieStore(null)
   }
 
   def configureProtocols(existingProtocols: Array[String], sslConfig: SSLConfigSettings): Array[String] = {

--- a/play-ahc-ws-standalone/src/test/scala/play/api/libs/ws/ahc/AhcConfigBuilderSpec.scala
+++ b/play-ahc-ws-standalone/src/test/scala/play/api/libs/ws/ahc/AhcConfigBuilderSpec.scala
@@ -51,6 +51,7 @@ class AhcConfigBuilderSpec extends Specification with Mockito {
         actual.getRequestTimeout must_== defaultWsConfig.requestTimeout.toMillis
         actual.getConnectTimeout must_== defaultWsConfig.connectionTimeout.toMillis
         actual.isFollowRedirect must_== defaultWsConfig.followRedirects
+        actual.getCookieStore must_== null
 
         actual.getEnabledCipherSuites.toSeq must not contain Ciphers.deprecatedCiphers
         actual.getEnabledProtocols.toSeq must not contain Protocols.deprecatedProtocols


### PR DESCRIPTION
The WSRequest withCookies method suggests all cookies will be
discarded. This is not the case if the underlying http client has a
cookie store. Play ws also does not know about those cookies so for
example the AhcCurlRequestLogger does not log these cookies.

