### PR TITLE
[2.1.x] Keep dependencies like in v2.1.7

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -33,7 +33,7 @@ object Dependencies {
 
   val javaxInject = Seq("javax.inject" % "javax.inject" % "1")
 
-  val sslConfigVersion = "0.6.0"
+  val sslConfigVersion = "0.4.3"
   val sslConfigCore = Seq("com.typesafe" %% "ssl-config-core" % sslConfigVersion)
 
   val scalaXmlVersion = "1.2.0"
@@ -48,9 +48,9 @@ object Dependencies {
   val asyncHttpClientVersion = "2.10.5"
   val asyncHttpClient = Seq("org.asynchttpclient" % "async-http-client" % asyncHttpClientVersion)
 
-  val akkaVersion = "2.6.18+31-9d0684d8-SNAPSHOT"
+  val akkaVersion = "2.6.1"
   val akkaStreams = Seq("com.typesafe.akka" %% "akka-stream" % akkaVersion)
-  val akkaHttp = Seq("com.typesafe.akka" %% "akka-http" % "10.1.15")
+  val akkaHttp = Seq("com.typesafe.akka" %% "akka-http" % "10.1.11")
 
   val reactiveStreams = Seq("org.reactivestreams" % "reactive-streams" % "1.0.3")
 


### PR DESCRIPTION
Getting rid of the akka SNAPSHOT version.
akka did _not_ upgrade to ssl-config 0.6.x because it has binary compatibility issues with 0.4.x. Actually it got upgraded first, see https://github.com/akka/akka/pull/31046, then it got partially reverted, see https://github.com/akka/akka/pull/31252.
Partially reverted means that only the dependency was downgraded again, however akka itself removed methods and classes not available anymore in ssl-config 0.6.x, so akka 2.6.19 itself works nicely with ssl-config 0.6.x. However they didn't want to upgrade to latest ssl-config to not break libraries depending on akka and which also use removed methods and/or classes from ssl-config 0.4.3.

For play-ws stable branch 2.1.x I play the same game now, keeping the dependency versions like they were in the previous version, however leaving methods/classes available only in ssl-config 0.4.x (but not in 0.6.x), that got removed in #638, deleted.
That means people using upcoming play-ws 2.1.8 can safely upgrade to ssl-config 0.6.x.