### PR TITLE
use jdk.CollectionConverters instead of deprecated JavaConverters

### DIFF
--- a/integration-tests/src/test/java/play/libs/ws/ahc/AhcCurlRequestLoggerSpec.scala
+++ b/integration-tests/src/test/java/play/libs/ws/ahc/AhcCurlRequestLoggerSpec.scala
@@ -17,7 +17,7 @@ import uk.org.lidalia.slf4jext.Level
 import uk.org.lidalia.slf4jtest.TestLogger
 import uk.org.lidalia.slf4jtest.TestLoggerFactory
 
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 import scala.compat.java8.FutureConverters._
 
 class AhcCurlRequestLoggerSpec(implicit val executionEnv: ExecutionEnv)

--- a/integration-tests/src/test/scala/play/api/libs/ws/ahc/AhcCurlRequestLoggerSpec.scala
+++ b/integration-tests/src/test/scala/play/api/libs/ws/ahc/AhcCurlRequestLoggerSpec.scala
@@ -17,7 +17,7 @@ import uk.org.lidalia.slf4jext.Level
 import uk.org.lidalia.slf4jtest.TestLogger
 import uk.org.lidalia.slf4jtest.TestLoggerFactory
 
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 
 class AhcCurlRequestLoggerSpec(implicit val executionEnv: ExecutionEnv)
     extends Specification

