### PR TITLE
Use latest netty-reactive-streams version, ahc comes with outdated one

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -40,7 +40,11 @@ object Dependencies {
 
   val cachecontrol = Seq("org.playframework" %% "cachecontrol" % "3.0.1")
 
-  val asyncHttpClient = Seq("org.asynchttpclient" % "async-http-client" % "2.12.3")
+  val asyncHttpClient = Seq(
+    ("org.asynchttpclient" % "async-http-client" % "2.12.3") // 2.12.x comes with outdated netty-reactive-streams, so we ...
+      .exclude("com.typesafe.netty", "netty-reactive-streams"), // ... exclude it and pull in ...
+    "com.typesafe.netty" % "netty-reactive-streams" % "2.0.12", // ... a newer version ourselves (ahc v3 will drop that dependency)
+  )
 
   val pekkoVersion = "1.0.3"
 


### PR DESCRIPTION
Latest AsyncHttpClient v2 (currently 2.12.3) comes with an outdated netty-reactive-streams dependency: [2.0.4](https://github.com/AsyncHttpClient/async-http-client/blob/async-http-client-project-2.12.3/pom.xml#L473).

Meanwhile we are on 2.0.12, which besides upgrading netty to a very recent version, also brings some fixes:
https://github.com/playframework/netty-reactive-streams/compare/netty-reactive-streams-parent-2.0.4...netty-reactive-streams-parent-2.0.12

However, I will not include this PR right now in the next play-ws patch release, because I am not sure if such an upgrade would cause problems (specially because netty will be bumped from 4.1.43 to 4.1.104 which is, for netty, quite a big jump.

I keep this as a draft for later, as a reminder...