### PR TITLE
Group Scala Steward patch updates into single PR

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -1,8 +1,12 @@
 pullRequests.frequency = "@monthly"
 
+commits.message = "${artifactName} ${nextVersion} (was ${currentVersion})"
+
+pullRequests.grouping = [
+  { name = "patches", "title" = "Patch updates", "filter" = [{"version" = "patch"}] }
+]
+
 updates.pin  = [
   { groupId = "com.typesafe.akka", artifactId="akka-stream", version = "2.6." }
   { groupId = "com.typesafe.akka", artifactId="akka-http", version = "10.2." }
 ]
-
-commits.message = "${artifactName} ${nextVersion} (was ${currentVersion})"


### PR DESCRIPTION
Patch updates are likey to not break anything so we can just put them into one PR.