### PR TITLE
Document that uri throws.

### DIFF
--- a/play-ahc-ws-standalone/src/main/scala/play/api/libs/ws/ahc/StandaloneAhcWSRequest.scala
+++ b/play-ahc-ws-standalone/src/main/scala/play/api/libs/ws/ahc/StandaloneAhcWSRequest.scala
@@ -5,7 +5,7 @@
 package play.api.libs.ws.ahc
 
 import java.io.UnsupportedEncodingException
-import java.net.URI
+import java.net.{ URI, URISyntaxException }
 import java.nio.charset.{ Charset, StandardCharsets }
 
 import akka.stream.Materializer
@@ -51,6 +51,7 @@ case class StandaloneAhcWSRequest(
 
   override def contentType: Option[String] = this.headers.get(HttpHeaders.Names.CONTENT_TYPE).map(_.head)
 
+  @throws[URISyntaxException]("If the url is invalid.")
   override lazy val uri: URI = {
     val enc = (p: String) => java.net.URLEncoder.encode(p, "utf-8")
     new java.net.URI(if (queryString.isEmpty) url else {

--- a/play-ahc-ws-standalone/src/test/scala/play/api/libs/ws/ahc/AhcWSRequestSpec.scala
+++ b/play-ahc-ws-standalone/src/test/scala/play/api/libs/ws/ahc/AhcWSRequestSpec.scala
@@ -4,6 +4,8 @@
 
 package play.api.libs.ws.ahc
 
+import java.net.URISyntaxException
+
 import akka.actor.ActorSystem
 import akka.stream.ActorMaterializer
 import akka.util.ByteString
@@ -16,6 +18,7 @@ import play.api.libs.ws._
 import play.shaded.ahc.io.netty.handler.codec.http.HttpHeaderNames
 import play.shaded.ahc.org.asynchttpclient.Realm.AuthScheme
 import play.shaded.ahc.org.asynchttpclient.{ Param, SignatureCalculator, Request => AHCRequest }
+
 import scala.collection.JavaConverters._
 import scala.concurrent.duration._
 
@@ -105,6 +108,13 @@ class AhcWSRequestSpec extends Specification with Mockito with AfterAll with Def
       }
 
     }
+
+    "uri should not throw" in {
+      withClient { client =>
+        val req = client.url("https://github.com/playframework/play-ws/issues/267/?pipe=|")
+        req.uri must not(throwAn[URISyntaxException])
+      }
+    }.pendingUntilFixed("issue #267")
 
   }
 


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [x] Have you signed the [Typesafe CLA](https://www.typesafe.com/contribute/cla)?
* [x] Have you [squashed your commits](https://www.playframework.com/documentation/latest/WorkingWithGit#Squashing-commits)?
* [x] Have you added copyright headers to new files?
* [x] Have you checked that both Scala and Java APIs are updated?
* [x] Have you updated the documentation for both Scala and Java sections?
* [x] Have you added tests for any changed functionality?

## Fixes

Documents the surprising behavior of #267.

## Purpose

Documents that `lazy val uri: URI` throws.

## Background Context

@marcospereira suggested in https://github.com/playframework/play-ws/issues/267#issuecomment-419266583 that `def url(url: String): StandaloneWSRequest` should be tolerant of urls which include query params. I submit #288, but was not successful in getting it reviewed a second time and merged. URLs are hairy and I can understand why you may not trust the robustness of a community provided solution. #288 has been unmerged for about a year now, and marked `status: backlog` so I've closed it.

Instead, this PR just documents the current behavior, hopefully to prevent others from discovering it in prod as I did. I've also added a failing unit test.

## References

* #267 - original issue
* #288 - proposed solution