### PR TITLE
fix ssl-config url

### DIFF
--- a/play-ws-standalone/src/main/scala/play/api/libs/ws/WSClientConfig.scala
+++ b/play-ws-standalone/src/main/scala/play/api/libs/ws/WSClientConfig.scala
@@ -18,7 +18,7 @@ import scala.concurrent.duration._
  * @param useProxyProperties To use the JVM system’s HTTP proxy settings (http.proxyHost, http.proxyPort) (default is true).
  * @param userAgent  To configure the User-Agent header field (default is None).
  * @param compressionEnabled Set it to true to use gzip/deflater encoding (default is false).
- * @param ssl use custom SSL / TLS configuration, see https://typesafehub.github.io/ssl-config/ for documentation.
+ * @param ssl use custom SSL / TLS configuration, see https://lightbend.github.io/ssl-config/ for documentation.
  */
 case class WSClientConfig(
     connectionTimeout: Duration = 2.minutes,


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [x] Have you signed the [Typesafe CLA](https://www.typesafe.com/contribute/cla)?
* [x] Have you [squashed your commits](https://www.playframework.com/documentation/latest/WorkingWithGit#Squashing-commits)?
* [x] Have you added copyright headers to new files?
* [x] Have you checked that both Scala and Java APIs are updated?
* [x] Have you updated the documentation for both Scala and Java sections?
* [x] Have you added tests for any changed functionality?

## Fixes

N/A

## Purpose

Fixes the documentation links in scaladoc.

## Background Context

ssl-config repo moved to lightbend org from typesafehub.
https://github.com/lightbend/ssl-config/pull/65

## References
