### PR TITLE
Run tests with Java 21 also

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -37,7 +37,7 @@ jobs:
       - "check-docs"
     uses: playframework/.github/.github/workflows/cmd.yml@v3
     with:
-      java: 17, 11
+      java: 21, 17, 11
       scala: 2.13.x, 3.x
       cmd: sbt ++$MATRIX_SCALA 'testOnly -- xonly timefactor 5'
 


### PR DESCRIPTION
I think back then it was not available in the coursier index.