### PR TITLE
fix warnings in build.sbt

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -119,11 +119,8 @@ lazy val shadedCommonSettings = Seq(
 )
 
 lazy val shadeAssemblySettings = commonSettings ++ shadedCommonSettings ++ Seq(
-  assembly / assemblyOption ~= (_.copy(includeScala = false)),
+  assembly / assemblyOption ~= (_.withIncludeScala(false)),
   assembly / test := {},
-  assembly / assemblyOption ~= {
-    _.copy(includeScala = false)
-  },
   assembly / assemblyJarName := {
     CrossVersion.partialVersion(scalaVersion.value) match {
       case Some((epoch, major)) =>
@@ -220,7 +217,7 @@ lazy val `shaded-asynchttpclient` = project
     //ivyXML := <dependencies></dependencies>,
     //ivyLoggingLevel := UpdateLogging.Full,
     //logLevel := Level.Debug,
-    assembly / assemblyOption := (assembly / assemblyOption).value.copy(includeBin = false, includeScala = false),
+    assembly / assemblyOption := (assembly / assemblyOption).value.withIncludeBin(false).withIncludeScala(false),
     Compile / packageBin := assembly.value
   )
 
@@ -245,7 +242,7 @@ lazy val `shaded-oauth` = project
     // https://stackoverflow.com/questions/24807875/how-to-remove-projectdependencies-from-pom
     // Remove dependencies from the POM because we have a FAT jar here.
     makePomConfiguration := makePomConfiguration.value.withProcess(process = dependenciesFilter),
-    assembly / assemblyOption := (assembly / assemblyOption).value.copy(includeBin = false, includeScala = false),
+    assembly / assemblyOption := (assembly / assemblyOption).value.withIncludeBin(false).withIncludeScala(false),
     Compile / packageBin := assembly.value
   )
 


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [x] Have you signed the [Typesafe CLA](https://www.typesafe.com/contribute/cla)?
* [x] Have you [squashed your commits](https://www.playframework.com/documentation/latest/WorkingWithGit#Squashing-commits)?
* [x] Have you added copyright headers to new files?
* [x] Have you checked that both Scala and Java APIs are updated?
* [x] Have you updated the documentation for both Scala and Java sections?
* [x] Have you added tests for any changed functionality?

## Fixes

Fixes warnings 

## Purpose



## Background Context

```
/home/travis/build/playframework/play-ws/build.sbt:122: warning: method copy in class AssemblyOption is deprecated (since 1.0.0): copy method is deprecated; use withIncludeBin(...) etc
  assembly / assemblyOption ~= (_.copy(includeScala = false)),
                                  ^
/home/travis/build/playframework/play-ws/build.sbt:125: warning: method copy in class AssemblyOption is deprecated (since 1.0.0): copy method is deprecated; use withIncludeBin(...) etc
    _.copy(includeScala = false)
      ^
/home/travis/build/playframework/play-ws/build.sbt:223: warning: method copy in class AssemblyOption is deprecated (since 1.0.0): copy method is deprecated; use withIncludeBin(...) etc
    assembly / assemblyOption := (assembly / assemblyOption).value.copy(includeBin = false, includeScala = false),
                                                                   ^
/home/travis/build/playframework/play-ws/build.sbt:248: warning: method copy in class AssemblyOption is deprecated (since 1.0.0): copy method is deprecated; use withIncludeBin(...) etc
    assembly / assemblyOption := (assembly / assemblyOption).value.copy(includeBin = false, includeScala = false),
                                                                   ^
```

## References

https://github.com/sbt/sbt-assembly/pull/433