### PR TITLE
add parentheses for lambda param

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,11 +3,10 @@ language: scala
 
 git:
   depth: false # Avoid sbt-dynver not seeing the tag
-  
-env:
-  matrix:
-    - TRAVIS_JDK=11
 
+env:
+  jobs:
+    - TRAVIS_JDK=11
   global:
     # encrypt with: travis encrypt --pro BINTRAY_USER=...
     - secure: "RZUI6IHOV95LVej30BSsU5Oi8pEoFJDEwaitRj6AxK11YEvheUbcXhudw7BLQjubVwOzsMcJvuo7WINigshYmZiBSbsinuFJMdhq6vJkmoKnrA6RvY3/jkPddSKBHpaaCAYW7hVX4SmvZZucM6NHtYY5R8BA3lVUZepG/402HANvx1hZEQ12mYSJxCUk4UBUWaXLb7sl21CcuIsaEMR9wY6qzirGsyQSXGALCi9y7txfzJvVrsmomIeDx3xdITP4GQ6UW9QhPdpqoNr9TaZG0mtCfzMEPqdBJ+eR/e7R6IxvDQQ+kb0wbviDaSvTPUgzDWApBmJhWiu1hzx+dxsVCbayon5nEAWMMqUaBHQvYuujn0YV0aE8Wca4yo0HT9lWwnW3EId5+f4Na99e2YwVp7OwPtBL1ISzojFTh3CzBqkzhiZRfuYVAHCIJgxOUwXvvSWYh4oc5JZDUef47RNkIGH/iBpJ6nBsTiR/S1ZaGVoqf6XZiRu8xVGpZTCAyMwofX6JJcaWJgX2mxz9kx5PadXb7eJPwOO9CsdhiNBEtDBZdKQbIMVCtFw/kjgujCtJsl7y5PcW0SOJeUG6M9V79hwDkni8PdV0xxlyR0GzI7fULDht+qE8xwUDuIh4J4EUp1RC+oqNAXVPlrNvSTCRsyYdPs9WhyPxmpR7eFiEFoo="
@@ -15,9 +14,16 @@ env:
     - secure: "MFp03KTS8Xaigf5geg3cVRTN+yxUuON9T3bEAtCXIAdsIj0tPDTJJ8ilZ2qxSfrUdNXmXwcBhjcT8iAIpth1q5JUu2gUXWP/hTGktqrvMWEHbAxYC0FNZea53a6aow1EqbHZEL2t+Bi7SAUxbNtVFNPICfLxL0Y4wLpoCT0HBjfM+vnQ04L49YyGM1xECmkR3VD6d6qra71rmIwIr8yHU7NOd4dVXxSmTfAJU3NiKDYbJX2yOofW+Fo70HTghmCryjcK47DPmrHzeVGwhVlqPvcSY/Bf4Ib82mMR7g3+plVb48etJRfE/Bm+UzadcSzxx+PRfsu0qSwptwCmeDHB+wwfqu6NX5AZhuOjzXuctSqje5TDBjhmS9hIxOM8Abl3w4QVFLdk8bNc6sWJ7VyRxXt2VgIHEoN+cQwKbxAyrxokwp43O/tVB5+fho04vjwiX61pH4GKXzGTVaEZVCaEBmXqThVoeb9T+PxG/ofMGEqFT3NZVEhAZRx2AbqE7ALuDykKc5aIs4fFUZwnNYYoTWsnBHBaZZqVqeexVCt3cFAArNg6xhYujswOMWv9kkp2CgDY3jbqFisH9yanOuCoh2lKIgLzldv5q2kYoS4tUIKqqTnjMaB0/GyU5UT61IBxo5NMjDVb7YvhqgBXBzdoFQh1ODyKeNoKc/IWGbfXfYw="
 
 scala:
-  - 2.13.1
+  - 2.13.6
 
-before_install: curl -Ls https://raw.githubusercontent.com/shyiko/jabba/0.11.2/install.sh | bash && . ~/.jabba/jabba.sh
+before_install:
+  - |
+    curl -Ls https://git.io/sbt -o sbt || travis_terminate 1
+    chmod 0755 sbt || travis_terminate 1
+    sudo mv sbt /usr/local/bin/sbt || travis_terminate 1
+  - curl --version # for debug purpose
+  - if [ ! -f ~/.jabba/jabba.sh ]; then curl -L -v --retry 5 -o jabba-install.sh https://git.io/jabba && bash jabba-install.sh; fi
+  - . ~/.jabba/jabba.sh
 install: jabba install $(jabba ls-remote "adopt@~1.$TRAVIS_JDK.0-0" --latest=patch) && jabba use "$_" && java -Xmx32m -version
 
 script:
@@ -31,27 +37,27 @@ jobs:
       name: "Validations"
       script: sbt mimaReportBinaryIssues validateCode doc
       env:
