### PR TITLE
[3.0.x] StreamedResponse `headers` map is now case insensitively

### DIFF
--- a/play-ahc-ws-standalone/src/main/java/play/libs/ws/ahc/StreamedResponse.java
+++ b/play-ahc-ws-standalone/src/main/java/play/libs/ws/ahc/StreamedResponse.java
@@ -17,9 +17,11 @@ import scala.collection.Seq;
 import scala.jdk.javaapi.StreamConverters;
 
 import java.net.URI;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.TreeMap;
 import java.util.function.Predicate;
 
 import static java.util.stream.Collectors.toMap;
@@ -121,7 +123,16 @@ public class StreamedResponse implements StandaloneWSResponse, CookieBuilder {
     }
 
     private static java.util.Map<String, List<String>> asJava(scala.collection.Map<String, Seq<String>> scalaMap) {
-        return StreamConverters.asJavaSeqStream(scalaMap).collect(toMap(f -> f._1(), f -> CollectionConverters.asJava(f._2())));
+        return StreamConverters.asJavaSeqStream(scalaMap).collect(toMap(f -> f._1(), f -> CollectionConverters.asJava(f._2()),
+                (l, r) -> {
+                    final List<String> merged = new ArrayList<>(l.size() + r.size());
+                    merged.addAll(l);
+                    merged.addAll(r);
+                    return merged;
+                },
+                () -> new TreeMap<>(String.CASE_INSENSITIVE_ORDER)
+            )
+        );
     }
 
 }

--- a/play-ahc-ws-standalone/src/test/scala/play/api/libs/ws/ahc/AhcWSResponseSpec.scala
+++ b/play-ahc-ws-standalone/src/test/scala/play/api/libs/ws/ahc/AhcWSResponseSpec.scala
@@ -128,6 +128,14 @@ class AhcWSResponseSpec extends Specification with DefaultBodyReadables with Def
       headers.contains("Bar") must beTrue
     }
 
+    "get headers map which retrieves headers case insensitively (for streamed responses)" in {
+      val srcHeaders = Map("Foo" -> Seq("a"), "foo" -> Seq("b"), "FOO" -> Seq("b"), "Bar" -> Seq("baz"))
+      val response   = new StreamedResponse(null, 200, "", null, srcHeaders, null, true)
+      val headers    = response.headers
+      headers("foo") must_== Seq("a", "b", "b")
+      headers("BAR") must_== Seq("baz")
+    }
+
     "get a single header" in {
       val ahcResponse: AHCResponse = mock[AHCResponse]
       val ahcHeaders               = new DefaultHttpHeaders(true)

--- a/play-ahc-ws-standalone/src/test/scala/play/libs/ws/ahc/AhcWSResponseSpec.scala
+++ b/play-ahc-ws-standalone/src/test/scala/play/libs/ws/ahc/AhcWSResponseSpec.scala
@@ -46,6 +46,14 @@ class AhcWSResponseSpec extends Specification with DefaultBodyReadables with Def
       headers.get("BAR").asScala must_== Seq("baz")
     }
 
+    "get headers map which retrieves headers case insensitively (for streamed responses)" in {
+      val srcHeaders = Map("Foo" -> Seq("a"), "foo" -> Seq("b"), "FOO" -> Seq("b"), "Bar" -> Seq("baz"))
+      val response   = new StreamedResponse(null, 200, "", null, srcHeaders, null, true)
+      val headers    = response.getHeaders
+      headers.get("foo").asScala must_== Seq("a", "b", "b")
+      headers.get("BAR").asScala must_== Seq("baz")
+    }
+
     "get a single header" in {
       val srcResponse = mock[Response]
       val srcHeaders = new DefaultHttpHeaders()


### PR DESCRIPTION
- Fixes #908