### PR TITLE
Correctly shade netty-reactive-streams

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -191,7 +191,9 @@ lazy val `shaded-asynchttpclient` = project
       ShadeRule.rename("org.asynchttpclient.**" -> "play.shaded.ahc.@0").inAll,
       ShadeRule.rename("io.netty.**" -> "play.shaded.ahc.@0").inAll,
       ShadeRule.rename("javassist.**" -> "play.shaded.ahc.@0").inAll,
-      ShadeRule.rename("org.playframework.netty.**" -> "play.shaded.ahc.@0").inAll,
+      ShadeRule // asynchttpclient 2.x depends on netty-reactive-streams 2.x (v3 drops it, see async-http-client#1843 + #1819)
+        .rename("com.typesafe.netty.**" -> "play.shaded.ahc.@0")
+        .inAll,
       ShadeRule.rename("javax.activation.**" -> "play.shaded.ahc.@0").inAll,
       ShadeRule.rename("com.sun.activation.**" -> "play.shaded.ahc.@0").inAll,
       ShadeRule.zap("org.reactivestreams.**").inAll,


### PR DESCRIPTION
Fixes
- #862

The problem was introduced in 0efba3c556f65e3ba54c9b0ea9319aa58d86f3aa were the assumption was made that the latest netty-reactive-streams version 3 needs to be shaded, however turns out that latest asynchttpclient 2.x [still depends on netty-reactive-streams 2.x](https://github.com/AsyncHttpClient/async-http-client/blob/async-http-client-project-2.12.3/pom.xml#L339-L340), so the changing the shading rename rule `com.typesafe.netty.**` to `org.playframework.netty.**` does not make sense and ruines the original shading...

With this fix the shading works again (tested locally).

Side note:
Upcoming async-http-client v3 does not depend on `netty-reactive-streams` anymore, so as soon as we upgrade, we can remove the corresponding shading settings:
- https://github.com/AsyncHttpClient/async-http-client/issues/1819
- https://github.com/AsyncHttpClient/async-http-client/pull/1843

Another side note:
We already had a case were we almost ran into a problem because of the fact that async-http-client depends on netty-reactive-streams, but back then we were lucky that selenium dropped the usage of async-http-client.
- https://github.com/playframework/playframework/issues/12049

So basically with upcoming async-http-client 3 things will improve from itself :wink: 