### PR TITLE
remove scala-java8-compat dependency

### DIFF
--- a/integration-tests/src/test/java/play/libs/ws/ahc/AhcCurlRequestLoggerSpec.scala
+++ b/integration-tests/src/test/java/play/libs/ws/ahc/AhcCurlRequestLoggerSpec.scala
@@ -18,7 +18,7 @@ import uk.org.lidalia.slf4jtest.TestLogger
 import uk.org.lidalia.slf4jtest.TestLoggerFactory
 
 import scala.jdk.CollectionConverters._
-import scala.compat.java8.FutureConverters._
+import scala.jdk.FutureConverters._
 
 class AhcCurlRequestLoggerSpec(implicit val executionEnv: ExecutionEnv)
     extends Specification
@@ -52,7 +52,7 @@ class AhcCurlRequestLoggerSpec(implicit val executionEnv: ExecutionEnv)
         .url(s"http://localhost:$testServerPort/")
         .setRequestFilter(curlRequestLogger)
         .get()
-        .toScala
+        .asScala
         .awaitFor(defaultTimeout)
 
       testLogger.getLoggingEvents.asScala.map(_.getMessage) must containMatch("--verbose")
@@ -67,7 +67,7 @@ class AhcCurlRequestLoggerSpec(implicit val executionEnv: ExecutionEnv)
         .addHeader("My-Header", "My-Header-Value")
         .setRequestFilter(curlRequestLogger)
         .get()
-        .toScala
+        .asScala
         .awaitFor(defaultTimeout)
 
       val messages = testLogger.getLoggingEvents.asScala.map(_.getMessage)
@@ -84,7 +84,7 @@ class AhcCurlRequestLoggerSpec(implicit val executionEnv: ExecutionEnv)
         .addCookie(new DefaultWSCookie("cookie1", "value1", "localhost", "path", 10L, true, true))
         .setRequestFilter(curlRequestLogger)
         .get()
-        .toScala
+        .asScala
         .awaitFor(defaultTimeout)
 
       val messages = testLogger.getLoggingEvents.asScala.map(_.getMessage)
@@ -100,7 +100,7 @@ class AhcCurlRequestLoggerSpec(implicit val executionEnv: ExecutionEnv)
         .url(s"http://localhost:$testServerPort/")
         .setRequestFilter(curlRequestLogger)
         .get()
-        .toScala
+        .asScala
         .awaitFor(defaultTimeout)
 
       testLogger.getLoggingEvents.asScala.map(_.getMessage) must containMatch("--request GET")
@@ -115,7 +115,7 @@ class AhcCurlRequestLoggerSpec(implicit val executionEnv: ExecutionEnv)
         .setAuth(new WSAuthInfo("username", "password", WSAuthScheme.BASIC))
         .setRequestFilter(curlRequestLogger)
         .get()
