### PR TITLE
Change travis to use latest JDK point version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ scala:
   - 2.13.1
 
 before_install: curl -Ls https://git.io/jabba | bash && . ~/.jabba/jabba.sh
-install: jabba install "adopt@~1.$TRAVIS_JDK.0-0" && jabba use "$_" && java -Xmx32m -version
+install: jabba install $(jabba ls-remote "adopt@~1.$TRAVIS_JDK.0-0" --latest=patch) && jabba use "$_" && java -Xmx32m -version
 
 script:
   - sbt ++$TRAVIS_SCALA_VERSION 'testOnly -- xonly timefactor 5' mimaReportBinaryIssues validateCode doc


### PR DESCRIPTION
Getting errors because the version Jabba asks for is too low:

```
Setting environment variables from .travis.yml

$ export JABBA_HOME=$HOME/.jabba

$ export TRAVIS_JDK=adopt@1.8.202-08

$ export JVM_OPTS=@/etc/sbt/jvmopts

$ export SBT_OPTS=@/etc/sbt/sbtopts
cache.1

Setting up build cache

$ java -Xmx32m -version

openjdk version "11.0.2" 2019-01-15

OpenJDK Runtime Environment 18.9 (build 11.0.2+9)

OpenJDK 64-Bit Server VM 18.9 (build 11.0.2+9, mixed mode)

$ javac -J-Xmx32m -version

javac 11.0.2

Using Scala 2.12.8
before_install

1.86s$ curl -sL https://github.com/shyiko/jabba/raw/master/install.sh | bash && . ~/.jabba/jabba.sh

0.21s$ $JABBA_HOME/bin/jabba install $TRAVIS_JDK

No compatible version found for adopt@1.8.202-08
```