### PR TITLE
update `.scalafmt.conf`. enforce new wildcard syntax

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -12,3 +12,10 @@ spaces.inImportCurlyBraces = true   # more idiomatic to include whitepsace in im
 trailingCommas = preserve
 newlines.afterCurlyLambda = preserve
 version = 3.9.8
+rewrite.scala3.convertToNewSyntax = true
+rewrite.scala3.newSyntax.control = false
+runner.dialectOverride {
+  allowSignificantIndentation = false
+  allowAsForImportRename = false
+  allowStarWildcardImport = false
+}

--- a/integration-tests/src/test/scala/play/api/libs/ws/ahc/XMLRequestSpec.scala
+++ b/integration-tests/src/test/scala/play/api/libs/ws/ahc/XMLRequestSpec.scala
@@ -46,7 +46,7 @@ class XMLRequestSpec extends Specification with AfterAll with MustMatchers {
 
     override def bodyAsBytes: ByteString = ByteString.fromArray(byteArray)
 
-    override def bodyAsSource: org.apache.pekko.stream.scaladsl.Source[ByteString, _] = ???
+    override def bodyAsSource: org.apache.pekko.stream.scaladsl.Source[ByteString, ?] = ???
   }
 
   "write an XML node" in {

--- a/play-ahc-ws-standalone/src/main/scala/play/api/libs/oauth/OAuth.scala
+++ b/play-ahc-ws-standalone/src/main/scala/play/api/libs/oauth/OAuth.scala
@@ -107,7 +107,7 @@ class OAuthCalculator(consumerKey: ConsumerKey, requestToken: RequestToken)
   private val ahcRequestToken = new AHCRequestToken(requestToken.token, requestToken.secret)
   private val calculator      = new OAuthSignatureCalculator(ahcConsumerKey, ahcRequestToken)
 
-  override def calculateAndAddSignature(request: Request, requestBuilder: RequestBuilderBase[_]): Unit = {
+  override def calculateAndAddSignature(request: Request, requestBuilder: RequestBuilderBase[?]): Unit = {
     calculator.calculateAndAddSignature(request, requestBuilder)
   }
 }

--- a/play-ahc-ws-standalone/src/main/scala/play/api/libs/ws/ahc/AhcLoggerFactory.scala
+++ b/play-ahc-ws-standalone/src/main/scala/play/api/libs/ws/ahc/AhcLoggerFactory.scala
@@ -24,7 +24,7 @@ class AhcLoggerFactory(lf: ILoggerFactory = SLF4JLoggerFactory.getILoggerFactory
     }
   }
 
-  def apply(clazz: Class[_]): NoDepsLogger = createLogger(clazz.getName)
+  def apply(clazz: Class[?]): NoDepsLogger = createLogger(clazz.getName)
   def apply(name: String): NoDepsLogger    = createLogger(name)
 
 }

