### PR TITLE
No need to exclude scala-parser-combinators anymore

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -45,10 +45,7 @@ object Dependencies {
 
   val oauth = Seq("oauth.signpost" % "signpost-core" % "2.1.1")
 
-  val cachecontrol = Seq(
-    "com.typesafe.play"      %% "cachecontrol"             % "2.2.0",
-    "org.scala-lang.modules" %% "scala-parser-combinators" % "2.1.0"
-  )
+  val cachecontrol = Seq("com.typesafe.play" %% "cachecontrol" % "2.2.0")
 
   val asyncHttpClient = Seq("org.asynchttpclient" % "async-http-client" % "2.12.3")
 
@@ -65,9 +62,7 @@ object Dependencies {
     _.exclude("com.typesafe", "*").exclude("org.scala-lang.modules", "*")
   ) ++ testDependencies
 
-  val standaloneAhcWSDependencies = scalaJava8Compat ++ cachecontrol.map(
-    _.exclude("org.scala-lang", "*").exclude("org.scala-lang.modules", "*")
-  ) ++ slf4jApi ++ reactiveStreams ++ testDependencies
+  val standaloneAhcWSDependencies = scalaJava8Compat ++ cachecontrol ++ slf4jApi ++ reactiveStreams ++ testDependencies
 
   val standaloneAhcWSJsonDependencies = playJson ++ testDependencies
 


### PR DESCRIPTION
cachecontrol 2.2.0 pulls in the correct `scala-parser-combinators` version for Scala 2 or 3 already: https://github.com/playframework/cachecontrol/blob/2.2.0/project/Dependencies.scala#L15-L21

I think the excludes you added here are not necessary anymore. I think you added them because you started your pull request #604 long time before cachencontrol 2.2.0 was released, because before that it was just using `1.1.2`, which had no support for Scala 3.