### PR TITLE
Update scalafmt `docstrings` setting

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,7 +1,7 @@
 align = true
 assumeStandardLibraryStripMargin = true
 danglingParentheses = true
-docstrings = JavaDoc
+docstrings.style = Asterisk
 maxColumn = 120
 project.git = true
 rewrite.rules = [ AvoidInfix, ExpandImportSelectors, RedundantParens, SortModifiers, PreferCurlyFors ]


### PR DESCRIPTION


# Pull Request Checklist

* [x] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [x] Have you signed the [Typesafe CLA](https://www.typesafe.com/contribute/cla)?
* [x] Have you [squashed your commits](https://www.playframework.com/documentation/latest/WorkingWithGit#Squashing-commits)?
* [x] Have you added copyright headers to new files?
* [x] Have you checked that both Scala and Java APIs are updated?
* [x] Have you updated the documentation for both Scala and Java sections?
* [x] Have you added tests for any changed functionality?

## Fixes


## Purpose

prepare scalafmt 3.x

https://app.travis-ci.com/github/playframework/play-ws/jobs/553942436#L456
https://scalameta.org/scalafmt/docs/configuration.html#docstringsstyle--asterisk

```
[error] Invalid config: 3 errors
[error] [E0] <input>:9:0 error: Type mismatch;
[error]   found    : String (value: "JavaDoc")
[error]   expected : Object
[error]     "docstrings" : "JavaDoc",
[error] ^
```

## Background Context

## References

