### PR TITLE
JPMS Automatic-Module-Name for all jars published

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -5,6 +5,7 @@ import Dependencies._
 import com.typesafe.tools.mima.plugin.MimaPlugin.mimaDefaultSettings
 import com.typesafe.tools.mima.core.ProblemFilters
 import com.typesafe.tools.mima.core._
+import play.ws.AutomaticModuleName
 import sbtassembly.AssemblyPlugin.autoImport._
 import sbtassembly.MergeStrategy
 import org.scalafmt.sbt.ScalafmtPlugin
@@ -299,6 +300,7 @@ lazy val `play-ws-standalone` = project
   .settings(commonSettings)
   .settings(mimaSettings)
   .settings(libraryDependencies ++= standaloneApiWSDependencies)
+  .settings(AutomaticModuleName.settings("play.ws.standalone"))
   .disablePlugins(sbtassembly.AssemblyPlugin)
 
 //---------------------------------------------------------------
@@ -348,6 +350,7 @@ lazy val `play-ahc-ws-standalone` = project
     )
   )
   .settings(mimaSettings)
+  .settings(AutomaticModuleName.settings("play.ws.standalone.ahc"))
   .dependsOn(
     `play-ws-standalone`
   )
@@ -366,6 +369,7 @@ lazy val `play-ws-standalone-json` = project
     testOptions in Test := Seq(Tests.Argument(TestFrameworks.JUnit, "-a", "-v")),
     libraryDependencies ++= standaloneAhcWSJsonDependencies
   )
+  .settings(AutomaticModuleName.settings("play.ws.standalone.json"))
   .dependsOn(
     `play-ws-standalone`
   )
@@ -384,6 +388,7 @@ lazy val `play-ws-standalone-xml` = project
     testOptions in Test := Seq(Tests.Argument(TestFrameworks.JUnit, "-a", "-v")),
     libraryDependencies ++= standaloneAhcWSXMLDependencies
   )
+  .settings(AutomaticModuleName.settings("play.ws.standalone.xml"))
   .dependsOn(
     `play-ws-standalone`
   )

--- a/project/AutomaticModuleName.scala
+++ b/project/AutomaticModuleName.scala
@@ -1,0 +1,24 @@
+/*
+ * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ */
+package play.ws;
+
+import sbt.Def
+import sbt._
+import sbt.Keys._
+
+/**
+ * Helper to set Automatic-Module-Name in projects.
+ *
+ * !! DO NOT BE TEMPTED INTO AUTOMATICALLY DERIVING THE NAMES FROM PROJECT NAMES !!
+ *
+ * The names carry a lot of implications and DO NOT have to always align 1:1 with the group ids or package names,
+ * though there should be of course a strong relationship between them.
+ */
+object AutomaticModuleName {
+  private val AutomaticModuleName = "Automatic-Module-Name"
+
+  def settings(name: String): Seq[Def.Setting[Task[Seq[PackageOption]]]] = Seq(
+    packageOptions in (Compile, packageBin) += Package.ManifestAttributes(AutomaticModuleName -> name)
+  )
+}


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [x] Have you signed the [Typesafe CLA](https://www.typesafe.com/contribute/cla)?
* [x] Have you [squashed your commits](https://www.playframework.com/documentation/latest/WorkingWithGit#Squashing-commits)?
* [x] Have you added copyright headers to new files?
* [ ] Have you checked that both Scala and Java APIs are updated?
* [ ] Have you updated the documentation for both Scala and Java sections?
* [ ] Have you added tests for any changed functionality?

Trying to introduce Automatic-Module-Name, as per https://github.com/playframework/playframework/pull/10087

## Fixes

Fixes nothing, added support for Java 9 Modules but adding Automatic-Module-Name to the MANIFEST.MF file

## Purpose

Add Automatic-Module-Name to the MANIFEST.MF so for anyone wanting to start moving to Java 9+ can start moving.

## Background Context

Same approach as https://github.com/playframework/playframework/pull/10087

## References

Are there any relevant issues / PRs / mailing lists discussions?