--- a/play-ahc-ws-standalone/src/main/scala/play/api/libs/ws/ahc/StandaloneAhcWSClient.scala
+++ b/play-ahc-ws-standalone/src/main/scala/play/api/libs/ws/ahc/StandaloneAhcWSClient.scala
@@ -113,7 +113,7 @@ class StandaloneAhcWSClient @Inject() (asyncHttpClient: AsyncHttpClient)(implici
 
       val wrap = new Publisher[HttpResponseBodyPart]() {
         override def subscribe(
-            s: Subscriber[_ >: HttpResponseBodyPart]
+            s: Subscriber[? >: HttpResponseBodyPart]
         ): Unit = {
           publisher.subscribe(new Subscriber[HttpResponseBodyPart] {
             override def onSubscribe(sub: Subscription): Unit =
@@ -155,7 +155,7 @@ class StandaloneAhcWSClient @Inject() (asyncHttpClient: AsyncHttpClient)(implici
     streamStarted.future
   }
 
-  private[ahc] def blockingToByteString(bodyAsSource: Source[ByteString, _]) = {
+  private[ahc] def blockingToByteString(bodyAsSource: Source[ByteString, ?]) = {
     StandaloneAhcWSClient.logger.warn(
       s"blockingToByteString is a blocking and unsafe operation!"
     )

--- a/play-ahc-ws-standalone/src/main/scala/play/api/libs/ws/ahc/StandaloneAhcWSResponse.scala
+++ b/play-ahc-ws-standalone/src/main/scala/play/api/libs/ws/ahc/StandaloneAhcWSResponse.scala
@@ -47,7 +47,7 @@ class StandaloneAhcWSResponse(ahcResponse: AHCResponse)
    */
   override lazy val bodyAsBytes: ByteString = ByteString.fromArray(underlying[AHCResponse].getResponseBodyAsBytes)
 
-  override lazy val bodyAsSource: Source[ByteString, _] = Source.single(bodyAsBytes)
+  override lazy val bodyAsSource: Source[ByteString, ?] = Source.single(bodyAsBytes)
 }
 
 object StandaloneAhcWSResponse {

--- a/play-ahc-ws-standalone/src/main/scala/play/api/libs/ws/ahc/Streamed.scala
+++ b/play-ahc-ws-standalone/src/main/scala/play/api/libs/ws/ahc/Streamed.scala
@@ -79,7 +79,7 @@ class DefaultStreamedAsyncHandler[T](
 }
 
 private case object EmptyPublisher extends Publisher[HttpResponseBodyPart] {
-  def subscribe(s: Subscriber[_ >: HttpResponseBodyPart]): Unit = {
+  def subscribe(s: Subscriber[? >: HttpResponseBodyPart]): Unit = {
     if (s eq null)
       throw new NullPointerException("Subscriber must not be null, rule 1.9")
     s.onSubscribe(CancelledSubscription)

--- a/play-ahc-ws-standalone/src/main/scala/play/api/libs/ws/ahc/StreamedResponse.scala
+++ b/play-ahc-ws-standalone/src/main/scala/play/api/libs/ws/ahc/StreamedResponse.scala
@@ -115,7 +115,7 @@ class StreamedResponse(
    */
   override lazy val bodyAsBytes: ByteString = client.blockingToByteString(bodyAsSource)
 
-  override lazy val bodyAsSource: Source[ByteString, _] = {
+  override lazy val bodyAsSource: Source[ByteString, ?] = {
     Source
       .fromPublisher(publisher)
       .map((bodyPart: HttpResponseBodyPart) => ByteString.fromArray(bodyPart.getBodyPartBytes))

--- a/play-ahc-ws-standalone/src/main/scala/play/api/libs/ws/ahc/cache/CacheAsyncConnection.scala
+++ b/play-ahc-ws-standalone/src/main/scala/play/api/libs/ws/ahc/cache/CacheAsyncConnection.scala
@@ -52,7 +52,7 @@ class AsyncCacheableConnection[T](
       }
 
       asyncHandler match {
-        case progressAsyncHandler: ProgressAsyncHandler[_] =>
+        case progressAsyncHandler: ProgressAsyncHandler[?] =>
           progressAsyncHandler.onHeadersWritten()
           progressAsyncHandler.onContentWritten()
         case _ =>

--- a/play-ahc-ws-standalone/src/main/scala/play/api/libs/ws/ahc/cache/CachingAsyncHttpClient.scala
+++ b/play-ahc-ws-standalone/src/main/scala/play/api/libs/ws/ahc/cache/CachingAsyncHttpClient.scala
@@ -63,7 +63,7 @@ class CachingAsyncHttpClient(underlying: AsyncHttpClient, ahcHttpCache: AhcHttpC
   }
 
   @throws(classOf[IOException])
-  protected def execute[T](request: Request, handler: AsyncCompletionHandler[T], future: ListenableFuture[_])(implicit
+  protected def execute[T](request: Request, handler: AsyncCompletionHandler[T], future: ListenableFuture[?])(implicit
       ec: ExecutionContext
   ): ListenableFuture[T] = {
     if (logger.isTraceEnabled) {

--- a/play-ahc-ws-standalone/src/test/scala/play/api/libs/ws/ahc/AhcWSRequestSpec.scala
+++ b/play-ahc-ws-standalone/src/test/scala/play/api/libs/ws/ahc/AhcWSRequestSpec.scala
@@ -527,7 +527,7 @@ class AhcWSRequestSpec extends Specification with AfterAll with DefaultBodyReada
       val calc   = new SignatureCalculator with WSSignatureCalculator {
         override def calculateAndAddSignature(
             request: play.shaded.ahc.org.asynchttpclient.Request,
-            requestBuilder: play.shaded.ahc.org.asynchttpclient.RequestBuilderBase[_]
+            requestBuilder: play.shaded.ahc.org.asynchttpclient.RequestBuilderBase[?]
         ): Unit = {
           called = true
         }

--- a/play-ahc-ws-standalone/src/test/scala/play/libs/ws/ahc/AhcWSRequestSpec.scala
+++ b/play-ahc-ws-standalone/src/test/scala/play/libs/ws/ahc/AhcWSRequestSpec.scala
@@ -181,7 +181,7 @@ class AhcWSRequestSpec extends Specification with DefaultBodyReadables with Defa
       )
       var called = false
       val calc   = new SignatureCalculator with WSSignatureCalculator {
-        override def calculateAndAddSignature(request: Request, requestBuilder: RequestBuilderBase[_]): Unit = {
+        override def calculateAndAddSignature(request: Request, requestBuilder: RequestBuilderBase[?]): Unit = {
           called = true
         }
       }

--- a/play-ws-standalone-json/src/test/scala/play/api/libs/ws/JsonBodyReadablesSpec.scala
+++ b/play-ws-standalone-json/src/test/scala/play/api/libs/ws/JsonBodyReadablesSpec.scala
@@ -35,7 +35,7 @@ class JsonBodyReadablesSpec extends Specification with MustMatchers {
 
     override def bodyAsBytes: ByteString = ByteString.fromArray(byteArray)
 
-    override def bodyAsSource: Source[ByteString, _] = ???
+    override def bodyAsSource: Source[ByteString, ?] = ???
   }
 
   "decode encodings correctly" should {

--- a/play-ws-standalone/src/main/scala/play/api/libs/ws/Body.scala
+++ b/play-ws-standalone/src/main/scala/play/api/libs/ws/Body.scala
@@ -28,7 +28,7 @@ case class InMemoryBody(bytes: ByteString) extends WSBody
  *
  * @param source A flow of the bytes of the body
  */
-case class SourceBody(source: Source[ByteString, _]) extends WSBody
+case class SourceBody(source: Source[ByteString, ?]) extends WSBody
 
 @implicitNotFound(
   "Cannot find an instance of StandaloneWSResponse to ${R}. Define a BodyReadable[${R}] or extend play.api.libs.ws.ahc.DefaultBodyReadables"

--- a/play-ws-standalone/src/main/scala/play/api/libs/ws/DefaultBodyReadables.scala
+++ b/play-ws-standalone/src/main/scala/play/api/libs/ws/DefaultBodyReadables.scala
@@ -70,7 +70,7 @@ trait DefaultBodyReadables {
   /**
    * Converts a response body into `Source[ByteString, _]`.
    */
-  implicit val readableAsSource: BodyReadable[Source[ByteString, _]] = BodyReadable(_.bodyAsSource)
+  implicit val readableAsSource: BodyReadable[Source[ByteString, ?]] = BodyReadable(_.bodyAsSource)
 }
 
 object DefaultBodyReadables extends DefaultBodyReadables

--- a/play-ws-standalone/src/main/scala/play/api/libs/ws/DefaultBodyWritables.scala
+++ b/play-ws-standalone/src/main/scala/play/api/libs/ws/DefaultBodyWritables.scala
@@ -52,7 +52,7 @@ trait DefaultBodyWritables {
   /**
    * Creates an SourceBody with "application/octet-stream" content type from a file.
    */
-  implicit val writableOf_Source: BodyWritable[Source[ByteString, _]] = {
+  implicit val writableOf_Source: BodyWritable[Source[ByteString, ?]] = {
     BodyWritable(source => SourceBody(source), "application/octet-stream")
   }
 

--- a/play-ws-standalone/src/main/scala/play/api/libs/ws/StandaloneWSResponse.scala
+++ b/play-ws-standalone/src/main/scala/play/api/libs/ws/StandaloneWSResponse.scala
@@ -137,5 +137,5 @@ trait StandaloneWSResponse {
   /**
    * @return the response as a source of bytes
    */
-  def bodyAsSource: Source[ByteString, _]
+  def bodyAsSource: Source[ByteString, ?]
 }


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [x] Have you [squashed your commits](https://www.playframework.com/documentation/latest/WorkingWithGit#Squashing-commits)?
* [x] Have you added copyright headers to new files?
* [x] Have you checked that both Scala and Java APIs are updated?
* [x] Have you updated the documentation for both Scala and Java sections?
* [x] Have you added tests for any changed functionality?

## Fixes



## Purpose


## Background Context

old wildcard syntax is deprecated in latest Scala 3.x

```
Welcome to Scala 3.7.1 (21.0.7, Java OpenJDK 64-Bit Server VM).
Type in expressions for evaluation. Or try :help.
                                                                                                                                                                                                        
scala> def f: List[_] = Nil
1 warning found
-- Warning: --------------------------------------------------------------------
1 |def f: List[_] = Nil
  |            ^
  |        `_` is deprecated for wildcard arguments of types: use `?` instead
def f: List[?]
                                                                                                                                                                                                        
scala> def f: List[?] = Nil
def f: List[?]

```

## References

https://docs.scala-lang.org/scala3/reference/changed-features/wildcards.html