### PR TITLE
Fix mima and dependency to scala-java8-compat 0.9.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -65,14 +65,8 @@ def scalacOptionsFor(scalaBinVersion: String): Seq[String] = scalaBinVersion mat
 
 lazy val mimaSettings = mimaDefaultSettings ++ Seq(
   mimaPreviousArtifacts := {
-    val VersionPattern = """^(\d+).(\d+).(\d+)(-.*)?""".r
-    val previousVersions = version.value match {
-      case VersionPattern("2", "0", "5", _) if scalaBinaryVersion.value == "2.13" => Set.empty // added 2.13.0 support in 2.0.5-SNAPSHOT.
-      case VersionPattern(epoch, major, minor, _) => (0 until minor.toInt).map(v => s"$epoch.$major.$v")
-      case _ => sys.error(s"Cannot find previous versions for ${version.value}")
-    }
-
-    previousVersions.toSet.map(previousVersion => organization.value %% name.value % previousVersion)
+      if(scalaVersion.value.equals(scala213))  Set.empty //TODO enable when 2.0.7 is available Set(organization.value %% name.value % "2.0.7")
+      else  Set(organization.value %% name.value % "2.0.0")
   },
   mimaBinaryIssueFilters ++= Seq(
     ProblemFilters.exclude[MissingTypesProblem]("play.api.libs.ws.ahc.AhcWSClientConfig$"),

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -21,7 +21,7 @@ object Dependencies {
 
   val junitInterface = Seq("com.novocode" % "junit-interface" % "0.11")
 
-  val scalaJava8Compat = Seq("org.scala-lang.modules" %% "scala-java8-compat" % "0.8.0")
+  val scalaJava8Compat = Seq("org.scala-lang.modules" %% "scala-java8-compat" % "0.9.0")
 
   val playJsonVersion = "2.7.4"
   val playJson = Seq("com.typesafe.play" %% "play-json" % playJsonVersion)


### PR DESCRIPTION
For some unknown reason scala-java8-compat_2.13:0.8.0 is missing? Maybe previous release was using some other resolvers?

This fix simplifies the MiMa check and preapred for the ground for after 2.0.7 when we will be able to enable the check for 2.0.7.