--- a/integration-tests/src/test/scala/play/libs/ws/ahc/AhcWSRequestFilterSpec.scala
+++ b/integration-tests/src/test/scala/play/libs/ws/ahc/AhcWSRequestFilterSpec.scala
@@ -38,7 +38,7 @@ class AhcWSRequestFilterSpec(implicit val executionEnv: ExecutionEnv)
   "setRequestFilter" should {
 
     "work with one request filter" in withClient() { client =>
-      import scala.collection.JavaConverters._
+      import scala.jdk.CollectionConverters._
       val callList = new java.util.ArrayList[Integer]()
       val responseFuture = FutureConverters.toScala(
         client
@@ -54,7 +54,7 @@ class AhcWSRequestFilterSpec(implicit val executionEnv: ExecutionEnv)
     }
 
     "stream with one request filter" in withClient() { client =>
-      import scala.collection.JavaConverters._
+      import scala.jdk.CollectionConverters._
       val callList = new java.util.ArrayList[Integer]()
       val responseFuture = FutureConverters.toScala(
         client
@@ -70,7 +70,7 @@ class AhcWSRequestFilterSpec(implicit val executionEnv: ExecutionEnv)
     }
 
     "work with three request filter" in withClient() { client =>
-      import scala.collection.JavaConverters._
+      import scala.jdk.CollectionConverters._
       val callList = new java.util.ArrayList[Integer]()
       val responseFuture = FutureConverters.toScala(
         client
@@ -88,7 +88,7 @@ class AhcWSRequestFilterSpec(implicit val executionEnv: ExecutionEnv)
     }
 
     "stream with three request filters" in withClient() { client =>
-      import scala.collection.JavaConverters._
+      import scala.jdk.CollectionConverters._
       val callList = new java.util.ArrayList[Integer]()
       val responseFuture = FutureConverters.toScala(
         client

--- a/play-ahc-ws-standalone/src/main/java/play/libs/ws/ahc/StreamedResponse.java
+++ b/play-ahc-ws-standalone/src/main/java/play/libs/ws/ahc/StreamedResponse.java
@@ -23,7 +23,7 @@ import java.util.Optional;
 import java.util.function.Predicate;
 
 import static java.util.stream.Collectors.toMap;
-import static scala.collection.JavaConverters.seqAsJavaListConverter;
+import scala.jdk.javaapi.CollectionConverters;
 
 public class StreamedResponse implements StandaloneWSResponse, CookieBuilder {
 
@@ -121,7 +121,7 @@ public class StreamedResponse implements StandaloneWSResponse, CookieBuilder {
     }
 
     private static java.util.Map<String, List<String>> asJava(scala.collection.Map<String, Seq<String>> scalaMap) {
-        return ScalaStreamSupport.stream(scalaMap).collect(toMap(f -> f._1(), f -> seqAsJavaListConverter(f._2()).asJava()));
+        return ScalaStreamSupport.stream(scalaMap).collect(toMap(f -> f._1(), f -> CollectionConverters.asJava(f._2())));
     }
 
 }

--- a/play-ahc-ws-standalone/src/main/scala/play/api/libs/ws/ahc/AhcUtilities.scala
+++ b/play-ahc-ws-standalone/src/main/scala/play/api/libs/ws/ahc/AhcUtilities.scala
@@ -14,7 +14,7 @@ import scala.collection.immutable.TreeMap
 trait AhcUtilities {
 
   def headersToMap(headers: HttpHeaders): TreeMap[String, Seq[String]] = {
-    import scala.collection.JavaConverters._
+    import scala.jdk.CollectionConverters._
     val mutableMap = scala.collection.mutable.HashMap[String, Seq[String]]()
     headers.names().asScala.foreach { name =>
       mutableMap.put(name, headers.getAll(name).asScala.toSeq)

--- a/play-ahc-ws-standalone/src/main/scala/play/api/libs/ws/ahc/FormUrlEncodedParser.scala
+++ b/play-ahc-ws-standalone/src/main/scala/play/api/libs/ws/ahc/FormUrlEncodedParser.scala
@@ -45,7 +45,7 @@ private[ahc] object FormUrlEncodedParser {
    * @return A Map of keys to the sequence of values for that key
    */
   def parseAsJava(data: String, encoding: String): java.util.Map[String, java.util.List[String]] = {
-    import scala.collection.JavaConverters._
+    import scala.jdk.CollectionConverters._
     parse(data, encoding).map { case (key, values) =>
       key -> values.asJava
     }.asJava
@@ -58,7 +58,7 @@ private[ahc] object FormUrlEncodedParser {
    * @return A Map of keys to the sequence of array values for that key
    */
   def parseAsJavaArrayValues(data: String, encoding: String): java.util.Map[String, Array[String]] = {
-    import scala.collection.JavaConverters._
+    import scala.jdk.CollectionConverters._
     parse(data, encoding).map { case (key, values) =>
       key -> values.toArray
     }.asJava

--- a/play-ahc-ws-standalone/src/main/scala/play/api/libs/ws/ahc/StandaloneAhcWSRequest.scala
+++ b/play-ahc-ws-standalone/src/main/scala/play/api/libs/ws/ahc/StandaloneAhcWSRequest.scala
@@ -20,7 +20,7 @@ import play.shaded.ahc.org.asynchttpclient._
 import play.shaded.ahc.org.asynchttpclient.proxy.{ ProxyServer => AHCProxyServer }
 import play.shaded.ahc.org.asynchttpclient.util.HttpUtils
 
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 import scala.collection.immutable.TreeMap
 import scala.concurrent.Future
 import scala.concurrent.duration.Duration
@@ -449,7 +449,7 @@ case class StandaloneAhcWSRequest(
     }
 
     wsProxyServer.nonProxyHosts.foreach { nonProxyHosts =>
-      import scala.collection.JavaConverters._
+      import scala.jdk.CollectionConverters._
       proxyBuilder.setNonProxyHosts(nonProxyHosts.asJava)
     }
     proxyBuilder.build()

--- a/play-ahc-ws-standalone/src/main/scala/play/api/libs/ws/ahc/StandaloneAhcWSResponse.scala
+++ b/play-ahc-ws-standalone/src/main/scala/play/api/libs/ws/ahc/StandaloneAhcWSResponse.scala
@@ -11,7 +11,7 @@ import play.api.libs.ws.StandaloneWSResponse
 import play.api.libs.ws.WSCookie
 import play.shaded.ahc.org.asynchttpclient.{ Response => AHCResponse }
 
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 
 /**
  * A WS HTTP response backed by org.asynchttpclient.Response.

--- a/play-ahc-ws-standalone/src/main/scala/play/api/libs/ws/ahc/cache/AhcHttpCache.scala
+++ b/play-ahc-ws-standalone/src/main/scala/play/api/libs/ws/ahc/cache/AhcHttpCache.scala
@@ -320,7 +320,7 @@ class AhcHttpCache(underlying: standaloneAhc.cache.Cache, heuristicsEnabled: Boo
       logger.trace(s"freshenResponse: newHeaders = $newHeaders, storedResponse = $response")
     }
 
-    import collection.JavaConverters._
+    import scala.jdk.CollectionConverters._
 
     // Need to freshen this stale response
     // https://tools.ietf.org/html/rfc7234#section-4.3.4
@@ -443,7 +443,7 @@ class AhcHttpCache(underlying: standaloneAhc.cache.Cache, heuristicsEnabled: Boo
     val stripSet       = stripHeaderCalculator.stripHeaders(originResponse)
 
     val r = if (stripSet.nonEmpty) {
-      import scala.collection.JavaConverters._
+      import scala.jdk.CollectionConverters._
       val stripHeaderNames = stripSet.map(_.toString()).asJavaCollection
       logger.debug(s"massageCachedResponse: stripHeaderNames = $stripHeaderNames")
       stripHeaderNames.asScala.foreach(httpResponse.getHeaders.remove)

--- a/play-ahc-ws-standalone/src/main/scala/play/api/libs/ws/ahc/cache/CacheAsyncConnection.scala
+++ b/play-ahc-ws-standalone/src/main/scala/play/api/libs/ws/ahc/cache/CacheAsyncConnection.scala
@@ -45,7 +45,7 @@ class AsyncCacheableConnection[T](
       }
 
       if (state eq AsyncHandler.State.CONTINUE) {
-        import collection.JavaConverters._
+        import scala.jdk.CollectionConverters._
         response.bodyParts.asScala.foreach { bodyPart =>
           asyncHandler.onBodyPartReceived(bodyPart)
         }

--- a/play-ahc-ws-standalone/src/main/scala/play/api/libs/ws/ahc/cache/CacheableResponse.scala
+++ b/play-ahc-ws-standalone/src/main/scala/play/api/libs/ws/ahc/cache/CacheableResponse.scala
@@ -59,7 +59,7 @@ class CacheableResponseBuilder(ahcConfig: AsyncHttpClientConfig) {
   }
 
   def build: CacheableResponse = {
-    import scala.collection.JavaConverters._
+    import scala.jdk.CollectionConverters._
     new CacheableResponse(status.get, headers.get, bodyParts.asJava, ahcConfig)
   }
 }
@@ -107,7 +107,7 @@ case class CacheableResponse(
 
   @throws(classOf[IOException])
   override def getResponseBodyAsByteBuffer: ByteBuffer = {
-    import scala.collection.JavaConverters._
+    import scala.jdk.CollectionConverters._
     val length = bodyParts.asScala.map(_.length()).sum
     val target = ByteBuffer.wrap(new Array[Byte](length))
     bodyParts.asScala.foreach(part => target.put(part.getBodyPartBytes))
@@ -211,7 +211,7 @@ case class CacheableResponse(
     if (!isNonEmpty(setCookieHeaders)) setCookieHeaders = headers.getAll(SET_COOKIE)
     if (isNonEmpty(setCookieHeaders)) {
       val cookies = new util.ArrayList[Cookie](1)
-      import scala.collection.JavaConverters._
+      import scala.jdk.CollectionConverters._
       for (value <- setCookieHeaders.iterator.asScala) {
         val c =
           if (ahcConfig.isUseLaxCookieEncoder) ClientCookieDecoder.LAX.decode(value)

--- a/play-ahc-ws-standalone/src/main/scala/play/api/libs/ws/ahc/cache/Debug.scala
+++ b/play-ahc-ws-standalone/src/main/scala/play/api/libs/ws/ahc/cache/Debug.scala
@@ -56,7 +56,7 @@ private[ahc] trait Debug extends AhcUtilities {
   }
 
   def debug(bodyParts: java.util.List[HttpResponseBodyPart]): String = {
-    import collection.JavaConverters._
+    import scala.jdk.CollectionConverters._
     bodyParts.asScala.map(debug).toString()
   }
 

--- a/play-ahc-ws-standalone/src/test/scala/play/api/libs/ws/ahc/AhcWSRequestSpec.scala
+++ b/play-ahc-ws-standalone/src/test/scala/play/api/libs/ws/ahc/AhcWSRequestSpec.scala
@@ -4,7 +4,7 @@
 
 package play.api.libs.ws.ahc
 
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 import scala.concurrent.duration._
 
 import akka.actor.ActorSystem
@@ -266,7 +266,7 @@ class AhcWSRequestSpec
 
     "not make Content-Type header if there is Content-Type in headers already" in {
       withClient { client =>
-        import scala.collection.JavaConverters._
+        import scala.jdk.CollectionConverters._
 
         val req: AHCRequest = client
           .url("http://playframework.com/")
@@ -358,7 +358,7 @@ class AhcWSRequestSpec
 
     "Have form params for content type application/x-www-form-urlencoded when signed" in {
       withClient { client =>
-        import scala.collection.JavaConverters._
+        import scala.jdk.CollectionConverters._
         val consumerKey  = ConsumerKey("key", "secret")
         val requestToken = RequestToken("token", "secret")
         val calc         = OAuthCalculator(consumerKey, requestToken)
@@ -653,7 +653,7 @@ class AhcWSRequestSpec
   }
 
   "Remove a user defined content length header if we are parsing body explicitly when signed" in withClient { client =>
-    import scala.collection.JavaConverters._
+    import scala.jdk.CollectionConverters._
     val consumerKey  = ConsumerKey("key", "secret")
     val requestToken = RequestToken("token", "secret")
     val calc         = OAuthCalculator(consumerKey, requestToken)
@@ -674,7 +674,7 @@ class AhcWSRequestSpec
   }
 
   "Verify Content-Type header is passed through correctly" in withClient { client =>
-    import scala.collection.JavaConverters._
+    import scala.jdk.CollectionConverters._
     val req: AHCRequest = client
       .url("http://playframework.com/")
       .withHttpHeaders(HttpHeaderNames.CONTENT_TYPE.toString() -> "text/plain; charset=US-ASCII")

--- a/play-ahc-ws-standalone/src/test/scala/play/libs/ws/ahc/AhcWSRequestSpec.scala
+++ b/play-ahc-ws-standalone/src/test/scala/play/libs/ws/ahc/AhcWSRequestSpec.scala
@@ -18,7 +18,7 @@ import play.shaded.ahc.org.asynchttpclient.Request
 import play.shaded.ahc.org.asynchttpclient.RequestBuilderBase
 import play.shaded.ahc.org.asynchttpclient.SignatureCalculator
 
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 import scala.collection.mutable
 import scala.compat.java8.OptionConverters._
 
@@ -113,7 +113,7 @@ class AhcWSRequestSpec extends Specification with Mockito with DefaultBodyReadab
       }
 
       "have form params when passing in map" in {
-        import scala.collection.JavaConverters._
+        import scala.jdk.CollectionConverters._
         val client = StandaloneAhcWSClient.create(
           AhcWSClientConfigFactory.forConfig(ConfigFactory.load(), this.getClass.getClassLoader), /*materializer*/ null
         )
@@ -132,7 +132,7 @@ class AhcWSRequestSpec extends Specification with Mockito with DefaultBodyReadab
       }
 
       "have form params when content-type application/x-www-form-urlencoded and signed" in {
-        import scala.collection.JavaConverters._
+        import scala.jdk.CollectionConverters._
         val client = StandaloneAhcWSClient.create(
           AhcWSClientConfigFactory.forConfig(ConfigFactory.load(), this.getClass.getClassLoader), /*materializer*/ null
         )
@@ -152,7 +152,7 @@ class AhcWSRequestSpec extends Specification with Mockito with DefaultBodyReadab
       }
 
       "remove a user defined content length header if we are parsing body explicitly when signed" in {
-        import scala.collection.JavaConverters._
+        import scala.jdk.CollectionConverters._
         val client = StandaloneAhcWSClient.create(
           AhcWSClientConfigFactory.forConfig(ConfigFactory.load(), this.getClass.getClassLoader), /*materializer*/ null
         )
@@ -519,7 +519,7 @@ class AhcWSRequestSpec extends Specification with Mockito with DefaultBodyReadab
       }
 
       "support a query string parameter with an encoded equals sign" in {
-        import scala.collection.JavaConverters._
+        import scala.jdk.CollectionConverters._
         val client = StandaloneAhcWSClient.create(
           AhcWSClientConfigFactory.forConfig(ConfigFactory.load(), this.getClass.getClassLoader), /*materializer*/ null
         )
@@ -669,7 +669,7 @@ class AhcWSRequestSpec extends Specification with Mockito with DefaultBodyReadab
   }
 
   def requestWithQueryString(query: String) = {
-    import scala.collection.JavaConverters._
+    import scala.jdk.CollectionConverters._
     val client = StandaloneAhcWSClient.create(
       AhcWSClientConfigFactory.forConfig(ConfigFactory.load(), this.getClass.getClassLoader), /*materializer*/ null
     )

--- a/play-ahc-ws-standalone/src/test/scala/play/libs/ws/ahc/AhcWSResponseSpec.scala
+++ b/play-ahc-ws-standalone/src/test/scala/play/libs/ws/ahc/AhcWSResponseSpec.scala
@@ -10,7 +10,7 @@ import play.libs.ws._
 import play.shaded.ahc.io.netty.handler.codec.http.DefaultHttpHeaders
 import play.shaded.ahc.org.asynchttpclient.Response
 
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 import scala.compat.java8.OptionConverters._
 
 class AhcWSResponseSpec extends Specification with Mockito with DefaultBodyReadables with DefaultBodyWritables {


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [x] Have you signed the [Typesafe CLA](https://www.typesafe.com/contribute/cla)?
* [x] Have you [squashed your commits](https://www.playframework.com/documentation/latest/WorkingWithGit#Squashing-commits)?
* [x] Have you added copyright headers to new files?
* [x] Have you checked that both Scala and Java APIs are updated?
* [x] Have you updated the documentation for both Scala and Java sections?
* [x] Have you added tests for any changed functionality?

## Fixes


## Purpose

fix warnings.


## Background Context

- https://github.com/playframework/play-ws/pull/603 play-ws drop Scala 2.12 support.
- JavaConverters deprecated since Scala 2.13 https://github.com/scala/scala/blob/v2.13.8/src/library/scala/collection/JavaConverters.scala#L78

## References
