### PR TITLE
Make it possible to enable/disable cookie store

### DIFF
--- a/integration-tests/src/test/scala/play/api/libs/ws/ahc/AhcWSClientSpec.scala
+++ b/integration-tests/src/test/scala/play/api/libs/ws/ahc/AhcWSClientSpec.scala
@@ -4,14 +4,20 @@
 
 package play.api.libs.ws.ahc
 
-import akka.http.scaladsl.server.Route
+import akka.http.scaladsl.model.StatusCodes.Redirection
+import akka.http.scaladsl.model.headers.{ HttpCookie, RawHeader }
+import akka.http.scaladsl.model.{ StatusCode, StatusCodes }
+import akka.http.scaladsl.server.Directives._
+import akka.http.scaladsl.server.{ MissingCookieRejection, Route }
 import akka.stream.scaladsl.Sink
 import akka.util.ByteString
 import org.specs2.concurrent.{ ExecutionEnv, FutureAwait }
+import org.specs2.execute.Result
 import org.specs2.matcher.FutureMatchers
 import org.specs2.mutable.Specification
 import play.AkkaServerProvider
-import play.api.libs.ws.{ BodyReadable, DefaultBodyReadables }
+import play.api.libs.ws._
+import play.shaded.ahc.org.asynchttpclient.handler.MaxRedirectException
 
 import scala.concurrent._
 
@@ -20,19 +26,72 @@ class AhcWSClientSpec(implicit val executionEnv: ExecutionEnv) extends Specifica
   with StandaloneWSClientSupport
   with FutureMatchers
   with FutureAwait
