### PR TITLE
Use a browsable URL for scm.url

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -84,7 +84,7 @@ lazy val commonSettings = Def.settings(
         </license>
       </licenses>
       <scm>
-        <url>git@github.com/playframework/play-ws.git</url>
+        <url>https://github.com/playframework/play-ws</url>
         <connection>scm:git:git@github.com/playframework/play-ws.git</connection>
       </scm>
       <developers>


### PR DESCRIPTION
This changes the scm.url to a browsable URL as recommended by the [POM Reference](https://maven.apache.org/pom.html#SCM). Scala Steward uses this URL to link to the updated dependency (as can be seen [here](https://github.com/mfirry/scala-http-clients/pull/76)) and a `git@` URL is not suitable for this purpose.



