### PR TITLE
fix compile error with Scala 2.13

### DIFF
--- a/play-ahc-ws-standalone/src/main/scala/play/api/libs/ws/ahc/AhcCurlRequestLogger.scala
+++ b/play-ahc-ws-standalone/src/main/scala/play/api/libs/ws/ahc/AhcCurlRequestLogger.scala
@@ -58,7 +58,7 @@ trait CurlFormat {
         val encodedPassword = Base64.getUrlEncoder.encodeToString(s"$userName:$password".getBytes(StandardCharsets.US_ASCII))
         b.append(s"""  --header 'Authorization: Basic ${quote(encodedPassword)}'""")
         b.append(" \\\n")
-      case _ => Unit
+      case _ =>
     }
 
     // headers


### PR DESCRIPTION

# Pull Request Checklist

* [x] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [x] Have you signed the [Typesafe CLA](https://www.typesafe.com/contribute/cla)?
* [x] Have you [squashed your commits](https://www.playframework.com/documentation/latest/WorkingWithGit#Squashing-commits)?
* [x] Have you added copyright headers to new files?
* [x] Have you checked that both Scala and Java APIs are updated?
* [x] Have you updated the documentation for both Scala and Java sections?
* [x] Have you added tests for any changed functionality?

## Fixes

Fixes compile error

## Purpose

remove `Unit` 

## Background Context

```
Welcome to Scala 2.13.0-RC1 (Java HotSpot(TM) 64-Bit Server VM, Java 1.8.0_192).
Type in expressions for evaluation. Or try :help.

scala> Unit
       ^
       error: `Unit` companion object is not allowed in source; instead, use `()` for the unit value
```


## References

Are there any relevant issues / PRs / mailing lists discussions?
