### PR TITLE
add explicit type annotations for implicit val

### DIFF
--- a/integration-tests/src/test/scala/play/AkkaServerProvider.scala
+++ b/integration-tests/src/test/scala/play/AkkaServerProvider.scala
@@ -31,8 +31,8 @@ trait AkkaServerProvider extends BeforeAfterAll {
   val defaultTimeout: FiniteDuration = 5.seconds
 
   // Create Akka system for thread and streaming management
-  implicit val system       = ActorSystem()
-  implicit val materializer = Materializer.matFromSystem
+  implicit val system: ActorSystem        = ActorSystem()
+  implicit val materializer: Materializer = Materializer.matFromSystem
 
   lazy val futureServer: Future[Http.ServerBinding] = {
     // Using 0 (zero) means that a random free port will be used.

--- a/integration-tests/src/test/scala/play/api/libs/ws/ahc/JsonRequestSpec.scala
+++ b/integration-tests/src/test/scala/play/api/libs/ws/ahc/JsonRequestSpec.scala
@@ -31,8 +31,8 @@ import scala.io.Codec
 class JsonRequestSpec extends Specification with Mockito with AfterAll with JsonBodyWritables {
   sequential
 
-  implicit val system       = ActorSystem()
-  implicit val materializer = Materializer.matFromSystem
+  implicit val system: ActorSystem        = ActorSystem()
+  implicit val materializer: Materializer = Materializer.matFromSystem
 
   override def afterAll: Unit = {
     system.terminate()

--- a/integration-tests/src/test/scala/play/api/libs/ws/ahc/XMLRequestSpec.scala
+++ b/integration-tests/src/test/scala/play/api/libs/ws/ahc/XMLRequestSpec.scala
@@ -22,8 +22,8 @@ import scala.xml.Elem
 class XMLRequestSpec extends Specification with Mockito with AfterAll with MustMatchers {
   sequential
 
-  implicit val system       = ActorSystem()
-  implicit val materializer = Materializer.matFromSystem
+  implicit val system: ActorSystem        = ActorSystem()
+  implicit val materializer: Materializer = Materializer.matFromSystem
 
   override def afterAll: Unit = {
     system.terminate()

--- a/play-ahc-ws-standalone/src/test/scala/play/api/libs/ws/ahc/AhcWSRequestSpec.scala
+++ b/play-ahc-ws-standalone/src/test/scala/play/api/libs/ws/ahc/AhcWSRequestSpec.scala
@@ -35,9 +35,9 @@ class AhcWSRequestSpec
 
   sequential
 
-  implicit val system       = ActorSystem()
-  implicit val materializer = Materializer.matFromSystem
-  val wsClient              = StandaloneAhcWSClient()
+  implicit val system: ActorSystem        = ActorSystem()
+  implicit val materializer: Materializer = Materializer.matFromSystem
+  val wsClient                            = StandaloneAhcWSClient()
 
   override def afterAll: Unit = {
     wsClient.close()


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [x] Have you signed the [Typesafe CLA](https://www.typesafe.com/contribute/cla)?
* [x] Have you [squashed your commits](https://www.playframework.com/documentation/latest/WorkingWithGit#Squashing-commits)?
* [x] Have you added copyright headers to new files?
* [x] Have you checked that both Scala and Java APIs are updated?
* [x] Have you updated the documentation for both Scala and Java sections?
* [x] Have you added tests for any changed functionality?

## Fixes



## Purpose

add explicit types

## Background Context

prepare Scala 3

```
$ scala -version
Scala compiler version 3.0.1 -- Copyright 2002-2021, LAMP/EPFL
$ scala 
scala> implicit val a = 2
1 |implicit val a = 2
  |             ^
  |             type of implicit definition needs to be given explicitly

```

## References
