### PR TITLE
Fix url encoding when it's disabled.

### DIFF
--- a/play-ahc-ws-standalone/src/main/scala/play/api/libs/ws/ahc/StandaloneAhcWSRequest.scala
+++ b/play-ahc-ws-standalone/src/main/scala/play/api/libs/ws/ahc/StandaloneAhcWSRequest.scala
@@ -57,18 +57,24 @@ case class StandaloneAhcWSRequest(
   override def contentType: Option[String] = this.headers.get(HttpHeaders.Names.CONTENT_TYPE).map(_.head)
 
   override lazy val uri: URI = {
-    val enc = (p: String) => java.net.URLEncoder.encode(p, "utf-8")
     new java.net.URI(
       if (queryString.isEmpty) url
       else {
         val qs = (for {
           (n, vs) <- queryString
           v       <- vs
-        } yield s"${enc(n)}=${enc(v)}").mkString("&")
+        } yield s"${encode(n)}=${encode(v)}").mkString("&")
         s"$url?$qs"
       }
     )
   }
+
+  private def encode(param: String): String =
+    if (this.disableUrlEncoding.getOrElse(false)) {
+      param
+    } else {
+      java.net.URLEncoder.encode(param, "utf-8")
+    }
 
   override def sign(calc: WSSignatureCalculator): Self = copy(calc = Some(calc))
 

--- a/play-ahc-ws-standalone/src/test/scala/play/api/libs/ws/ahc/AhcWSRequestSpec.scala
+++ b/play-ahc-ws-standalone/src/test/scala/play/api/libs/ws/ahc/AhcWSRequestSpec.scala
@@ -69,6 +69,12 @@ class AhcWSRequestSpec
       request.withQueryStringParameters("&" -> "=").uri.toString must equalTo("http://example.com?%26=%3D")
     }
 
+    "disable URL-encode with query string" in {
+      val request = StandaloneAhcWSRequest(client, "http://example.com", disableUrlEncoding = Option(true))
+
+      request.withQueryStringParameters("&" -> "=").uri.toString must equalTo("http://example.com?&==")
+    }
+
     "set all query string parameters" in {
       val request = StandaloneAhcWSRequest(client, "http://example.com")
 


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [x] Have you signed the [Typesafe CLA](https://www.typesafe.com/contribute/cla)?
* [x] Have you [squashed your commits](https://www.playframework.com/documentation/latest/WorkingWithGit#Squashing-commits)?
* [x] Have you added copyright headers to new files?
* [ ] Have you checked that both Scala and Java APIs are updated?
* [x] Have you updated the documentation for both Scala and Java sections?
* [x] Have you added tests for any changed functionality?

## Fixes

Fixes playframework/playframework#10473

## Purpose

Config `play.ws.ahc.disableUrlEncoding` not working, when `play.ws.ahc.disableUrlEncoding` set to true, the generated URL should be `http://example.com/endpoint?param=val1+val2`.

## Background Context

I search for `play.ws.ahc.disableUrlEncoding` key and figure out that only Scala API uses it.
My guess is that Java API wrap the Scala API and uses it.

## References

playframework/playframework#10473
