### PR TITLE
Make play.ws.ahc.disableUrlEncoding actually do something useful

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -72,7 +72,10 @@ lazy val mimaSettings = Seq(
     ProblemFilters.exclude[IncompatibleSignatureProblem]("play.api.libs.ws.ahc.AhcWSClientConfig.curried"),
     ProblemFilters.exclude[DirectMissingMethodProblem]("play.api.libs.ws.ahc.AhcWSClientConfig.apply"),
     ProblemFilters.exclude[DirectMissingMethodProblem]("play.api.libs.ws.ahc.AhcWSClientConfig.copy"),
-    ProblemFilters.exclude[DirectMissingMethodProblem]("play.api.libs.ws.ahc.AhcWSClientConfig.this")
+    ProblemFilters.exclude[DirectMissingMethodProblem]("play.api.libs.ws.ahc.AhcWSClientConfig.this"),
+    ProblemFilters.exclude[ReversedMissingMethodProblem]("play.libs.ws.StandaloneWSRequest.setDisableUrlEncoding"),
+    ProblemFilters.exclude[ReversedMissingMethodProblem]("play.libs.ws.StandaloneWSRequest.getDisableUrlEncoding"),
+    ProblemFilters.exclude[ReversedMissingMethodProblem]("play.api.libs.ws.StandaloneWSRequest.withDisableUrlEncoding")
   )
 )
 

--- a/integration-tests/src/test/java/play/libs/ws/ahc/JsonRequestTest.java
+++ b/integration-tests/src/test/java/play/libs/ws/ahc/JsonRequestTest.java
@@ -8,6 +8,7 @@ import static org.assertj.core.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import com.typesafe.config.ConfigFactory;
 import org.junit.Test;
 import play.libs.ws.*;
 import play.shaded.ahc.io.netty.handler.codec.http.HttpHeaderNames;
