### PR TITLE
remove specs2-mock and specs2-junit dependency

### DIFF
--- a/integration-tests/src/test/scala/play/api/libs/ws/ahc/JsonRequestSpec.scala
+++ b/integration-tests/src/test/scala/play/api/libs/ws/ahc/JsonRequestSpec.scala
@@ -12,7 +12,7 @@ import akka.util.ByteString
 import org.mockito.Mockito.times
 import org.mockito.Mockito.verify
 import org.mockito.Mockito.when
-import org.specs2.mock.Mockito
+import org.mockito.Mockito
 
 import org.specs2.mutable.Specification
 import org.specs2.specification.AfterAll
@@ -25,11 +25,15 @@ import play.libs.ws.DefaultObjectMapper
 import play.shaded.ahc.org.asynchttpclient.Response
 
 import scala.io.Codec
+import scala.reflect.ClassTag
 
 /**
  */
-class JsonRequestSpec extends Specification with Mockito with AfterAll with JsonBodyWritables {
+class JsonRequestSpec extends Specification with AfterAll with JsonBodyWritables {
   sequential
+
+  private def mock[A](implicit a: ClassTag[A]): A =
+    Mockito.mock(a.runtimeClass).asInstanceOf[A]
 
   implicit val system: ActorSystem        = ActorSystem()
   implicit val materializer: Materializer = Materializer.matFromSystem

--- a/integration-tests/src/test/scala/play/api/libs/ws/ahc/XMLRequestSpec.scala
+++ b/integration-tests/src/test/scala/play/api/libs/ws/ahc/XMLRequestSpec.scala
@@ -10,7 +10,6 @@ import akka.actor.ActorSystem
 import akka.stream.Materializer
 import akka.util.ByteString
 import org.specs2.matcher.MustMatchers
-import org.specs2.mock.Mockito
 import org.specs2.mutable.Specification
 import org.specs2.specification.AfterAll
 import play.api.libs.ws._
@@ -19,7 +18,7 @@ import scala.xml.Elem
 
 /**
  */
-class XMLRequestSpec extends Specification with Mockito with AfterAll with MustMatchers {
+class XMLRequestSpec extends Specification with AfterAll with MustMatchers {
   sequential
 
   implicit val system: ActorSystem        = ActorSystem()

--- a/integration-tests/src/test/scala/play/api/libs/ws/ahc/cache/CachingSpec.scala
+++ b/integration-tests/src/test/scala/play/api/libs/ws/ahc/cache/CachingSpec.scala
@@ -7,10 +7,11 @@ package play.api.libs.ws.ahc.cache
 import akka.http.scaladsl.model._
 import akka.http.scaladsl.model.headers._
 import akka.http.scaladsl.server.Route
+import org.mockito.ArgumentMatchers.any
+import org.mockito.Mockito
 import org.mockito.Mockito.when
 import org.specs2.concurrent.ExecutionEnv
 import org.specs2.matcher.FutureMatchers
-import org.specs2.mock.Mockito
 import org.specs2.mutable.Specification
 import org.specs2.specification.AfterAll
 import play.AkkaServerProvider
@@ -19,13 +20,16 @@ import play.api.libs.ws.DefaultBodyReadables._
 import play.shaded.ahc.org.asynchttpclient._
 
 import scala.concurrent.Future
+import scala.reflect.ClassTag
 
 class CachingSpec(implicit val executionEnv: ExecutionEnv)
     extends Specification
     with AkkaServerProvider
     with AfterAll
-    with FutureMatchers
-    with Mockito {
+    with FutureMatchers {
+
+  private def mock[A](implicit a: ClassTag[A]): A =
+    Mockito.mock(a.runtimeClass).asInstanceOf[A]
 
   val asyncHttpClient: AsyncHttpClient = {
     val config                           = AhcWSClientConfigFactory.forClientConfig()
@@ -64,7 +68,8 @@ class CachingSpec(implicit val executionEnv: ExecutionEnv)
         }
         .await
 
-      there.was(one(cache).get(EffectiveURIKey("GET", new java.net.URI(s"http://localhost:$testServerPort/hello"))))
+      Mockito.verify(cache).get(EffectiveURIKey("GET", new java.net.URI(s"http://localhost:$testServerPort/hello")))
+      success
     }
   }
 }

--- a/play-ahc-ws-standalone/src/test/scala/play/api/libs/ws/ahc/AhcConfigBuilderSpec.scala
+++ b/play-ahc-ws-standalone/src/test/scala/play/api/libs/ws/ahc/AhcConfigBuilderSpec.scala
@@ -9,7 +9,6 @@ import com.typesafe.config.ConfigFactory
 import com.typesafe.sslconfig.ssl.Protocols
 import com.typesafe.sslconfig.ssl.SSLConfigFactory
 import com.typesafe.sslconfig.ssl.SSLConfigSettings
-import org.specs2.mock.Mockito
 import org.specs2.mutable.Specification
 import play.api.libs.ws.WSClientConfig
 import play.shaded.ahc.org.asynchttpclient.proxy.ProxyServerSelector
@@ -19,7 +18,7 @@ import scala.concurrent.duration._
 
 /**
  */
-class AhcConfigBuilderSpec extends Specification with Mockito {
+class AhcConfigBuilderSpec extends Specification {
 
   val defaultWsConfig = WSClientConfig()
   val defaultConfig   = AhcWSClientConfig(defaultWsConfig)

--- a/play-ahc-ws-standalone/src/test/scala/play/api/libs/ws/ahc/AhcWSClientConfigParserSpec.scala
+++ b/play-ahc-ws-standalone/src/test/scala/play/api/libs/ws/ahc/AhcWSClientConfigParserSpec.scala
@@ -5,13 +5,12 @@
 package play.api.libs.ws.ahc
 
 import com.typesafe.config.ConfigFactory
-import org.specs2.mock._
 import org.specs2.mutable._
 import play.api.libs.ws.WSClientConfig
 
 import scala.concurrent.duration._
 
-class AhcWSClientConfigParserSpec extends Specification with Mockito {
+class AhcWSClientConfigParserSpec extends Specification {
 
   val defaultWsConfig = WSClientConfig()
   val defaultConfig   = AhcWSClientConfig(defaultWsConfig)

--- a/play-ahc-ws-standalone/src/test/scala/play/api/libs/ws/ahc/AhcWSRequestSpec.scala
+++ b/play-ahc-ws-standalone/src/test/scala/play/api/libs/ws/ahc/AhcWSRequestSpec.scala
@@ -11,8 +11,8 @@ import akka.actor.ActorSystem
 import akka.stream.Materializer
 import akka.util.ByteString
 
+import org.mockito.Mockito
 import org.specs2.execute.Result
-import org.specs2.mock.Mockito
 import org.specs2.mutable.Specification
 import org.specs2.specification.AfterAll
 
@@ -26,14 +26,14 @@ import play.shaded.ahc.org.asynchttpclient.SignatureCalculator
 import play.shaded.ahc.org.asynchttpclient.Param
 import play.shaded.ahc.org.asynchttpclient.{ Request => AHCRequest }
 
-class AhcWSRequestSpec
-    extends Specification
-    with Mockito
-    with AfterAll
-    with DefaultBodyReadables
-    with DefaultBodyWritables {
+import scala.reflect.ClassTag
+
+class AhcWSRequestSpec extends Specification with AfterAll with DefaultBodyReadables with DefaultBodyWritables {
 
   sequential
+
+  private def mock[A](implicit a: ClassTag[A]): A =
+    Mockito.mock(a.runtimeClass).asInstanceOf[A]
 
   implicit val system: ActorSystem        = ActorSystem()
   implicit val materializer: Materializer = Materializer.matFromSystem

--- a/play-ahc-ws-standalone/src/test/scala/play/api/libs/ws/ahc/AhcWSResponseSpec.scala
+++ b/play-ahc-ws-standalone/src/test/scala/play/api/libs/ws/ahc/AhcWSResponseSpec.scala
@@ -9,7 +9,7 @@ import java.util
 
 import akka.util.ByteString
 import org.mockito.Mockito.when
-import org.specs2.mock.Mockito
+import org.mockito.Mockito
 import org.specs2.mutable.Specification
 import play.api.libs.ws._
 import play.shaded.ahc.io.netty.handler.codec.http.DefaultHttpHeaders
@@ -17,7 +17,12 @@ import play.shaded.ahc.io.netty.handler.codec.http.cookie.DefaultCookie
 import play.shaded.ahc.io.netty.handler.codec.http.cookie.{ Cookie => AHCCookie }
 import play.shaded.ahc.org.asynchttpclient.{ Response => AHCResponse }
 
-class AhcWSResponseSpec extends Specification with Mockito with DefaultBodyReadables with DefaultBodyWritables {
+import scala.reflect.ClassTag
+
+class AhcWSResponseSpec extends Specification with DefaultBodyReadables with DefaultBodyWritables {
+
+  private def mock[A](implicit a: ClassTag[A]): A =
+    Mockito.mock(a.runtimeClass).asInstanceOf[A]
 
   "Ahc WS Response" should {
     "get cookies from an AHC response" in {

--- a/play-ahc-ws-standalone/src/test/scala/play/libs/ws/ahc/AhcWSRequestSpec.scala
+++ b/play-ahc-ws-standalone/src/test/scala/play/libs/ws/ahc/AhcWSRequestSpec.scala
@@ -9,7 +9,6 @@ import com.typesafe.config.ConfigFactory
 import java.time.Duration
 import java.util.Collections
 
-import org.specs2.mock.Mockito
 import org.specs2.mutable._
 import play.libs.oauth.OAuth
 import play.libs.ws._
@@ -22,7 +21,7 @@ import scala.jdk.CollectionConverters._
 import scala.collection.mutable
 import scala.jdk.OptionConverters._
 
-class AhcWSRequestSpec extends Specification with Mockito with DefaultBodyReadables with DefaultBodyWritables {
+class AhcWSRequestSpec extends Specification with DefaultBodyReadables with DefaultBodyWritables {
 
   "AhcWSRequest" should {
 

--- a/play-ahc-ws-standalone/src/test/scala/play/libs/ws/ahc/AhcWSResponseSpec.scala
+++ b/play-ahc-ws-standalone/src/test/scala/play/libs/ws/ahc/AhcWSResponseSpec.scala
@@ -5,7 +5,7 @@
 package play.libs.ws.ahc
 
 import org.mockito.Mockito.when
-import org.specs2.mock.Mockito
+import org.mockito.Mockito
 import org.specs2.mutable._
 import play.libs.ws._
 import play.shaded.ahc.io.netty.handler.codec.http.DefaultHttpHeaders
@@ -13,8 +13,12 @@ import play.shaded.ahc.org.asynchttpclient.Response
 
 import scala.jdk.CollectionConverters._
 import scala.jdk.OptionConverters._
+import scala.reflect.ClassTag
 
-class AhcWSResponseSpec extends Specification with Mockito with DefaultBodyReadables with DefaultBodyWritables {
+class AhcWSResponseSpec extends Specification with DefaultBodyReadables with DefaultBodyWritables {
+
+  private def mock[A](implicit a: ClassTag[A]): A =
+    Mockito.mock(a.runtimeClass).asInstanceOf[A]
 
   "getUnderlying" should {
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -18,9 +18,9 @@ object Dependencies {
   val specsVersion = "4.19.2"
   val specsBuild = Seq(
     "specs2-core",
-    "specs2-junit",
-    "specs2-mock"
   ).map("org.specs2" %% _ % specsVersion cross CrossVersion.for3Use2_13)
+
+  val mockito = Seq("org.mockito" % "mockito-core" % "5.2.0")
 
   val slf4jtest = Seq("uk.org.lidalia" % "slf4j-test" % "1.2.0")
 
@@ -47,7 +47,8 @@ object Dependencies {
 
   val reactiveStreams = Seq("org.reactivestreams" % "reactive-streams" % "1.0.4")
 
-  val testDependencies = (specsBuild ++ junitInterface ++ assertj ++ awaitility ++ slf4jtest ++ logback).map(_ % Test)
+  val testDependencies =
+    (mockito ++ specsBuild ++ junitInterface ++ assertj ++ awaitility ++ slf4jtest ++ logback).map(_ % Test)
 
   val standaloneApiWSDependencies = javaxInject ++ sslConfigCore ++ akkaStreams.map(
     _.exclude("com.typesafe", "*")


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [x] Have you [squashed your commits](https://www.playframework.com/documentation/latest/WorkingWithGit#Squashing-commits)?
* [x] Have you added copyright headers to new files?
* [x] Have you checked that both Scala and Java APIs are updated?
* [x] Have you updated the documentation for both Scala and Java sections?
* [x] Have you added tests for any changed functionality?

## Fixes


## Purpose

remove specs2-mock and specs2-junit dependency

## Background Context

- same motivation as https://github.com/playframework/play-ws/pull/748 This changes prepare for migrate to latest specs2 or another testing library(scalatest?)

## References
