### PR TITLE
rename `master` branch to `main`

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -4,7 +4,7 @@ on:
   push:
     # branches to consider in the event; optional, defaults to all
     branches:
-      - master
+      - main
 
 jobs:
   update_release_draft:

--- a/.travis.yml
+++ b/.travis.yml
@@ -67,7 +67,7 @@ jobs:
 stages:
   - name: test
   - name: publish
-    if: ((branch = master AND type = push) OR (tag IS present)) AND NOT fork
+    if: ((branch = main AND type = push) OR (tag IS present)) AND NOT fork
 
 cache:
   directories:
@@ -82,5 +82,5 @@ before_cache:
 
 branches:
   only:
-    - master
+    - main
     - /^\d+\.\d+(\.\d+)?(-\S*)?$/

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://travis-ci.com/playframework/play-ws.svg?branch=master)](https://travis-ci.com/github/playframework/play-ws) [![Maven](https://img.shields.io/maven-central/v/com.typesafe.play/play-ws-standalone_2.12.svg)](http://mvnrepository.com/artifact/com.typesafe.play/play-ws-standalone_2.12) [![Javadocs](https://javadoc.io/badge/com.typesafe.play/play-ws-standalone_2.12.svg)](https://javadoc.io/doc/com.typesafe.play/play-ws-standalone_2.12)
+[![Build Status](https://travis-ci.com/playframework/play-ws.svg?branch=main)](https://travis-ci.com/github/playframework/play-ws) [![Maven](https://img.shields.io/maven-central/v/com.typesafe.play/play-ws-standalone_2.12.svg)](http://mvnrepository.com/artifact/com.typesafe.play/play-ws-standalone_2.12) [![Javadocs](https://javadoc.io/badge/com.typesafe.play/play-ws-standalone_2.12.svg)](https://javadoc.io/doc/com.typesafe.play/play-ws-standalone_2.12)
 
 # Play WS Standalone
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,13 +1,13 @@
 ## Releasing
 
-This is released from the `master` branch from `2.2.0` forward. Unless an older version needs patching, then it must be released from the maintenance branch, for instance `2.1.x` branch. If there is no maintenance branch for the release that needs patching, create it from the tag.
+This is released from the `main` branch from `2.2.0` forward. Unless an older version needs patching, then it must be released from the maintenance branch, for instance `2.1.x` branch. If there is no maintenance branch for the release that needs patching, create it from the tag.
 
 ## Cutting the release
 
 ### Requires contributor access
 
 - Check the [draft release notes](https://github.com/playframework/play-ws/releases) to see if everything is there
-- Wait until [master build finished](https://travis-ci.com/github/playframework/play-ws/builds) after merging the last PR
+- Wait until [main branch build finishes](https://travis-ci.com/github/playframework/play-ws/builds) after merging the last PR
 - Update the [draft release](https://github.com/playframework/play-ws/releases) with the next tag version (eg. `2.2.0`), title and release description
 - Check that Travis CI release build has executed successfully (Travis will start a [CI build](https://travis-ci.com/github/playframework/play-ws/builds) for the new tag and publish artifacts to Bintray)
 

--- a/build.sbt
+++ b/build.sbt
@@ -58,7 +58,7 @@ lazy val mimaSettings = Seq(
     organization.value %% name.value % previousStableVersion.value
       .getOrElse(throw new Error("Unable to determine previous version"))
   ),
-  // these exclusions are only for master branch and are targeting 2.2.x
+  // these exclusions are only for main branch and are targeting 2.2.x
   mimaBinaryIssueFilters ++= Seq(
     ProblemFilters.exclude[MissingTypesProblem]("play.api.libs.ws.ahc.AhcWSClientConfig$"),
     ProblemFilters.exclude[IncompatibleResultTypeProblem]("play.api.libs.ws.ahc.AhcWSClientConfig.<init>$default$6"),


### PR DESCRIPTION
references #596

I've already done the renaming, so this just changes the repo contents to reflect the new reality