-        .toScala
+        .asScala
         .awaitFor(defaultTimeout)
 
       testLogger.getLoggingEvents.asScala.map(_.getMessage) must containMatch(
@@ -134,7 +134,7 @@ class AhcCurlRequestLoggerSpec(implicit val executionEnv: ExecutionEnv)
           .setBody(body("the-body"))
           .setRequestFilter(curlRequestLogger)
           .get()
-          .toScala
+          .asScala
           .awaitFor(defaultTimeout)
 
         testLogger.getLoggingEvents.asScala.map(_.getMessage) must containMatch("the-body")
@@ -149,7 +149,7 @@ class AhcCurlRequestLoggerSpec(implicit val executionEnv: ExecutionEnv)
           .url(s"http://localhost:$testServerPort/")
           .setRequestFilter(curlRequestLogger)
           .get()
-          .toScala
+          .asScala
           .awaitFor(defaultTimeout)
 
         testLogger.getLoggingEvents.asScala.map(_.getMessage) must not containMatch "--data"
@@ -167,7 +167,7 @@ class AhcCurlRequestLoggerSpec(implicit val executionEnv: ExecutionEnv)
         .setAuth(new WSAuthInfo("username", "password", WSAuthScheme.BASIC))
         .setRequestFilter(curlRequestLogger)
         .get()
-        .toScala
+        .asScala
         .awaitFor(defaultTimeout)
 
       testLogger.getLoggingEvents.get(0).getMessage must beEqualTo(

--- a/integration-tests/src/test/scala/play/libs/ws/ahc/AhcWSRequestFilterSpec.scala
+++ b/integration-tests/src/test/scala/play/libs/ws/ahc/AhcWSRequestFilterSpec.scala
@@ -14,7 +14,7 @@ import org.specs2.mutable.Specification
 import play.AkkaServerProvider
 
 import scala.concurrent.duration._
-import scala.compat.java8.FutureConverters
+import scala.jdk.FutureConverters._
 
 class AhcWSRequestFilterSpec(implicit val executionEnv: ExecutionEnv)
     extends Specification
@@ -40,12 +40,12 @@ class AhcWSRequestFilterSpec(implicit val executionEnv: ExecutionEnv)
     "work with one request filter" in withClient() { client =>
       import scala.jdk.CollectionConverters._
       val callList = new java.util.ArrayList[Integer]()
-      val responseFuture = FutureConverters.toScala(
+      val responseFuture =
         client
           .url(s"http://localhost:$testServerPort")
           .setRequestFilter(new CallbackRequestFilter(callList, 1))
           .get()
-      )
+          .asScala
       responseFuture
         .map { _ =>
           callList.asScala must contain(1)
@@ -56,12 +56,12 @@ class AhcWSRequestFilterSpec(implicit val executionEnv: ExecutionEnv)
     "stream with one request filter" in withClient() { client =>
       import scala.jdk.CollectionConverters._
       val callList = new java.util.ArrayList[Integer]()
-      val responseFuture = FutureConverters.toScala(
+      val responseFuture =
         client
           .url(s"http://localhost:$testServerPort")
           .setRequestFilter(new CallbackRequestFilter(callList, 1))
           .stream()
-      )
+          .asScala
       responseFuture
         .map { _ =>
           callList.asScala must contain(1)
@@ -72,14 +72,14 @@ class AhcWSRequestFilterSpec(implicit val executionEnv: ExecutionEnv)
     "work with three request filter" in withClient() { client =>
       import scala.jdk.CollectionConverters._
       val callList = new java.util.ArrayList[Integer]()
-      val responseFuture = FutureConverters.toScala(
+      val responseFuture =
         client
           .url(s"http://localhost:$testServerPort")
           .setRequestFilter(new CallbackRequestFilter(callList, 1))
           .setRequestFilter(new CallbackRequestFilter(callList, 2))
           .setRequestFilter(new CallbackRequestFilter(callList, 3))
           .get()
-      )
+          .asScala
       responseFuture
         .map { _ =>
           callList.asScala must containTheSameElementsAs(Seq(1, 2, 3))
@@ -90,14 +90,14 @@ class AhcWSRequestFilterSpec(implicit val executionEnv: ExecutionEnv)
     "stream with three request filters" in withClient() { client =>
       import scala.jdk.CollectionConverters._
       val callList = new java.util.ArrayList[Integer]()
-      val responseFuture = FutureConverters.toScala(
+      val responseFuture =
         client
           .url(s"http://localhost:$testServerPort")
           .setRequestFilter(new CallbackRequestFilter(callList, 1))
           .setRequestFilter(new CallbackRequestFilter(callList, 2))
           .setRequestFilter(new CallbackRequestFilter(callList, 3))
           .stream()
-      )
+          .asScala
       responseFuture
         .map { _ =>
           callList.asScala must containTheSameElementsAs(Seq(1, 2, 3))
@@ -108,12 +108,12 @@ class AhcWSRequestFilterSpec(implicit val executionEnv: ExecutionEnv)
     "should allow filters to modify the request" in withClient() { client =>
       val appendedHeader      = "X-Request-Id"
       val appendedHeaderValue = "someid"
-      val responseFuture = FutureConverters.toScala(
+      val responseFuture =
         client
           .url(s"http://localhost:$testServerPort")
           .setRequestFilter(new HeaderAppendingFilter(appendedHeader, appendedHeaderValue))
           .get()
-      )
+          .asScala
 
       responseFuture
         .map { response =>
@@ -125,12 +125,12 @@ class AhcWSRequestFilterSpec(implicit val executionEnv: ExecutionEnv)
     "allow filters to modify the streaming request" in withClient() { client =>
       val appendedHeader      = "X-Request-Id"
       val appendedHeaderValue = "someid"
-      val responseFuture = FutureConverters.toScala(
+      val responseFuture =
         client
           .url(s"http://localhost:$testServerPort")
           .setRequestFilter(new HeaderAppendingFilter(appendedHeader, appendedHeaderValue))
           .stream()
-      )
+          .asScala
 
       responseFuture
         .map { response =>

--- a/play-ahc-ws-standalone/src/main/java/play/libs/ws/ahc/StandaloneAhcWSClient.java
+++ b/play-ahc-ws-standalone/src/main/java/play/libs/ws/ahc/StandaloneAhcWSClient.java
@@ -26,8 +26,7 @@ import play.shaded.ahc.org.asynchttpclient.DefaultAsyncHttpClientConfig;
 import play.shaded.ahc.org.asynchttpclient.Request;
 import play.shaded.ahc.org.asynchttpclient.Response;
 import play.shaded.ahc.org.asynchttpclient.*;
-import scala.compat.java8.FutureConverters;
-import scala.compat.java8.FutureConverters$;
+import scala.jdk.javaapi.FutureConverters;
 import scala.concurrent.ExecutionContext;
 import scala.concurrent.Future;
 import scala.concurrent.Promise;
@@ -84,7 +83,7 @@ public class StandaloneAhcWSClient implements StandaloneWSClient {
             scalaPromise.failure(exception);
         }
         Future<StandaloneWSResponse> future = scalaPromise.future();
-        return FutureConverters.toJava(future);
+        return FutureConverters.asJava(future);
     }
 
     CompletionStage<StandaloneWSResponse> executeStream(Request request, ExecutionContext ec) {
@@ -115,7 +114,7 @@ public class StandaloneAhcWSClient implements StandaloneWSClient {
 
                             @Override
                             public void onComplete() {
-                                FutureConverters$.MODULE$.toJava(streamCompletion.future())
+                                FutureConverters.asJava(streamCompletion.future())
                                     .handle((d, t) -> {
                                         if (d != null) s.onComplete();
                                         else s.onError(t);
@@ -140,7 +139,7 @@ public class StandaloneAhcWSClient implements StandaloneWSClient {
             streamStarted,
             streamCompletion
         ));
-        return FutureConverters.toJava(streamStarted.future());
+        return FutureConverters.asJava(streamStarted.future());
     }
 
     /**

--- a/play-ahc-ws-standalone/src/main/java/play/libs/ws/ahc/StreamedResponse.java
+++ b/play-ahc-ws-standalone/src/main/java/play/libs/ws/ahc/StreamedResponse.java
@@ -14,7 +14,7 @@ import play.libs.ws.WSCookie;
 import play.shaded.ahc.io.netty.handler.codec.http.HttpHeaderNames;
 import play.shaded.ahc.org.asynchttpclient.HttpResponseBodyPart;
 import scala.collection.Seq;
-import scala.compat.java8.ScalaStreamSupport;
+import scala.jdk.javaapi.StreamConverters;
 
 import java.net.URI;
 import java.util.List;
@@ -121,7 +121,7 @@ public class StreamedResponse implements StandaloneWSResponse, CookieBuilder {
     }
 
     private static java.util.Map<String, List<String>> asJava(scala.collection.Map<String, Seq<String>> scalaMap) {
-        return ScalaStreamSupport.stream(scalaMap).collect(toMap(f -> f._1(), f -> CollectionConverters.asJava(f._2())));
+        return StreamConverters.asJavaSeqStream(scalaMap).collect(toMap(f -> f._1(), f -> CollectionConverters.asJava(f._2())));
     }
 
 }

--- a/play-ahc-ws-standalone/src/main/scala/play/api/libs/ws/ahc/StandaloneAhcWSClient.scala
+++ b/play-ahc-ws-standalone/src/main/scala/play/api/libs/ws/ahc/StandaloneAhcWSClient.scala
@@ -23,7 +23,7 @@ import play.shaded.ahc.org.asynchttpclient._
 import java.util.function.{ Function => JFunction }
 
 import scala.collection.immutable.TreeMap
-import scala.compat.java8.FunctionConverters._
+import scala.jdk.FunctionConverters._
 import scala.concurrent.Await
 import scala.concurrent.Future
 import scala.concurrent.Promise

--- a/play-ahc-ws-standalone/src/test/scala/play/libs/ws/ahc/AhcWSRequestSpec.scala
+++ b/play-ahc-ws-standalone/src/test/scala/play/libs/ws/ahc/AhcWSRequestSpec.scala
@@ -20,7 +20,7 @@ import play.shaded.ahc.org.asynchttpclient.SignatureCalculator
 
 import scala.jdk.CollectionConverters._
 import scala.collection.mutable
-import scala.compat.java8.OptionConverters._
+import scala.jdk.OptionConverters._
 
 class AhcWSRequestSpec extends Specification with Mockito with DefaultBodyReadables with DefaultBodyWritables {
 

--- a/play-ahc-ws-standalone/src/test/scala/play/libs/ws/ahc/AhcWSResponseSpec.scala
+++ b/play-ahc-ws-standalone/src/test/scala/play/libs/ws/ahc/AhcWSResponseSpec.scala
@@ -11,7 +11,7 @@ import play.shaded.ahc.io.netty.handler.codec.http.DefaultHttpHeaders
 import play.shaded.ahc.org.asynchttpclient.Response
 
 import scala.jdk.CollectionConverters._
-import scala.compat.java8.OptionConverters._
+import scala.jdk.OptionConverters._
 
 class AhcWSResponseSpec extends Specification with Mockito with DefaultBodyReadables with DefaultBodyWritables {
 

--- a/play-ws-standalone/src/main/scala/play/api/libs/ws/DefaultBodyWritables.scala
+++ b/play-ws-standalone/src/main/scala/play/api/libs/ws/DefaultBodyWritables.scala
@@ -13,7 +13,7 @@ import akka.stream.scaladsl.FileIO
 import akka.stream.scaladsl.Source
 import akka.util.ByteString
 
-import scala.compat.java8.FunctionConverters.asScalaFromSupplier
+import scala.jdk.FunctionConverters._
 
 /**
  * Default BodyWritable for a request body, for use with
@@ -46,7 +46,7 @@ trait DefaultBodyWritables {
    * Creates an SourceBody with "application/octet-stream" content type from an inputstream.
    */
   implicit val writableOf_InputStream: BodyWritable[Supplier[java.io.InputStream]] = {
-    BodyWritable(supplier => SourceBody(fromInputStream(asScalaFromSupplier(supplier))), "application/octet-stream")
+    BodyWritable(supplier => SourceBody(fromInputStream(supplier.asScala)), "application/octet-stream")
   }
 
   /**

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -26,8 +26,6 @@ object Dependencies {
 
   val junitInterface = Seq("com.github.sbt" % "junit-interface" % "0.13.3")
 
-  val scalaJava8Compat = Seq("org.scala-lang.modules" %% "scala-java8-compat" % "1.0.2")
-
   val playJson = Seq("com.typesafe.play" %% "play-json" % "2.10.0-RC6")
 
   val slf4jApi = Seq("org.slf4j" % "slf4j-api" % "1.7.36")
@@ -54,15 +52,13 @@ object Dependencies {
 
   val reactiveStreams = Seq("org.reactivestreams" % "reactive-streams" % "1.0.3")
 
-  val testDependencies = (specsBuild.map(
-    _.exclude("org.scala-lang.modules", "*")
-  ) ++ junitInterface ++ assertj ++ awaitility ++ slf4jtest ++ logback).map(_ % Test)
+  val testDependencies = (specsBuild ++ junitInterface ++ assertj ++ awaitility ++ slf4jtest ++ logback).map(_ % Test)
 
-  val standaloneApiWSDependencies = javaxInject ++ scalaJava8Compat ++ sslConfigCore ++ akkaStreams.map(
-    _.exclude("com.typesafe", "*").exclude("org.scala-lang.modules", "*")
+  val standaloneApiWSDependencies = javaxInject ++ sslConfigCore ++ akkaStreams.map(
+    _.exclude("com.typesafe", "*")
   ) ++ testDependencies
 
-  val standaloneAhcWSDependencies = scalaJava8Compat ++ cachecontrol ++ slf4jApi ++ reactiveStreams ++ testDependencies
+  val standaloneAhcWSDependencies = cachecontrol ++ slf4jApi ++ reactiveStreams ++ testDependencies
 
   val standaloneAhcWSJsonDependencies = playJson ++ testDependencies
 


### PR DESCRIPTION
# Pull Request Checklist


* [x] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [x] Have you signed the [Typesafe CLA](https://www.typesafe.com/contribute/cla)?
* [x] Have you [squashed your commits](https://www.playframework.com/documentation/latest/WorkingWithGit#Squashing-commits)?
* [x] Have you added copyright headers to new files?
* [x] Have you checked that both Scala and Java APIs are updated?
* [x] Have you updated the documentation for both Scala and Java sections?
* [x] Have you added tests for any changed functionality?

## Fixes


## Purpose


## Background Context


- play-ws dropped Scala 2.12 support https://github.com/playframework/play-ws/pull/603
- https://github.com/scala/scala/blob/2.13.x/src/library/scala/jdk/ scala std lib has some converters since Scala 2.13

## References
