### PR TITLE
add explicit type annotations for implicits

### DIFF
--- a/play-ahc-ws-standalone/src/test/scala/play/api/libs/ws/ahc/AhcWSRequestSpec.scala
+++ b/play-ahc-ws-standalone/src/test/scala/play/api/libs/ws/ahc/AhcWSRequestSpec.scala
@@ -50,8 +50,8 @@ class AhcWSRequestSpec
 
   "Given the full URL" in {
 
-    implicit val materializer = mock[akka.stream.Materializer]
-    val client                = mock[StandaloneAhcWSClient]
+    implicit val materializer: Materializer = mock[akka.stream.Materializer]
+    val client                              = mock[StandaloneAhcWSClient]
 
     "request withQueryStringParameters" in {
       val request = StandaloneAhcWSRequest(client, "http://example.com")

--- a/play-ahc-ws-standalone/src/test/scala/play/api/libs/ws/ahc/cache/AhcWSCacheSpec.scala
+++ b/play-ahc-ws-standalone/src/test/scala/play/api/libs/ws/ahc/cache/AhcWSCacheSpec.scala
@@ -22,8 +22,8 @@ class AhcWSCacheSpec extends Specification {
     "calculate LM freshness" in {
       import scala.concurrent.ExecutionContext.Implicits.global
 
-      implicit val cache = new AhcHttpCache(new StubHttpCache(), true)
-      val url            = "http://localhost:9000"
+      implicit val cache: AhcHttpCache = new AhcHttpCache(new StubHttpCache(), true)
+      val url                          = "http://localhost:9000"
 
       val uri                      = new URI(url)
       val lastModifiedDate: String = format(now.minusHours(1))
@@ -41,8 +41,8 @@ class AhcWSCacheSpec extends Specification {
     "be disabled when set to false" in {
       import scala.concurrent.ExecutionContext.Implicits.global
 
-      implicit val cache = new AhcHttpCache(new StubHttpCache(), false)
-      val url            = "http://localhost:9000"
+      implicit val cache: AhcHttpCache = new AhcHttpCache(new StubHttpCache(), false)
+      val url                          = "http://localhost:9000"
 
       val uri                      = new URI(url)
       val lastModifiedDate: String = "Wed, 09 Apr 2008 23:55:38 GMT"
@@ -62,8 +62,8 @@ class AhcWSCacheSpec extends Specification {
     "calculate keys correctly" in {
       import scala.concurrent.ExecutionContext.Implicits.global
 
-      implicit val cache = new AhcHttpCache(new StubHttpCache(), false)
-      val achConfig      = new DefaultAsyncHttpClientConfig.Builder().build()
+      implicit val cache: AhcHttpCache = new AhcHttpCache(new StubHttpCache(), false)
+      val achConfig                    = new DefaultAsyncHttpClientConfig.Builder().build()
 
       val url = "http://localhost:9000"
 


### PR DESCRIPTION

# Pull Request Checklist

* [x] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [x] Have you signed the [Typesafe CLA](https://www.typesafe.com/contribute/cla)?
* [x] Have you [squashed your commits](https://www.playframework.com/documentation/latest/WorkingWithGit#Squashing-commits)?
* [x] Have you added copyright headers to new files?
* [x] Have you checked that both Scala and Java APIs are updated?
* [x] Have you updated the documentation for both Scala and Java sections?
* [x] Have you added tests for any changed functionality?

## Fixes

## Purpose

- prepare Scala 3. separate #604

```
play-ahc-ws-standalone/src/test/scala/play/api/libs/ws/ahc/cache/AhcWSCacheSpec.scala:25:27 
[error] 25 |      implicit val cache = new AhcHttpCache(new StubHttpCache(), true)
[error]    |                           ^
[error]    |value cache needs result type because its right-hand side attempts implicit search
```

## Background Context

## References
