### PR TITLE
fix warning in CachingAsyncHttpClient

### DIFF
--- a/play-ahc-ws-standalone/src/main/scala/play/api/libs/ws/ahc/cache/CachingAsyncHttpClient.scala
+++ b/play-ahc-ws-standalone/src/main/scala/play/api/libs/ws/ahc/cache/CachingAsyncHttpClient.scala
@@ -220,7 +220,7 @@ class CachingAsyncHttpClient(underlying: AsyncHttpClient, ahcHttpCache: AhcHttpC
   }
 
   protected def composeRequest(request: Request)(block: RequestBuilder => RequestBuilder): Request = {
-    val rb      = new RequestBuilder(request)
+    val rb      = request.toBuilder
     val builder = block(rb)
     builder.build()
   }


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [x] Have you [squashed your commits](https://www.playframework.com/documentation/latest/WorkingWithGit#Squashing-commits)?
* [x] Have you added copyright headers to new files?
* [x] Have you checked that both Scala and Java APIs are updated?
* [x] Have you updated the documentation for both Scala and Java sections?
* [x] Have you added tests for any changed functionality?

## Fixes

fix warning

## Purpose


## Background Context


https://github.com/AsyncHttpClient/async-http-client/blob/7a370af58dc8895a27a14d0a81af2a3b91930651/client/src/main/java/org/asynchttpclient/RequestBuilder.java#L43-L46

```
[warn] /home/runner/work/play-ws/play-ws/play-ahc-ws-standalone/src/main/scala/play/api/libs/ws/ahc/cache/CachingAsyncHttpClient.scala:223:19: constructor RequestBuilder in class RequestBuilder is deprecated
[warn]     val rb      = new RequestBuilder(request)
[warn]                   ^
```


## References
