### PR TITLE
XML Readable : support any charset superior to utf-8

### DIFF
--- a/play-ws-standalone-xml/src/main/java/play/libs/ws/XMLBodyReadables.java
+++ b/play-ws-standalone-xml/src/main/java/play/libs/ws/XMLBodyReadables.java
@@ -5,6 +5,9 @@
 package play.libs.ws;
 
 import org.w3c.dom.Document;
+import org.xml.sax.InputSource;
+
+import java.io.ByteArrayInputStream;
 
 /**
  *
@@ -12,7 +15,7 @@ import org.w3c.dom.Document;
 public interface XMLBodyReadables {
 
     default BodyReadable<Document> xml() {
-        return response -> XML.fromString(response.getBody());
+        return response -> XML.fromInputSource(new InputSource(new ByteArrayInputStream(response.getBodyAsBytes().toArray())));
     }
 
 }

--- a/play-ws-standalone-xml/src/main/scala/play/api/libs/ws/XMLBodyReadables.scala
+++ b/play-ws-standalone-xml/src/main/scala/play/api/libs/ws/XMLBodyReadables.scala
@@ -4,6 +4,10 @@
 
 package play.api.libs.ws
 
+import java.io.ByteArrayInputStream
+
+import scala.xml.InputSource
+
 trait XMLBodyReadables {
 
   import scala.xml.Elem
@@ -15,7 +19,7 @@ trait XMLBodyReadables {
    * }}}
    */
   implicit val readableAsXml: BodyReadable[Elem] = BodyReadable { response =>
-    XML.parser.loadString(response.body)
+    xml.XML.load(new InputSource(new ByteArrayInputStream(response.bodyAsBytes.toArray)))
   }
 
 }


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [x] Have you signed the [Typesafe CLA](https://www.typesafe.com/contribute/cla)?
* [x] Have you [squashed your commits](https://www.playframework.com/documentation/latest/WorkingWithGit#Squashing-commits)?
* [x] Have you added copyright headers to new files?
* [x] Have you checked that both Scala and Java APIs are updated?
* [x] Have you updated the documentation for both Scala and Java sections?
* [x] Have you added tests for any changed functionality?

## Fixes

Fixes #328 

## Purpose

What does this PR do?

Supports any charset superior to utf-16 (if supported by java itself)

## Background Context

Why did you take this approach?

Look at Play.BodyParsers.tolerantXml

## References

Are there any relevant issues / PRs / mailing lists discussions?
#328 