-  with DefaultBodyReadables {
+  with DefaultBodyReadables
+  with DefaultBodyWritables {
 
-  override val routes: Route = {
-    import akka.http.scaladsl.server.Directives._
-    get {
-      complete("<h1>Say hello to akka-http</h1>")
+  def withClientFollowingRedirect(config: AhcWSClientConfig = AhcWSClientConfigFactory.forConfig())(block: StandaloneAhcWSClient => Result): Result = {
+    withClient(
+      config.copy(
+        wsClientConfig = config.wsClientConfig.copy(followRedirects = true)
+      )
+    )(block)
+  }
+
+  val indexRoutes: Route = {
+    path("index") {
+      extractRequest { request =>
+        respondWithHeaders(request.headers.map(h => RawHeader(s"Req-${h.name}", h.value))) {
+          get {
+            complete("Say hello to akka-http")
+          } ~
+            post {
+              complete(s"POST: ${request.entity}")
+            }
+        }
+      }
+    }
+  }
+
+  val cookieRoutes: Route = {
+    path("cookie") {
+      get {
+        setCookie(HttpCookie("flash", "redirect-cookie")) {
+          redirect("/cookie-destination", StatusCodes.MovedPermanently)
+        }
+      }
     } ~
-      post {
-        entity(as[String]) { echo =>
-          complete(echo)
+      path("cookie-destination") {
+        get {
+          optionalCookie("flash") {
+            case Some(c) => complete(s"Cookie value => ${c.value}")
+            case None => reject(MissingCookieRejection("flash"))
+          }
         }
       }
   }
+
+  val redirectRoutes: Route = {
+    // Single redirect
+    path("redirect" / IntNumber) { status =>
+      get {
+        val redirectCode = StatusCode.int2StatusCode(status).asInstanceOf[Redirection]
+        redirect("/index", redirectCode)
+      } ~
+        post {
+          val redirectCode = StatusCode.int2StatusCode(status).asInstanceOf[Redirection]
+          redirect("/index", redirectCode)
+        }
+    } ~
+      path("redirects" / IntNumber / IntNumber) { (status, count) =>
+        get {
+          val redirectCode = StatusCode.int2StatusCode(status).asInstanceOf[Redirection]
+          if (status == 1) redirect("/index", redirectCode)
+          else redirect(s"/redirects/$status/${count - 1}", redirectCode)
+        }
+      }
+  }
+
+  override val routes: Route = indexRoutes ~ cookieRoutes ~ redirectRoutes
 
   "url" should {
     "throw an exception on invalid url" in {
@@ -53,14 +112,14 @@ class AhcWSClientSpec(implicit val executionEnv: ExecutionEnv) extends Specifica
     "request a url as an in memory string" in {
       withClient() { client =>
         val result = Await.result(client.url(s"http://localhost:$testServerPort/index").get().map(res => res.body[String]), defaultTimeout)
-        result must beEqualTo("<h1>Say hello to akka-http</h1>")
+        result must beEqualTo("Say hello to akka-http")
       }
     }
 
     "request a url as a Foo" in {
       case class Foo(body: String)
 
-      implicit val fooBodyReadable = BodyReadable[Foo] { response =>
+      implicit val fooBodyReadable: BodyReadable[Foo] = BodyReadable[Foo] { response =>
         import play.shaded.ahc.org.asynchttpclient.{ Response => AHCResponse }
         val ahcResponse = response.asInstanceOf[StandaloneAhcWSResponse].underlying[AHCResponse]
         Foo(ahcResponse.getResponseBody)
@@ -68,7 +127,7 @@ class AhcWSClientSpec(implicit val executionEnv: ExecutionEnv) extends Specifica
 
       withClient() { client =>
         val result = Await.result(client.url(s"http://localhost:$testServerPort/index").get().map(res => res.body[Foo]), defaultTimeout)
-        result must beEqualTo(Foo("<h1>Say hello to akka-http</h1>"))
+        result must beEqualTo(Foo("Say hello to akka-http"))
       }
     }
 
@@ -76,7 +135,182 @@ class AhcWSClientSpec(implicit val executionEnv: ExecutionEnv) extends Specifica
       withClient() { client =>
         val resultSource = Await.result(client.url(s"http://localhost:$testServerPort/index").stream().map(_.bodyAsSource), defaultTimeout)
         val bytes: ByteString = Await.result(resultSource.runWith(Sink.head), defaultTimeout)
-        bytes.utf8String must beEqualTo("<h1>Say hello to akka-http</h1>")
+        bytes.utf8String must beEqualTo("Say hello to akka-http")
+      }
+    }
+
+    "when following redirect" in {
+
+      "honor the number of redirects allowed" in {
+        // 1. Default number of max redirects is 5
+        withClientFollowingRedirect() { client =>
+          {
+            val request = client
+              // 2. Ask to redirect 10 times
+              .url(s"http://localhost:$testServerPort/redirects/302/10")
+              .get()
+            Await.result(request, defaultTimeout)
+          } must throwA[MaxRedirectException]
+        }
+      }
+
+      "should follow a redirect when configured to" in {
+        withClientFollowingRedirect() { client =>
+          val result = Await.result(client.url(s"http://localhost:$testServerPort/redirect/302").get().map(res => res.body[String]), defaultTimeout)
+          result must beEqualTo("Say hello to akka-http")
+        }
+      }
+
+      "should not follow redirect if client is configured not to" in {
+        val wsConfig = WSClientConfig().copy(followRedirects = false)
+        val ahcWsConfig = AhcWSClientConfigFactory.forConfig().copy(wsClientConfig = wsConfig)
+        withClient(config = ahcWsConfig) { client =>
+          val result = Await.result(client.url(s"http://localhost:$testServerPort/redirect/302").get(), defaultTimeout)
+          result.status must beEqualTo(302)
+        }
+      }
+
+      "should not follow redirect if request is configured not to" in {
+        // 1. Client is configured to follow the redirect
+        withClientFollowingRedirect() { client =>
+          val request = client
+            .url(s"http://localhost:$testServerPort/redirect/302")
+            // 2. But turn off follow redirects for this request
+            .withFollowRedirects(false)
+            .get()
+          val result = Await.result(request, defaultTimeout)
+          result.status must beEqualTo(302)
+        }
+      }
+
+      "follow redirect for HTTP 301 Moved Permanently" in {
+        withClientFollowingRedirect() { client =>
+          val result = Await.result(client.url(s"http://localhost:$testServerPort/redirect/301").get().map(res => res.body[String]), defaultTimeout)
+          result must beEqualTo("Say hello to akka-http")
+        }
+      }
+
+      "follow redirect for HTTP 302 Found" in {
+        withClientFollowingRedirect() { client =>
+          val result = Await.result(client.url(s"http://localhost:$testServerPort/redirect/302").get().map(res => res.body[String]), defaultTimeout)
+          result must beEqualTo("Say hello to akka-http")
+        }
+      }
+
+      "follow redirect for HTTP 303 See Other" in {
+        withClientFollowingRedirect() { client =>
+          val result = Await.result(client.url(s"http://localhost:$testServerPort/redirect/303").get().map(res => res.body[String]), defaultTimeout)
+          result must beEqualTo("Say hello to akka-http")
+        }
+      }
+
+      "follow redirect for HTTP 307 Temporary Redirect" in {
+        withClientFollowingRedirect() { client =>
+          val result = Await.result(client.url(s"http://localhost:$testServerPort/redirect/307").get().map(res => res.body[String]), defaultTimeout)
+          result must beEqualTo("Say hello to akka-http")
+        }
+      }
+
+      "follow redirect for HTTP 308 Permanent Redirect" in {
+        withClientFollowingRedirect() { client =>
+          val result = Await.result(client.url(s"http://localhost:$testServerPort/redirect/308").get().map(res => res.body[String]), defaultTimeout)
+          result must beEqualTo("Say hello to akka-http")
+        }
+      }
+
+      "keep virtual host" in {
+        withClientFollowingRedirect() { client =>
+          val request = client
+            .url(s"http://localhost:$testServerPort/redirect/303")
+            .withVirtualHost("localhost1")
+            .get()
+          val result = Await.result(request, defaultTimeout)
+          result.header("Req-Host") must beSome("localhost1")
+        }
+      }
+
+      "keep http headers" in {
+        withClientFollowingRedirect() { client =>
+          val request = client
+            .url(s"http://localhost:$testServerPort/redirect/303")
+            .addHttpHeaders("X-Test" -> "Test")
+            .get()
+          val result = Await.result(request, defaultTimeout)
+          result.header("Req-X-Test") must beSome("Test")
+        }
+      }
+
+      "keep auth information" in {
+        withClientFollowingRedirect() { client =>
+          val request = client
+            .url(s"http://localhost:$testServerPort/redirect/303")
+            .withAuth("test", "test", WSAuthScheme.BASIC)
+            .get()
+          val result = Await.result(request, defaultTimeout)
+          result.header("Req-Authorization") must beSome
+        }
+      }
+
+      "keep cookie when following redirect automatically and cookie store is configured" in {
+        withClientFollowingRedirect(AhcWSClientConfigFactory.forConfig().copy(useCookieStore = true)) { client =>
+          val result = Await.result(client.url(s"http://localhost:$testServerPort/cookie").get().map(res => res.body[String]), defaultTimeout)
+          result must beEqualTo(s"Cookie value => redirect-cookie")
+        }
+      }
+
+      "not keep cookie when repeating the request" in {
+        withClientFollowingRedirect() { client =>
+          // First let's do a request that sets a cookie
+          val res1 = Await.result(client.url(s"http://localhost:$testServerPort/cookie").get().map(res => res.body[String]), defaultTimeout)
+
+          // Then run a request to a url that checks the cookie, but without setting it
+          val res2 = Await.result(client.url(s"http://localhost:$testServerPort/cookie-destination").get().map(res => res.body[String]), defaultTimeout)
+          res2 must beEqualTo(s"Request is missing required cookie 'flash'")
+        }
+      }
+
+      "switch to get " in {
+        "for HTTP 301 Moved Permanently" in {
+          withClientFollowingRedirect() { client =>
+            val request = client
+              .url(s"http://localhost:$testServerPort/redirect/301")
+              // 1. We are doing a POST to a URL that will redirect to a path
+              // That only accepts GETs
+              .post("request body")
+
+            val result = Await.result(request.map(res => res.body[String]), defaultTimeout)
+
+            // 2. So when following the redirect, the GET path should be found
+            // and we get its body
+            result must beEqualTo("Say hello to akka-http")
+          }
+        }
+
+        "for HTTP 303 See Other" in {
+          withClientFollowingRedirect() { client =>
+            val request = client
+              .url(s"http://localhost:$testServerPort/redirect/303")
+              .post("request body")
+            val result = Await.result(request.map(res => res.body[String]), defaultTimeout)
+            result must beEqualTo("Say hello to akka-http")
+          }
+        }
+
+        "for HTTP 302 Found and not strict handling" in {
+          withClientFollowingRedirect() { client =>
+            val request = client
+              .url(s"http://localhost:$testServerPort/redirect/302")
+              // 1. We are doing a POST to a URL that will redirect to a path
+              // That only accepts GETs
+              .post("request body")
+
+            val result = Await.result(request.map(res => res.body[String]), defaultTimeout)
+
+            // 2. So when following the redirect, the GET path should be found
+            // and we get its body
+            result must beEqualTo("Say hello to akka-http")
+          }
+        }
       }
     }
 

--- a/play-ahc-ws-standalone/src/main/resources/reference.conf
+++ b/play-ahc-ws-standalone/src/main/resources/reference.conf
@@ -28,6 +28,9 @@ play {
 
       # Whether to use LAX(no cookie name/value verification) or STRICT (verifies cookie name/value) cookie decoder
       useLaxCookieEncoder = false
+
+      # Whether to use a cookie store
+      useCookieStore = false
     }
   }
 }

--- a/play-ahc-ws-standalone/src/main/scala/play/api/libs/ws/ahc/AhcConfig.scala
+++ b/play-ahc-ws-standalone/src/main/scala/play/api/libs/ws/ahc/AhcConfig.scala
@@ -44,7 +44,8 @@ case class AhcWSClientConfig(
     maxRequestRetry: Int = 5,
     disableUrlEncoding: Boolean = false,
     keepAlive: Boolean = true,
-    useLaxCookieEncoder: Boolean = false)
+    useLaxCookieEncoder: Boolean = false,
+    useCookieStore: Boolean = false)
 
 /**
  * Factory for creating AhcWSClientConfig, for use from Java.
@@ -99,6 +100,7 @@ class AhcWSClientConfigParser @Inject() (
     val disableUrlEncoding = configuration.getBoolean("play.ws.ahc.disableUrlEncoding")
     val keepAlive = configuration.getBoolean("play.ws.ahc.keepAlive")
     val useLaxCookieEncoder = configuration.getBoolean("play.ws.ahc.useLaxCookieEncoder")
+    val useCookieStore = configuration.getBoolean("play.ws.ahc.useCookieStore")
 
     AhcWSClientConfig(
       wsClientConfig = wsClientConfig,
@@ -110,7 +112,8 @@ class AhcWSClientConfigParser @Inject() (
       maxRequestRetry = maxRequestRetry,
       disableUrlEncoding = disableUrlEncoding,
       keepAlive = keepAlive,
-      useLaxCookieEncoder = useLaxCookieEncoder
+      useLaxCookieEncoder = useLaxCookieEncoder,
+      useCookieStore = useCookieStore
     )
   }
 }
@@ -209,12 +212,9 @@ class AhcConfigBuilder(ahcConfig: AhcWSClientConfig = AhcWSClientConfig()) {
     builder.setShutdownTimeout(0)
     builder.setUseLaxCookieEncoder(ahcConfig.useLaxCookieEncoder)
 
-    // The WSRequest withCookies method suggests all cookies will be
-    // discarded. This is not the case if the underlying http client
-    // has a cookie store. Play ws also does not know about those
-    // cookies so for example the AhcCurlRequestLogger does not log
-    // these cookies.
-    builder.setCookieStore(null)
+    if (!ahcConfig.useCookieStore) {
+      builder.setCookieStore(null)
+    }
   }
 
   def configureProtocols(existingProtocols: Array[String], sslConfig: SSLConfigSettings): Array[String] = {

--- a/play-ws-standalone/src/main/java/play/libs/ws/StandaloneWSRequest.java
+++ b/play-ws-standalone/src/main/java/play/libs/ws/StandaloneWSRequest.java
@@ -229,7 +229,8 @@ public interface StandaloneWSRequest {
     StandaloneWSRequest addCookies(WSCookie... cookies);
 
     /**
-     * Set the request cookies. This discard the existing cookies.
+     * Set the request cookies. This discard the existing ones for this request, but when `play.ws.ahc.useCookieStore`
+     * is true, there is a cookie store that is global and keeps cookies between requests.
      *
      * @param cookies the cookies to be used.
      * @return the modified WSRequest.

--- a/play-ws-standalone/src/main/scala/play/api/libs/ws/StandaloneWSRequest.scala
+++ b/play-ws-standalone/src/main/scala/play/api/libs/ws/StandaloneWSRequest.scala
@@ -162,7 +162,8 @@ trait StandaloneWSRequest {
   }
 
   /**
-   * Returns this request with the given query string parameters, discarding the existing ones.
+   * Returns this request with the given query string parameters, discarding the existing ones for this request.
+   * But when `play.ws.ahc.useCookieStore` is true, there is a cookie store that is global and keeps cookies between requests.
    *
    * @param cookies the cookies to be used
    */

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -45,9 +45,9 @@ object Dependencies {
   val asyncHttpClientVersion = "2.6.0"
   val asyncHttpClient = Seq("org.asynchttpclient" % "async-http-client" % asyncHttpClientVersion)
 
-  val akkaVersion = "2.5.19"
+  val akkaVersion = "2.5.21"
   val akkaStreams = Seq("com.typesafe.akka" %% "akka-stream" % akkaVersion)
-  val akkaHttp = Seq("com.typesafe.akka" %% "akka-http" % "10.1.7")
+  val akkaHttp = Seq("com.typesafe.akka" %% "akka-http" % "10.1.8")
 
   val reactiveStreams = Seq("org.reactivestreams" % "reactive-streams" % "1.0.2")
 


### PR DESCRIPTION
## Purpose

This pull request is a follow up of the discussion in https://github.com/playframework/play-ws/pull/307 where cookie store was completely disabled.

## Background Context

I also considered to turn-off follow redirects and cookie store and handle the state for each request without relying on the underlying library, but this would require a more extensive change. In the end, I've decided to add a more comprehensive test suite here so that we can better refactor the code in the future if we choose to follow this option.

## Updates

Also updates Akka and Akka HTTP versions.