@@ -23,7 +24,8 @@ public class JsonRequestTest implements JsonBodyWritables {
     public void setJson() throws IOException {
         JsonNode node = DefaultObjectMapper.instance.readTree("{\"k1\":\"v2\"}");
 
-            StandaloneAhcWSClient client = mock(StandaloneAhcWSClient.class);
+        StandaloneAhcWSClient client = StandaloneAhcWSClient.create(
+                AhcWSClientConfigFactory.forConfig(ConfigFactory.load(), this.getClass().getClassLoader()), /*materializer*/ null);
         StandaloneAhcWSRequest ahcWSRequest = new StandaloneAhcWSRequest(client, "http://playframework.com/", null)
                 .setBody(body(node));
 

--- a/integration-tests/src/test/java/play/libs/ws/ahc/XMLRequestTest.java
+++ b/integration-tests/src/test/java/play/libs/ws/ahc/XMLRequestTest.java
@@ -6,14 +6,13 @@ package play.libs.ws.ahc;
 
 import static org.assertj.core.api.Assertions.*;
 
+import com.typesafe.config.ConfigFactory;
 import org.junit.Test;
 import org.w3c.dom.Document;
 import play.libs.ws.XML;
 import play.libs.ws.XMLBodyWritables;
 import play.shaded.ahc.io.netty.handler.codec.http.HttpHeaderNames;
 import play.shaded.ahc.org.asynchttpclient.Request;
-
-import static org.mockito.Mockito.mock;
 
 public class XMLRequestTest implements XMLBodyWritables {
 
@@ -25,7 +24,8 @@ public class XMLRequestTest implements XMLBodyWritables {
                   "<to>world</to>" +
                   "</note>");
 
-          StandaloneAhcWSClient client = mock(StandaloneAhcWSClient.class);
+          StandaloneAhcWSClient client = StandaloneAhcWSClient.create(
+                  AhcWSClientConfigFactory.forConfig(ConfigFactory.load(), this.getClass().getClassLoader()), /*materializer*/ null);
           StandaloneAhcWSRequest ahcWSRequest = new StandaloneAhcWSRequest(client, "http://playframework.com/", null)
                   .setBody(body(document));
 

--- a/integration-tests/src/test/scala/play/api/libs/ws/ahc/JsonRequestSpec.scala
+++ b/integration-tests/src/test/scala/play/api/libs/ws/ahc/JsonRequestSpec.scala
@@ -40,7 +40,7 @@ class JsonRequestSpec extends Specification with Mockito with AfterAll with Json
 
   "set a json node" in {
     val jsValue = Json.obj("k1" -> JsString("v1"))
-    val client  = mock[StandaloneAhcWSClient]
+    val client  = StandaloneAhcWSClient()
     val req = new StandaloneAhcWSRequest(client, "http://playframework.com/", null)
       .withBody(jsValue)
       .asInstanceOf[StandaloneAhcWSRequest]
@@ -55,7 +55,7 @@ class JsonRequestSpec extends Specification with Mockito with AfterAll with Json
 
     implicit val jsonReadable = body(objectMapper)
     val jsonNode              = objectMapper.readTree("""{"k1":"v1"}""")
-    val client                = mock[StandaloneAhcWSClient]
+    val client                = StandaloneAhcWSClient()
     val req = new StandaloneAhcWSRequest(client, "http://playframework.com/", null)
       .withBody(jsonNode)
       .asInstanceOf[StandaloneAhcWSRequest]

--- a/integration-tests/src/test/scala/play/api/libs/ws/ahc/XMLRequestSpec.scala
+++ b/integration-tests/src/test/scala/play/api/libs/ws/ahc/XMLRequestSpec.scala
@@ -54,7 +54,7 @@ class XMLRequestSpec extends Specification with Mockito with AfterAll with MustM
     import XMLBodyWritables._
 
     val xml    = XML.parser.loadString("<hello><test></test></hello>")
-    val client = mock[StandaloneAhcWSClient]
+    val client = StandaloneAhcWSClient()
     val req = new StandaloneAhcWSRequest(client, "http://playframework.com/", null)
       .withBody(xml)
       .asInstanceOf[StandaloneAhcWSRequest]

--- a/play-ahc-ws-standalone/src/main/java/play/libs/ws/ahc/StandaloneAhcWSRequest.java
+++ b/play-ahc-ws-standalone/src/main/java/play/libs/ws/ahc/StandaloneAhcWSRequest.java
@@ -20,6 +20,7 @@ import play.shaded.ahc.io.netty.handler.codec.http.HttpHeaderNames;
 import play.shaded.ahc.io.netty.handler.codec.http.HttpHeaders;
 import play.shaded.ahc.io.netty.handler.codec.http.cookie.Cookie;
 import play.shaded.ahc.io.netty.handler.codec.http.cookie.DefaultCookie;
+import play.shaded.ahc.org.asynchttpclient.AsyncHttpClient;
 import play.shaded.ahc.org.asynchttpclient.Realm;
 import play.shaded.ahc.org.asynchttpclient.Request;
 import play.shaded.ahc.org.asynchttpclient.RequestBuilder;
@@ -422,7 +423,12 @@ public class StandaloneAhcWSRequest implements StandaloneWSRequest {
         final HttpHeaders possiblyModifiedHeaders = new DefaultHttpHeaders(validate);
         this.headers.forEach(possiblyModifiedHeaders::add);
 
-        RequestBuilder builder = new RequestBuilder(method);
+        RequestBuilder builder = new RequestBuilder(method, disableUrlEncoding != null ?
+                    disableUrlEncoding :
+                    ((AsyncHttpClient) client
+                            .getUnderlying())
+                            .getConfig()
+                            .isDisableUrlEncodingForBoundRequests());
 
         builder.setUrl(url);
         builder.setQueryParams(queryParameters);

--- a/play-ahc-ws-standalone/src/main/java/play/libs/ws/ahc/StandaloneAhcWSRequest.java
+++ b/play-ahc-ws-standalone/src/main/java/play/libs/ws/ahc/StandaloneAhcWSRequest.java
@@ -72,6 +72,7 @@ public class StandaloneAhcWSRequest implements StandaloneWSRequest {
 
     private Duration timeout = Duration.ZERO;
     private Boolean followRedirects = null;
+    private Boolean disableUrlEncoding = null;
     private String virtualHost = null;
 
     private final List<WSRequestFilter> filters = new ArrayList<>();
@@ -216,6 +217,12 @@ public class StandaloneAhcWSRequest implements StandaloneWSRequest {
     }
 
     @Override
+    public StandaloneAhcWSRequest setDisableUrlEncoding(boolean disableUrlEncoding) {
+        this.disableUrlEncoding = disableUrlEncoding;
+        return this;
+    }
+
+    @Override
     public StandaloneAhcWSRequest setVirtualHost(String virtualHost) {
         this.virtualHost = virtualHost;
         return this;
@@ -329,6 +336,11 @@ public class StandaloneAhcWSRequest implements StandaloneWSRequest {
     @Override
     public Optional<Boolean> getFollowRedirects() {
         return Optional.ofNullable(this.followRedirects);
+    }
+
+    @Override
+    public Optional<Boolean> getDisableUrlEncoding() {
+        return Optional.ofNullable(this.disableUrlEncoding);
     }
 
     // Intentionally package public.

--- a/play-ahc-ws-standalone/src/main/scala/play/api/libs/ws/ahc/StandaloneAhcWSRequest.scala
+++ b/play-ahc-ws-standalone/src/main/scala/play/api/libs/ws/ahc/StandaloneAhcWSRequest.scala
@@ -279,7 +279,7 @@ case class StandaloneAhcWSRequest(
         new RequestBuilder(method, disableEncodingFlag)
       }
       .getOrElse {
-        new RequestBuilder(method)
+        new RequestBuilder(method, client.underlying[AsyncHttpClient].getConfig.isDisableUrlEncodingForBoundRequests)
       }
 
     // Set the URL.

--- a/play-ahc-ws-standalone/src/main/scala/play/api/libs/ws/ahc/StandaloneAhcWSRequest.scala
+++ b/play-ahc-ws-standalone/src/main/scala/play/api/libs/ws/ahc/StandaloneAhcWSRequest.scala
@@ -124,6 +124,9 @@ case class StandaloneAhcWSRequest(
 
   override def withFollowRedirects(follow: Boolean): Self = copy(followRedirects = Some(follow))
 
+  override def withDisableUrlEncoding(disableUrlEncoding: Boolean): Self =
+    copy(disableUrlEncoding = Some(disableUrlEncoding))
+
   override def withRequestTimeout(timeout: Duration): Self = {
     timeout match {
       case Duration.Inf =>

--- a/play-ahc-ws-standalone/src/test/scala/play/api/libs/ws/ahc/AhcWSRequestSpec.scala
+++ b/play-ahc-ws-standalone/src/test/scala/play/api/libs/ws/ahc/AhcWSRequestSpec.scala
@@ -560,6 +560,35 @@ class AhcWSRequestSpec
       req.getFollowRedirect must beEqualTo(true)
     }
 
+    "enable url encoding by default" in withClient { client =>
+      val req: AHCRequest = client
+        .url("http://playframework.com/")
+        .addQueryStringParameters("abc+def" -> "uvw+xyz")
+        .asInstanceOf[StandaloneAhcWSRequest]
+        .buildRequest()
+      req.getUrl must beEqualTo("http://playframework.com/?abc%2Bdef=uvw%2Bxyz")
+    }
+
+    "disable url encoding globally via client config" in {
+      val client = StandaloneAhcWSClient(AhcWSClientConfigFactory.forConfig().copy(disableUrlEncoding = true))
+      val req: AHCRequest = client
+        .url("http://playframework.com/")
+        .addQueryStringParameters("abc+def" -> "uvw+xyz")
+        .asInstanceOf[StandaloneAhcWSRequest]
+        .buildRequest()
+      req.getUrl must beEqualTo("http://playframework.com/?abc+def=uvw+xyz")
+    }
+
+    "disable url encoding for specific request only" in withClient { client =>
+      val req: AHCRequest = client
+        .url("http://playframework.com/")
+        .addQueryStringParameters("abc+def" -> "uvw+xyz")
+        .withDisableUrlEncoding(disableUrlEncoding = true)
+        .asInstanceOf[StandaloneAhcWSRequest]
+        .buildRequest()
+      req.getUrl must beEqualTo("http://playframework.com/?abc+def=uvw+xyz")
+    }
+
     "finite timeout" in withClient { client =>
       val req: AHCRequest = client
         .url("http://playframework.com/")

--- a/play-ahc-ws-standalone/src/test/scala/play/libs/ws/ahc/AhcWSRequestSpec.scala
+++ b/play-ahc-ws-standalone/src/test/scala/play/libs/ws/ahc/AhcWSRequestSpec.scala
@@ -27,14 +27,18 @@ class AhcWSRequestSpec extends Specification with Mockito with DefaultBodyReadab
   "AhcWSRequest" should {
 
     "Have GET method as the default" in {
-      val client  = mock[StandaloneAhcWSClient]
+      val client = StandaloneAhcWSClient.create(
+        AhcWSClientConfigFactory.forConfig(ConfigFactory.load(), this.getClass.getClassLoader), /*materializer*/ null
+      )
       val request = new StandaloneAhcWSRequest(client, "http://example.com", /*materializer*/ null)
       request.getMethod must be_==("GET")
       request.buildRequest().getMethod must be_==("GET")
     }
 
     "Set virtualHost appropriately" in {
-      val client  = mock[StandaloneAhcWSClient]
+      val client = StandaloneAhcWSClient.create(
+        AhcWSClientConfigFactory.forConfig(ConfigFactory.load(), this.getClass.getClassLoader), /*materializer*/ null
+      )
       val request = new StandaloneAhcWSRequest(client, "http://example.com", /*materializer*/ null)
       request.setVirtualHost("foo.com")
       val actual = request.buildRequest().getVirtualHost()
@@ -42,8 +46,10 @@ class AhcWSRequestSpec extends Specification with Mockito with DefaultBodyReadab
     }
 
     "set the url" in {
-      val client = mock[StandaloneAhcWSClient]
-      val req    = new StandaloneAhcWSRequest(client, "http://playframework.com/", null)
+      val client = StandaloneAhcWSClient.create(
+        AhcWSClientConfigFactory.forConfig(ConfigFactory.load(), this.getClass.getClassLoader), /*materializer*/ null
+      )
+      val req = new StandaloneAhcWSRequest(client, "http://playframework.com/", null)
       (req.getUrl must be_===("http://playframework.com/")).and {
         val setReq = req.setUrl("http://example.com")
         (setReq.getUrl must be_===("http://example.com")).and {
@@ -55,7 +61,9 @@ class AhcWSRequestSpec extends Specification with Mockito with DefaultBodyReadab
     "For POST requests" in {
 
       "get method" in {
-        val client = mock[StandaloneAhcWSClient]
+        val client = StandaloneAhcWSClient.create(
+          AhcWSClientConfigFactory.forConfig(ConfigFactory.load(), this.getClass.getClassLoader), /*materializer*/ null
+        )
         val req = new StandaloneAhcWSRequest(client, "http://playframework.com/", null)
           .setMethod("POST")
 
@@ -63,7 +71,9 @@ class AhcWSRequestSpec extends Specification with Mockito with DefaultBodyReadab
       }
 
       "set text/plain content-types for text bodies" in {
-        val client = mock[StandaloneAhcWSClient]
+        val client = StandaloneAhcWSClient.create(
+          AhcWSClientConfigFactory.forConfig(ConfigFactory.load(), this.getClass.getClassLoader), /*materializer*/ null
+        )
         val req = new StandaloneAhcWSRequest(client, "http://playframework.com/", null)
           .setBody(body("HELLO WORLD"))
           .asInstanceOf[StandaloneAhcWSRequest]
@@ -72,7 +82,9 @@ class AhcWSRequestSpec extends Specification with Mockito with DefaultBodyReadab
       }
 
       "sets content type based on a body when its not explicitly set" in {
-        val client = mock[StandaloneAhcWSClient]
+        val client = StandaloneAhcWSClient.create(
+          AhcWSClientConfigFactory.forConfig(ConfigFactory.load(), this.getClass.getClassLoader), /*materializer*/ null
+        )
         val req = new StandaloneAhcWSRequest(client, "http://playframework.com/", null)
           .setBody(body("HELLO WORLD")) // set body with a content type
           .asInstanceOf[StandaloneAhcWSRequest]
@@ -83,7 +95,9 @@ class AhcWSRequestSpec extends Specification with Mockito with DefaultBodyReadab
       }
 
       "keep existing content type when setting body" in {
-        val client = mock[StandaloneAhcWSClient]
+        val client = StandaloneAhcWSClient.create(
+          AhcWSClientConfigFactory.forConfig(ConfigFactory.load(), this.getClass.getClassLoader), /*materializer*/ null
+        )
         val req = new StandaloneAhcWSRequest(client, "http://playframework.com/", null)
           .setContentType("text/plain+hello") // set content type by hand
           .setBody(body("HELLO WORLD"))       // and body is set to string (see #5221)
@@ -100,7 +114,9 @@ class AhcWSRequestSpec extends Specification with Mockito with DefaultBodyReadab
 
       "have form params when passing in map" in {
         import scala.collection.JavaConverters._
-        val client = mock[StandaloneAhcWSClient]
+        val client = StandaloneAhcWSClient.create(
+          AhcWSClientConfigFactory.forConfig(ConfigFactory.load(), this.getClass.getClassLoader), /*materializer*/ null
+        )
         val req = new StandaloneAhcWSRequest(client, "http://playframework.com/", null)
           .setBody(body(Collections.singletonMap("param1", "value1")))
           .asInstanceOf[StandaloneAhcWSRequest]
@@ -117,7 +133,9 @@ class AhcWSRequestSpec extends Specification with Mockito with DefaultBodyReadab
 
       "have form params when content-type application/x-www-form-urlencoded and signed" in {
         import scala.collection.JavaConverters._
-        val client      = mock[StandaloneAhcWSClient]
+        val client = StandaloneAhcWSClient.create(
+          AhcWSClientConfigFactory.forConfig(ConfigFactory.load(), this.getClass.getClassLoader), /*materializer*/ null
+        )
         val consumerKey = new OAuth.ConsumerKey("key", "secret")
         val token       = new OAuth.RequestToken("token", "secret")
         val calc        = new OAuth.OAuthCalculator(consumerKey, token)
@@ -135,7 +153,9 @@ class AhcWSRequestSpec extends Specification with Mockito with DefaultBodyReadab
 
       "remove a user defined content length header if we are parsing body explicitly when signed" in {
         import scala.collection.JavaConverters._
-        val client      = mock[StandaloneAhcWSClient]
+        val client = StandaloneAhcWSClient.create(
+          AhcWSClientConfigFactory.forConfig(ConfigFactory.load(), this.getClass.getClassLoader), /*materializer*/ null
+        )
         val consumerKey = new OAuth.ConsumerKey("key", "secret")
         val token       = new OAuth.RequestToken("token", "secret")
         val calc        = new OAuth.OAuthCalculator(consumerKey, token)
@@ -157,7 +177,9 @@ class AhcWSRequestSpec extends Specification with Mockito with DefaultBodyReadab
     }
 
     "Use a custom signature calculator" in {
-      val client = mock[StandaloneAhcWSClient]
+      val client = StandaloneAhcWSClient.create(
+        AhcWSClientConfigFactory.forConfig(ConfigFactory.load(), this.getClass.getClassLoader), /*materializer*/ null
+      )
       var called = false
       val calc = new SignatureCalculator with WSSignatureCalculator {
         override def calculateAndAddSignature(request: Request, requestBuilder: RequestBuilderBase[_]): Unit = {
@@ -197,7 +219,9 @@ class AhcWSRequestSpec extends Specification with Mockito with DefaultBodyReadab
     }
 
     "allow adding an explicit Content-Type header if the BodyWritable doesn't set the Content-Type" in {
-      val client  = mock[StandaloneAhcWSClient]
+      val client = StandaloneAhcWSClient.create(
+        AhcWSClientConfigFactory.forConfig(ConfigFactory.load(), this.getClass.getClassLoader), /*materializer*/ null
+      )
       val request = new StandaloneAhcWSRequest(client, "http://example.com", /*materializer*/ null)
       request.setBody(body("HELLO WORLD", null))            // content type is not set
       request.addHeader("Content-Type", "application/json") // will be used as content type is not set with a body
@@ -206,7 +230,9 @@ class AhcWSRequestSpec extends Specification with Mockito with DefaultBodyReadab
     }
 
     "ignore explicit Content-Type header if the BodyWritable already set the Content-Type" in {
-      val client  = mock[StandaloneAhcWSClient]
+      val client = StandaloneAhcWSClient.create(
+        AhcWSClientConfigFactory.forConfig(ConfigFactory.load(), this.getClass.getClassLoader), /*materializer*/ null
+      )
       val request = new StandaloneAhcWSRequest(client, "http://example.com", /*materializer*/ null)
       request.setBody(body("HELLO WORLD"))
       request.addHeader("Content-Type", "application/json") // will be ignored since body already sets content type
@@ -215,7 +241,9 @@ class AhcWSRequestSpec extends Specification with Mockito with DefaultBodyReadab
     }
 
     "only send first Content-Type header and keep the charset when setting the Content-Type multiple times" in {
-      val client  = mock[StandaloneAhcWSClient]
+      val client = StandaloneAhcWSClient.create(
+        AhcWSClientConfigFactory.forConfig(ConfigFactory.load(), this.getClass.getClassLoader), /*materializer*/ null
+      )
       val request = new StandaloneAhcWSRequest(client, "http://example.com", /*materializer*/ null)
       request.addHeader("Content-Type", "application/json; charset=US-ASCII")
       request.addHeader("Content-Type", "application/xml")
@@ -225,7 +253,9 @@ class AhcWSRequestSpec extends Specification with Mockito with DefaultBodyReadab
     }
 
     "Set Realm.UsePreemptiveAuth to false when WSAuthScheme.DIGEST being used" in {
-      val client  = mock[StandaloneAhcWSClient]
+      val client = StandaloneAhcWSClient.create(
+        AhcWSClientConfigFactory.forConfig(ConfigFactory.load(), this.getClass.getClassLoader), /*materializer*/ null
+      )
       val request = new StandaloneAhcWSRequest(client, "http://example.com", /*materializer*/ null)
       request.setAuth("usr", "pwd", WSAuthScheme.DIGEST)
       val req = request.buildRequest()
@@ -233,7 +263,9 @@ class AhcWSRequestSpec extends Specification with Mockito with DefaultBodyReadab
     }
 
     "Set Realm.UsePreemptiveAuth to true when WSAuthScheme.DIGEST not being used" in {
-      val client  = mock[StandaloneAhcWSClient]
+      val client = StandaloneAhcWSClient.create(
+        AhcWSClientConfigFactory.forConfig(ConfigFactory.load(), this.getClass.getClassLoader), /*materializer*/ null
+      )
       val request = new StandaloneAhcWSRequest(client, "http://example.com", /*materializer*/ null)
       request.setAuth("usr", "pwd", WSAuthScheme.BASIC)
       val req = request.buildRequest()
@@ -243,7 +275,9 @@ class AhcWSRequestSpec extends Specification with Mockito with DefaultBodyReadab
     "For HTTP Headers" in {
 
       "add a new header" in {
-        val client  = mock[StandaloneAhcWSClient]
+        val client = StandaloneAhcWSClient.create(
+          AhcWSClientConfigFactory.forConfig(ConfigFactory.load(), this.getClass.getClassLoader), /*materializer*/ null
+        )
         val request = new StandaloneAhcWSRequest(client, "http://example.com", /*materializer*/ null)
 
         request
@@ -254,7 +288,9 @@ class AhcWSRequestSpec extends Specification with Mockito with DefaultBodyReadab
       }
 
       "add new value for existing header" in {
-        val client = mock[StandaloneAhcWSClient]
+        val client = StandaloneAhcWSClient.create(
+          AhcWSClientConfigFactory.forConfig(ConfigFactory.load(), this.getClass.getClassLoader), /*materializer*/ null
+        )
         val request = new StandaloneAhcWSRequest(client, "http://example.com", /*materializer*/ null)
           .addHeader("header1", "value1")
           .addHeader("header1", "value2")
@@ -269,7 +305,9 @@ class AhcWSRequestSpec extends Specification with Mockito with DefaultBodyReadab
       }
 
       "set all headers" in {
-        val client  = mock[StandaloneAhcWSClient]
+        val client = StandaloneAhcWSClient.create(
+          AhcWSClientConfigFactory.forConfig(ConfigFactory.load(), this.getClass.getClassLoader), /*materializer*/ null
+        )
         val request = new StandaloneAhcWSRequest(client, "http://example.com", /*materializer*/ null)
 
         request
@@ -280,7 +318,9 @@ class AhcWSRequestSpec extends Specification with Mockito with DefaultBodyReadab
       }
 
       "keep existing headers when adding a new one" in {
-        val client  = mock[StandaloneAhcWSClient]
+        val client = StandaloneAhcWSClient.create(
+          AhcWSClientConfigFactory.forConfig(ConfigFactory.load(), this.getClass.getClassLoader), /*materializer*/ null
+        )
         val request = new StandaloneAhcWSRequest(client, "http://example.com", /*materializer*/ null)
 
         val ahcReq = request
@@ -293,7 +333,9 @@ class AhcWSRequestSpec extends Specification with Mockito with DefaultBodyReadab
       }
 
       "treat header names case insensitively" in {
-        val client = mock[StandaloneAhcWSClient]
+        val client = StandaloneAhcWSClient.create(
+          AhcWSClientConfigFactory.forConfig(ConfigFactory.load(), this.getClass.getClassLoader), /*materializer*/ null
+        )
         val request = new StandaloneAhcWSRequest(client, "http://example.com", /*materializer*/ null)
           .addHeader("header1", "value1")
           .addHeader("HEADER1", "value2")
@@ -304,7 +346,9 @@ class AhcWSRequestSpec extends Specification with Mockito with DefaultBodyReadab
       }
 
       "get a single header" in {
-        val client = mock[StandaloneAhcWSClient]
+        val client = StandaloneAhcWSClient.create(
+          AhcWSClientConfigFactory.forConfig(ConfigFactory.load(), this.getClass.getClassLoader), /*materializer*/ null
+        )
         val request = new StandaloneAhcWSRequest(client, "http://example.com", /*materializer*/ null)
           .addHeader("header1", "value1")
           .addHeader("header1", "value2")
@@ -313,7 +357,9 @@ class AhcWSRequestSpec extends Specification with Mockito with DefaultBodyReadab
       }
 
       "get an empty optional when header is not present" in {
-        val client = mock[StandaloneAhcWSClient]
+        val client = StandaloneAhcWSClient.create(
+          AhcWSClientConfigFactory.forConfig(ConfigFactory.load(), this.getClass.getClassLoader), /*materializer*/ null
+        )
         val request = new StandaloneAhcWSRequest(client, "http://example.com", /*materializer*/ null)
           .addHeader("header1", "value1")
           .addHeader("header1", "value2")
@@ -322,7 +368,9 @@ class AhcWSRequestSpec extends Specification with Mockito with DefaultBodyReadab
       }
 
       "get all values for a header" in {
-        val client = mock[StandaloneAhcWSClient]
+        val client = StandaloneAhcWSClient.create(
+          AhcWSClientConfigFactory.forConfig(ConfigFactory.load(), this.getClass.getClassLoader), /*materializer*/ null
+        )
         val request = new StandaloneAhcWSRequest(client, "http://example.com", /*materializer*/ null)
           .addHeader("header1", "value1")
           .addHeader("header1", "value2")
@@ -331,7 +379,9 @@ class AhcWSRequestSpec extends Specification with Mockito with DefaultBodyReadab
       }
 
       "get an empty list when header is not present" in {
-        val client = mock[StandaloneAhcWSClient]
+        val client = StandaloneAhcWSClient.create(
+          AhcWSClientConfigFactory.forConfig(ConfigFactory.load(), this.getClass.getClassLoader), /*materializer*/ null
+        )
         val request = new StandaloneAhcWSRequest(client, "http://example.com", /*materializer*/ null)
           .addHeader("header1", "value1")
           .addHeader("header1", "value2")
@@ -340,7 +390,9 @@ class AhcWSRequestSpec extends Specification with Mockito with DefaultBodyReadab
       }
 
       "get all headers" in {
-        val client = mock[StandaloneAhcWSClient]
+        val client = StandaloneAhcWSClient.create(
+          AhcWSClientConfigFactory.forConfig(ConfigFactory.load(), this.getClass.getClassLoader), /*materializer*/ null
+        )
         val request = new StandaloneAhcWSRequest(client, "http://example.com", /*materializer*/ null)
           .addHeader("header1", "Value1ForHeader1")
           .addHeader("header1", "Value2ForHeader1")
@@ -356,7 +408,9 @@ class AhcWSRequestSpec extends Specification with Mockito with DefaultBodyReadab
     "For query string parameters" in {
 
       "add query string parameter" in {
-        val client = mock[StandaloneAhcWSClient]
+        val client = StandaloneAhcWSClient.create(
+          AhcWSClientConfigFactory.forConfig(ConfigFactory.load(), this.getClass.getClassLoader), /*materializer*/ null
+        )
         val request = new StandaloneAhcWSRequest(client, "http://example.com", /*materializer*/ null)
           .addQueryParameter("p1", "v1")
           .buildRequest()
@@ -365,7 +419,9 @@ class AhcWSRequestSpec extends Specification with Mockito with DefaultBodyReadab
       }
 
       "deterministic query param order a" in {
-        val client = mock[StandaloneAhcWSClient]
+        val client = StandaloneAhcWSClient.create(
+          AhcWSClientConfigFactory.forConfig(ConfigFactory.load(), this.getClass.getClassLoader), /*materializer*/ null
+        )
         val request = new StandaloneAhcWSRequest(client, "http://example.com", /*materializer*/ null)
           .addQueryParameter("p1", "v1")
           .addQueryParameter("p2", "v2")
@@ -375,7 +431,9 @@ class AhcWSRequestSpec extends Specification with Mockito with DefaultBodyReadab
       }
 
       "deterministic query param order b" in {
-        val client = mock[StandaloneAhcWSClient]
+        val client = StandaloneAhcWSClient.create(
+          AhcWSClientConfigFactory.forConfig(ConfigFactory.load(), this.getClass.getClassLoader), /*materializer*/ null
+        )
         val request = new StandaloneAhcWSRequest(client, "http://example.com", /*materializer*/ null)
           .addQueryParameter("p2", "v2")
           .addQueryParameter("p1", "v1")
@@ -385,7 +443,9 @@ class AhcWSRequestSpec extends Specification with Mockito with DefaultBodyReadab
       }
 
       "deterministic query param order for duplicate keys" in {
-        val client = mock[StandaloneAhcWSClient]
+        val client = StandaloneAhcWSClient.create(
+          AhcWSClientConfigFactory.forConfig(ConfigFactory.load(), this.getClass.getClassLoader), /*materializer*/ null
+        )
         val request = new StandaloneAhcWSRequest(client, "http://example.com", /*materializer*/ null)
           .addQueryParameter("p1", "v1")
           .addQueryParameter("p2", "v2")
@@ -397,7 +457,9 @@ class AhcWSRequestSpec extends Specification with Mockito with DefaultBodyReadab
       }
 
       "add new value for existing parameter" in {
-        val client = mock[StandaloneAhcWSClient]
+        val client = StandaloneAhcWSClient.create(
+          AhcWSClientConfigFactory.forConfig(ConfigFactory.load(), this.getClass.getClassLoader), /*materializer*/ null
+        )
         val request = new StandaloneAhcWSRequest(client, "http://example.com", /*materializer*/ null)
           .addQueryParameter("p1", "v1")
           .addQueryParameter("p1", "v2")
@@ -408,7 +470,9 @@ class AhcWSRequestSpec extends Specification with Mockito with DefaultBodyReadab
       }
 
       "keep existing parameters when adding a new one" in {
-        val client = mock[StandaloneAhcWSClient]
+        val client = StandaloneAhcWSClient.create(
+          AhcWSClientConfigFactory.forConfig(ConfigFactory.load(), this.getClass.getClassLoader), /*materializer*/ null
+        )
         val request = new StandaloneAhcWSRequest(client, "http://example.com", /*materializer*/ null)
           .addQueryParameter("p1", "v1")
           .addQueryParameter("p2", "v2")
@@ -419,7 +483,9 @@ class AhcWSRequestSpec extends Specification with Mockito with DefaultBodyReadab
       }
 
       "set all the parameters" in {
-        val client = mock[StandaloneAhcWSClient]
+        val client = StandaloneAhcWSClient.create(
+          AhcWSClientConfigFactory.forConfig(ConfigFactory.load(), this.getClass.getClassLoader), /*materializer*/ null
+        )
         val request = new StandaloneAhcWSRequest(client, "http://example.com", /*materializer*/ null)
           .setQueryString(Map("p1" -> Seq("v1").asJava, "p2" -> Seq("v2").asJava).asJava)
           .buildRequest()
@@ -457,7 +523,9 @@ class AhcWSRequestSpec extends Specification with Mockito with DefaultBodyReadab
 
       "support a query string parameter with an encoded equals sign" in {
         import scala.collection.JavaConverters._
-        val client      = mock[StandaloneAhcWSClient]
+        val client = StandaloneAhcWSClient.create(
+          AhcWSClientConfigFactory.forConfig(ConfigFactory.load(), this.getClass.getClassLoader), /*materializer*/ null
+        )
         val request     = new StandaloneAhcWSRequest(client, "http://example.com?bar=F%3Dma", /*materializer*/ null)
         val queryParams = request.buildRequest().getQueryParams.asScala
         val p           = queryParams(0)
@@ -514,7 +582,9 @@ class AhcWSRequestSpec extends Specification with Mockito with DefaultBodyReadab
       }
 
       "get existing cookies" in {
-        val client = mock[StandaloneAhcWSClient]
+        val client = StandaloneAhcWSClient.create(
+          AhcWSClientConfigFactory.forConfig(ConfigFactory.load(), this.getClass.getClassLoader), /*materializer*/ null
+        )
         val request = new StandaloneAhcWSRequest(client, "http://example.com", /*materializer*/ null)
           .addCookie(cookie("cookie1", "value1"))
 
@@ -526,7 +596,9 @@ class AhcWSRequestSpec extends Specification with Mockito with DefaultBodyReadab
       }
 
       "add a new cookie" in {
-        val client = mock[StandaloneAhcWSClient]
+        val client = StandaloneAhcWSClient.create(
+          AhcWSClientConfigFactory.forConfig(ConfigFactory.load(), this.getClass.getClassLoader), /*materializer*/ null
+        )
         val request = new StandaloneAhcWSRequest(client, "http://example.com", /*materializer*/ null)
           .addCookie(cookie("cookie1", "value1"))
           .buildRequest()
@@ -535,7 +607,9 @@ class AhcWSRequestSpec extends Specification with Mockito with DefaultBodyReadab
       }
 
       "add more than one cookie" in {
-        val client = mock[StandaloneAhcWSClient]
+        val client = StandaloneAhcWSClient.create(
+          AhcWSClientConfigFactory.forConfig(ConfigFactory.load(), this.getClass.getClassLoader), /*materializer*/ null
+        )
         val request = new StandaloneAhcWSRequest(client, "http://example.com", /*materializer*/ null)
           .addCookies(cookie("cookie1", "value1"), cookie("cookie2", "value2"))
           .buildRequest()
@@ -546,7 +620,9 @@ class AhcWSRequestSpec extends Specification with Mockito with DefaultBodyReadab
       }
 
       "keep existing cookies when adding a new one" in {
-        val client = mock[StandaloneAhcWSClient]
+        val client = StandaloneAhcWSClient.create(
+          AhcWSClientConfigFactory.forConfig(ConfigFactory.load(), this.getClass.getClassLoader), /*materializer*/ null
+        )
         val request = new StandaloneAhcWSRequest(client, "http://example.com", /*materializer*/ null)
           .addCookie(cookie("cookie1", "value1"))
           .addCookie(cookie("cookie2", "value2"))
@@ -558,7 +634,9 @@ class AhcWSRequestSpec extends Specification with Mockito with DefaultBodyReadab
       }
 
       "set all cookies" in {
-        val client = mock[StandaloneAhcWSClient]
+        val client = StandaloneAhcWSClient.create(
+          AhcWSClientConfigFactory.forConfig(ConfigFactory.load(), this.getClass.getClassLoader), /*materializer*/ null
+        )
         val request = new StandaloneAhcWSRequest(client, "http://example.com", /*materializer*/ null)
           .setCookies(List(cookie("cookie1", "value1"), cookie("cookie2", "value2")).asJava)
           .buildRequest()
@@ -569,7 +647,9 @@ class AhcWSRequestSpec extends Specification with Mockito with DefaultBodyReadab
       }
 
       "discard old cookies when setting" in {
-        val client = mock[StandaloneAhcWSClient]
+        val client = StandaloneAhcWSClient.create(
+          AhcWSClientConfigFactory.forConfig(ConfigFactory.load(), this.getClass.getClassLoader), /*materializer*/ null
+        )
         val request = new StandaloneAhcWSRequest(client, "http://example.com", /*materializer*/ null)
           .addCookies(cookie("cookie1", "value1"), cookie("cookie2", "value2"))
           .setCookies(List(cookie("cookie3", "value1"), cookie("cookie4", "value2")).asJava)
@@ -583,7 +663,9 @@ class AhcWSRequestSpec extends Specification with Mockito with DefaultBodyReadab
   }
 
   def requestWithTimeout(timeout: Duration) = {
-    val client  = mock[StandaloneAhcWSClient]
+    val client = StandaloneAhcWSClient.create(
+      AhcWSClientConfigFactory.forConfig(ConfigFactory.load(), this.getClass.getClassLoader), /*materializer*/ null
+    )
     val request = new StandaloneAhcWSRequest(client, "http://example.com", /*materializer*/ null)
     request.setRequestTimeout(timeout)
     request.buildRequest().getRequestTimeout()
@@ -591,7 +673,9 @@ class AhcWSRequestSpec extends Specification with Mockito with DefaultBodyReadab
 
   def requestWithQueryString(query: String) = {
     import scala.collection.JavaConverters._
-    val client  = mock[StandaloneAhcWSClient]
+    val client = StandaloneAhcWSClient.create(
+      AhcWSClientConfigFactory.forConfig(ConfigFactory.load(), this.getClass.getClassLoader), /*materializer*/ null
+    )
     val request = new StandaloneAhcWSRequest(client, "http://example.com", /*materializer*/ null)
     request.setQueryString(query)
     val queryParams = request.buildRequest().getQueryParams

--- a/play-ws-standalone/src/main/java/play/libs/ws/StandaloneWSRequest.java
+++ b/play-ws-standalone/src/main/java/play/libs/ws/StandaloneWSRequest.java
@@ -295,6 +295,14 @@ public interface StandaloneWSRequest {
     StandaloneWSRequest setFollowRedirects(boolean followRedirects);
 
     /**
+     * Sets whether url encoding should be disabled.
+     *
+     * @param disableUrlEncoding true if url encoding should be disabled
+     * @return the modified WSRequest
+     */
+    StandaloneWSRequest setDisableUrlEncoding(boolean disableUrlEncoding);
+
+    /**
      * Sets the virtual host as a "hostname:port" string.
      *
      * @param virtualHost the virtual host
@@ -449,6 +457,11 @@ public interface StandaloneWSRequest {
      * @return true if the request is configure to follow redirect, false if it is configure not to, Optional.empty() if nothing is configured and the global client preference should be used instead.
      */
     Optional<Boolean> getFollowRedirects();
+
+    /**
+     * @return true if the request is configure to disable url encoding, false if it is configure not to, Optional.empty() if nothing is configured and the global client preference should be used instead.
+     */
+    Optional<Boolean> getDisableUrlEncoding();
 
     /**
      * @return the content type, if any, or Optional.empty() if no content type is found.

--- a/play-ws-standalone/src/main/scala/play/api/libs/ws/StandaloneWSRequest.scala
+++ b/play-ws-standalone/src/main/scala/play/api/libs/ws/StandaloneWSRequest.scala
@@ -185,6 +185,11 @@ trait StandaloneWSRequest {
   def withFollowRedirects(follow: Boolean): Self
 
   /**
+   * Sets whether url encoding should be disabled
+   */
+  def withDisableUrlEncoding(disableUrlEncoding: Boolean): Self
+
+  /**
    * Sets the maximum time you expect the request to take.
    * Use Duration.Inf to set an infinite request timeout.
    * Warning: a stream consumption will be interrupted when this time is reached unless Duration.Inf is set.


### PR DESCRIPTION
Fixes https://github.com/playframework/playframework/issues/10473
Replaces invalid #545

Backport: #553

(To make review easy I recommend you to review commit after commit)

Right now the config `play.ws.ahc.disableUrlEncoding` **does nothing**.
https://github.com/playframework/play-ws/blob/2e42acc58ef276c0587eb44c1925755ee816ed8f/play-ahc-ws-standalone/src/main/resources/reference.conf#L29-L30

Technically, the config does get [parsed and read](https://github.com/playframework/play-ws/blob/v2.1.2/play-ahc-ws-standalone/src/main/scala/play/api/libs/ws/ahc/AhcConfig.scala#L100) and it will also be set onto the _client_:

https://github.com/playframework/play-ws/blob/735b38213011d4905426709205335a515a0333d7/play-ahc-ws-standalone/src/main/scala/play/api/libs/ws/ahc/AhcConfig.scala#L202

But now look closely at that line again... the builder is used to build a _client_ (not a request)... it says `setDisableUrlEncodingForBoundRequests`. What does that `...ForBoundRequests` mean? Like the name says that `disableUrlEncoding` flag will only be set for bound requests... I highly recommed to read this section what a bound and unbound request actually is: https://www.baeldung.com/async-http-client#creating-an-http-request:
> _A bound request is tied to the HTTP client it was created from and will, by default, use the configuration of that specific client if not specified otherwise._

> _To create a **bound request** we use the helper methods **from the class `AsyncHttpClient`** that start with the prefix `prepare`_

> _An **unbound request** can be created using the `RequestBuilder` class_

So now, how does play-ws create its requests?
It uses `new RequestBuilder(method)` (see [Scala API](https://github.com/playframework/play-ws/blob/v2.1.2/play-ahc-ws-standalone/src/main/scala/play/api/libs/ws/ahc/StandaloneAhcWSRequest.scala#L269) and [Java API](https://github.com/playframework/play-ws/blob/v2.1.2/play-ahc-ws-standalone/src/main/java/play/libs/ws/ahc/StandaloneAhcWSRequest.java#L413)), meaning it creates unbound requests...
**Therefore `play.ws.ahc.disableUrlEncoding` /  `setDisableUrlEncodingForBoundRequests` config does not have an effect at all on a request created by play-ws**

There are two ways to fix this now:
We could use a `client.prepare...(...)` method to create a bound request (via a `BoundRequestBuilder`) or, luckily, we can just pass the `disableUrlEncoding` flag to the `RequestBuilder(...)` constructor:   `new RequestBuilder(method, <disableUrlEncoding>)`.

One more thing: The Scala API already had some "support" for `disableUrlEncoding`, see [here](https://github.com/playframework/play-ws/blob/v2.1.2/play-ahc-ws-standalone/src/main/scala/play/api/libs/ws/ahc/StandaloneAhcWSRequest.scala#L266-L270). However, that never worked because there was no way to set that `disableUrlEncoding` member anyway, so it was completely useless... So I also added all `withDisableUrlEncoding` methods as well.

Last thing: If you look how a [`BoundRequestBuilder`](https://github.com/AsyncHttpClient/async-http-client/blob/async-http-client-project-2.12.2/client/src/main/java/org/asynchttpclient/BoundRequestBuilder.java) gets created via a [`prepare` method](https://github.com/AsyncHttpClient/async-http-client/blob/async-http-client-project-2.12.2/client/src/main/java/org/asynchttpclient/DefaultAsyncHttpClient.java#L149-L152), you [will see that it basically does the same like my fix](https://github.com/AsyncHttpClient/async-http-client/blob/async-http-client-project-2.12.2/client/src/main/java/org/asynchttpclient/DefaultAsyncHttpClient.java#L311-L313): using the `config.isDisableUrlEncodingForBoundRequests` flag.