### PR TITLE
Prevent XXE injection when parsing XML

### DIFF
--- a/play-ws-standalone-xml/src/main/scala/play/api/libs/ws/XMLBodyReadables.scala
+++ b/play-ws-standalone-xml/src/main/scala/play/api/libs/ws/XMLBodyReadables.scala
@@ -25,7 +25,7 @@ trait XMLBodyReadables {
    * }}}
    */
   implicit val readableAsXml: BodyReadable[Elem] = BodyReadable { response =>
-    xml.XML.load(new InputSource(new ByteArrayInputStream(response.bodyAsBytes.toArray)))
+    XML.parser.load(new InputSource(new ByteArrayInputStream(response.bodyAsBytes.toArray)))
   }
 
 }


### PR DESCRIPTION
## Fixes

Fixes #488

## Purpose

WS API `response.xml` is vulnerable to XXE injection attacks. Tracing the issue it seems to have been introduced a few years ago when the custom XML parser was replaced by a default one without the `xercesSaxParserFactory`.

I have reverted the code to using the custom factory parser.