### PR TITLE
Downgrade pekko (only temporarily in the main branch)

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -46,7 +46,7 @@ object Dependencies {
     "com.typesafe.netty" % "netty-reactive-streams" % "2.0.13", // ... a newer version ourselves (ahc v3 will drop that dependency)
   )
 
-  val pekkoVersion = "1.1.2"
+  val pekkoVersion = "1.0.3"
 
   val pekkoStreams = Seq("org.apache.pekko" %% "pekko-stream" % pekkoVersion)
 


### PR DESCRIPTION
Need to upgrade Pekko in https://github.com/playframework/playframework/ hand in hand later.

Will bump later again for another milestone release.