### PR TITLE
avoid specs2-mock `returns` DSL

### DIFF
--- a/integration-tests/src/test/scala/play/api/libs/ws/ahc/cache/CachingSpec.scala
+++ b/integration-tests/src/test/scala/play/api/libs/ws/ahc/cache/CachingSpec.scala
@@ -7,6 +7,7 @@ package play.api.libs.ws.ahc.cache
 import akka.http.scaladsl.model._
 import akka.http.scaladsl.model.headers._
 import akka.http.scaladsl.server.Route
+import org.mockito.Mockito.when
 import org.specs2.concurrent.ExecutionEnv
 import org.specs2.matcher.FutureMatchers
 import org.specs2.mock.Mockito
@@ -51,7 +52,7 @@ class CachingSpec(implicit val executionEnv: ExecutionEnv)
 
     "work once" in {
       val cache = mock[Cache]
-      cache.get(any[EffectiveURIKey]()).returns(Future.successful(None))
+      when(cache.get(any[EffectiveURIKey]())).thenReturn(Future.successful(None))
 
       val cachingAsyncHttpClient = new CachingAsyncHttpClient(asyncHttpClient, new AhcHttpCache(cache))
       val ws                     = new StandaloneAhcWSClient(cachingAsyncHttpClient)

--- a/play-ahc-ws-standalone/src/test/scala/play/api/libs/ws/ahc/AhcWSResponseSpec.scala
+++ b/play-ahc-ws-standalone/src/test/scala/play/api/libs/ws/ahc/AhcWSResponseSpec.scala
@@ -8,6 +8,7 @@ import java.nio.charset.StandardCharsets
 import java.util
 
 import akka.util.ByteString
+import org.mockito.Mockito.when
 import org.specs2.mock.Mockito
 import org.specs2.mutable.Specification
 import play.api.libs.ws._
@@ -26,7 +27,7 @@ class AhcWSResponseSpec extends Specification with Mockito with DefaultBodyReada
         ("someName", "someValue", true, "example.com", "/", 1000L, false, false)
 
       val ahcCookie: AHCCookie = asCookie(name, value, wrap, domain, path, maxAge, secure, httpOnly)
-      ahcResponse.getCookies.returns(util.Arrays.asList(ahcCookie))
+      when(ahcResponse.getCookies).thenReturn(util.Arrays.asList(ahcCookie))
 
       val response = StandaloneAhcWSResponse(ahcResponse)
 
@@ -48,7 +49,7 @@ class AhcWSResponseSpec extends Specification with Mockito with DefaultBodyReada
         ("someName", "someValue", true, "example.com", "/", 1000L, false, false)
 
       val ahcCookie: AHCCookie = asCookie(name, value, wrap, domain, path, maxAge, secure, httpOnly)
-      ahcResponse.getCookies.returns(util.Arrays.asList(ahcCookie))
+      when(ahcResponse.getCookies).thenReturn(util.Arrays.asList(ahcCookie))
 
       val response = StandaloneAhcWSResponse(ahcResponse)
 
@@ -68,7 +69,7 @@ class AhcWSResponseSpec extends Specification with Mockito with DefaultBodyReada
       val ahcResponse: AHCResponse = mock[AHCResponse]
 
       val ahcCookie: AHCCookie = asCookie("someName", "value", true, "domain", "path", -1L, false, false)
-      ahcResponse.getCookies.returns(util.Arrays.asList(ahcCookie))
+      when(ahcResponse.getCookies).thenReturn(util.Arrays.asList(ahcCookie))
 
       val response = StandaloneAhcWSResponse(ahcResponse)
 
@@ -81,7 +82,7 @@ class AhcWSResponseSpec extends Specification with Mockito with DefaultBodyReada
     "get the body as bytes from the AHC response" in {
       val ahcResponse: AHCResponse = mock[AHCResponse]
       val bytes = ByteString(-87, -72, 96, -63, -32, 46, -117, -40, -128, -7, 61, 109, 80, 45, 44, 30)
-      ahcResponse.getResponseBodyAsBytes.returns(bytes.toArray)
+      when(ahcResponse.getResponseBodyAsBytes).thenReturn(bytes.toArray)
       val response = StandaloneAhcWSResponse(ahcResponse)
       response.body[ByteString] must_== bytes
     }
@@ -90,9 +91,9 @@ class AhcWSResponseSpec extends Specification with Mockito with DefaultBodyReada
       val ahcResponse: AHCResponse = mock[AHCResponse]
       val json                     = """{ "foo": "☺" }"""
       val ahcHeaders               = new DefaultHttpHeaders(true)
-      ahcResponse.getContentType.returns("application/json")
-      ahcResponse.getHeaders.returns(ahcHeaders)
-      ahcResponse.getResponseBody(StandardCharsets.UTF_8).returns(json)
+      when(ahcResponse.getContentType).thenReturn("application/json")
+      when(ahcResponse.getHeaders).thenReturn(ahcHeaders)
+      when(ahcResponse.getResponseBody(StandardCharsets.UTF_8)).thenReturn(json)
       val response = StandaloneAhcWSResponse(ahcResponse)
       response.body[String] must_== json
     }
@@ -100,8 +101,8 @@ class AhcWSResponseSpec extends Specification with Mockito with DefaultBodyReada
     "get text body as a string from the AHC response" in {
       val ahcResponse: AHCResponse = mock[AHCResponse]
       val text                     = "Hello ☺"
-      ahcResponse.getContentType.returns("text/plain")
-      ahcResponse.getResponseBody(StandardCharsets.ISO_8859_1).returns(text)
+      when(ahcResponse.getContentType).thenReturn("text/plain")
+      when(ahcResponse.getResponseBody(StandardCharsets.ISO_8859_1)).thenReturn(text)
       val response = StandaloneAhcWSResponse(ahcResponse)
       response.body[String] must_== text
     }