-        - TRAVIS_SCALA_VERSION=2.13.5
+        - TRAVIS_SCALA_VERSION=2.13.6
         - TRAVIS_JDK=11
 
     - name: "Run tests with Scala 2.12 and AdoptOpenJDK 11"
       env:
-        - TRAVIS_SCALA_VERSION=2.12.13
+        - TRAVIS_SCALA_VERSION=2.12.14
         - TRAVIS_JDK=11
 
     - name: "Run tests with Scala 2.13 and AdoptOpenJDK 11"
       env:
-        - TRAVIS_SCALA_VERSION=2.13.5
+        - TRAVIS_SCALA_VERSION=2.13.6
         - TRAVIS_JDK=11
 
     - name: "Run tests with Scala 2.12 and AdoptOpenJDK 8"
       env:
-        - TRAVIS_SCALA_VERSION=2.12.13
+        - TRAVIS_SCALA_VERSION=2.12.14
         - TRAVIS_JDK=8
 
     - name: "Run tests with Scala 2.13 and AdoptOpenJDK 8"
       env:
-        - TRAVIS_SCALA_VERSION=2.13.5
+        - TRAVIS_SCALA_VERSION=2.13.6
         - TRAVIS_JDK=8
 
     - stage: publish
@@ -67,14 +73,12 @@ cache:
   directories:
     - "$HOME/.cache/coursier"
     - "$HOME/.ivy2/cache"
-    - "$HOME/.sbt/boot/"
-    - "$HOME/.jabba/jdk"
+    - "$HOME/.jabba"
+    - "$HOME/.sbt"
 
 before_cache:
-  - rm -rf $HOME/.ivy2/cache/com.typesafe.play/*
-  - rm -rf $HOME/.ivy2/cache/scala_*/sbt_*/com.typesafe.play/*
   - find $HOME/.ivy2 -name "ivydata-*.properties" -delete
-  - find $HOME/.sbt -name "*.lock" -delete
+  - find $HOME/.sbt  -name "*.lock"               -delete
 
 branches:
   only:

--- a/integration-tests/src/test/scala/play/libs/ws/ahc/AhcWSClientSpec.scala
+++ b/integration-tests/src/test/scala/play/libs/ws/ahc/AhcWSClientSpec.scala
@@ -50,7 +50,7 @@ class AhcWSClientSpec(implicit val executionEnv: ExecutionEnv)
 
     "source successfully" in withClient() { client =>
       val future = toScala(client.url(s"http://localhost:$testServerPort").stream())
-      val result: Future[ByteString] = future.flatMap { response: StandaloneWSResponse =>
+      val result: Future[ByteString] = future.flatMap { (response: StandaloneWSResponse) =>
         toScala(response.getBodyAsSource.runWith(Sink.head[ByteString](), materializer))
       }
       val expected: ByteString = ByteString.fromString("<h1>Say hello to akka-http</h1>")

--- a/play-ahc-ws-standalone/src/main/scala/play/api/libs/ws/ahc/StandaloneAhcWSClient.scala
+++ b/play-ahc-ws-standalone/src/main/scala/play/api/libs/ws/ahc/StandaloneAhcWSClient.scala
@@ -108,7 +108,7 @@ class StandaloneAhcWSClient @Inject() (asyncHttpClient: AsyncHttpClient)(implici
 
     val client = this
 
-    val function: JFunction[StreamedState, StreamedResponse] = { state: StreamedState =>
+    val function: JFunction[StreamedState, StreamedResponse] = { (state: StreamedState) =>
       val publisher = state.publisher
 
       val wrap = new Publisher[HttpResponseBodyPart]() {

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -6,8 +6,8 @@ import sbt._
 object Dependencies {
 
   // must align with versions in .travis.yml
-  val scala212 = "2.12.13"
-  val scala213 = "2.13.5"
+  val scala212 = "2.12.14"
+  val scala213 = "2.13.6"
 
   val logback = Seq("ch.qos.logback" % "logback-core" % "1.2.3")
 


### PR DESCRIPTION

# Pull Request Checklist

* [x] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [x] Have you signed the [Typesafe CLA](https://www.typesafe.com/contribute/cla)?
* [x] Have you [squashed your commits](https://www.playframework.com/documentation/latest/WorkingWithGit#Squashing-commits)?
* [x] Have you added copyright headers to new files?
* [x] Have you checked that both Scala and Java APIs are updated?
* [x] Have you updated the documentation for both Scala and Java sections?
* [x] Have you added tests for any changed functionality?

## Fixes

## Purpose

prepare Scala 3

```
scala> Option(1).map{ a => a }
val res0: Option[Int] = Some(1)

scala> Option(1).map{ a: Int => a }
1 |Option(1).map{ a: Int => a }
  |                      ^
  |parentheses are required around the parameter of a lambda
  |This construct can be rewritten automatically under -rewrite -source 3.0-migration.
```


## Background Context


## References