@@ -112,7 +113,7 @@ class AhcWSResponseSpec extends Specification with Mockito with DefaultBodyReada
       ahcHeaders.add("Foo", "bar")
       ahcHeaders.add("Foo", "baz")
       ahcHeaders.add("Bar", "baz")
-      ahcResponse.getHeaders.returns(ahcHeaders)
+      when(ahcResponse.getHeaders).thenReturn(ahcHeaders)
       val response = StandaloneAhcWSResponse(ahcResponse)
       val headers  = response.headers
       headers must beEqualTo(Map("Foo" -> Seq("bar", "baz"), "Bar" -> Seq("baz")))
@@ -128,7 +129,7 @@ class AhcWSResponseSpec extends Specification with Mockito with DefaultBodyReada
       ahcHeaders.add("Foo", "bar")
       ahcHeaders.add("Foo", "baz")
       ahcHeaders.add("Bar", "baz")
-      ahcResponse.getHeaders.returns(ahcHeaders)
+      when(ahcResponse.getHeaders).thenReturn(ahcHeaders)
       val response = StandaloneAhcWSResponse(ahcResponse)
 
       response.header("Foo") must beSome("bar")
@@ -141,7 +142,7 @@ class AhcWSResponseSpec extends Specification with Mockito with DefaultBodyReada
       ahcHeaders.add("Foo", "bar")
       ahcHeaders.add("Foo", "baz")
       ahcHeaders.add("Bar", "baz")
-      ahcResponse.getHeaders.returns(ahcHeaders)
+      when(ahcResponse.getHeaders).thenReturn(ahcHeaders)
       val response = StandaloneAhcWSResponse(ahcResponse)
 
       response.header("Non") must beNone
@@ -153,7 +154,7 @@ class AhcWSResponseSpec extends Specification with Mockito with DefaultBodyReada
       ahcHeaders.add("Foo", "bar")
       ahcHeaders.add("Foo", "baz")
       ahcHeaders.add("Bar", "baz")
-      ahcResponse.getHeaders.returns(ahcHeaders)
+      when(ahcResponse.getHeaders).thenReturn(ahcHeaders)
       val response = StandaloneAhcWSResponse(ahcResponse)
 
       response.headerValues("Foo") must beEqualTo(Seq("bar", "baz"))

--- a/play-ahc-ws-standalone/src/test/scala/play/libs/ws/ahc/AhcWSResponseSpec.scala
+++ b/play-ahc-ws-standalone/src/test/scala/play/libs/ws/ahc/AhcWSResponseSpec.scala
@@ -4,6 +4,7 @@
 
 package play.libs.ws.ahc
 
+import org.mockito.Mockito.when
 import org.specs2.mock.Mockito
 import org.specs2.mutable._
 import play.libs.ws._
@@ -34,7 +35,7 @@ class AhcWSResponseSpec extends Specification with Mockito with DefaultBodyReada
         .add("foo", "b")
         .add("FOO", "b")
         .add("Bar", "baz")
-      srcResponse.getHeaders.returns(srcHeaders)
+      when(srcResponse.getHeaders).thenReturn(srcHeaders)
       val response = new StandaloneAhcWSResponse(srcResponse)
       val headers  = response.getHeaders
       headers.get("foo").asScala must_== Seq("a", "b", "b")
@@ -48,7 +49,7 @@ class AhcWSResponseSpec extends Specification with Mockito with DefaultBodyReada
         .add("foo", "b")
         .add("FOO", "b")
         .add("Bar", "baz")
-      srcResponse.getHeaders.returns(srcHeaders)
+      when(srcResponse.getHeaders).thenReturn(srcHeaders)
       val response = new StandaloneAhcWSResponse(srcResponse)
 
       response.getSingleHeader("Foo").toScala must beSome("a")
@@ -62,7 +63,7 @@ class AhcWSResponseSpec extends Specification with Mockito with DefaultBodyReada
         .add("foo", "b")
         .add("FOO", "b")
         .add("Bar", "baz")
-      srcResponse.getHeaders.returns(srcHeaders)
+      when(srcResponse.getHeaders).thenReturn(srcHeaders)
       val response = new StandaloneAhcWSResponse(srcResponse)
 
       response.getSingleHeader("Non").toScala must beNone
@@ -75,7 +76,7 @@ class AhcWSResponseSpec extends Specification with Mockito with DefaultBodyReada
         .add("foo", "b")
         .add("FOO", "b")
         .add("Bar", "baz")
-      srcResponse.getHeaders.returns(srcHeaders)
+      when(srcResponse.getHeaders).thenReturn(srcHeaders)
       val response = new StandaloneAhcWSResponse(srcResponse)
 
       response.getHeaderValues("Foo").asScala must containTheSameElementsAs(Seq("a", "b", "b"))


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [x] Have you [squashed your commits](https://www.playframework.com/documentation/latest/WorkingWithGit#Squashing-commits)?
* [x] Have you added copyright headers to new files?
* [x] Have you checked that both Scala and Java APIs are updated?
* [x] Have you updated the documentation for both Scala and Java sections?
* [x] Have you added tests for any changed functionality?

## Fixes


## Purpose

avoid specs2-mock `returns` DSL. use mockito-core `when` and `thenReturn` directory.

https://github.com/etorreborre/specs2/blob/SPECS2-4.19.2/mock/shared/src/main/scala/org/specs2/mock/mockito/MockitoStubs.scala#L41-L43

## Background Context

play-ws using `specs2-mock` version 4.x with `CrossVersion.for3Use2_13`.
but specs2-mock does not available in latest specs2 5.x version.

This changes prepare for migrate to latest specs2 or another testing library(scalatest?)

## References
